### PR TITLE
Use 'Types::get' to avoid needing try/catch

### DIFF
--- a/src/Extension/ExtensionRegistry.php
+++ b/src/Extension/ExtensionRegistry.php
@@ -24,14 +24,7 @@ class ExtensionRegistry
 
     private function addComposerPackages(): void
     {
-        // We do a try/catch here, instead of using `method_exists`. This is
-        // because PHPStan is being a smart-ass, and takes the state of the
-        // generated `Types` class into account. And that's exactly the point.
-        try {
-            $packages = Types::boltExtension();
-        } catch (\Throwable $e) {
-            $packages = [];
-        }
+        $packages = Types::get('bolt-extension');
 
         /** @var PackageInterface $package */
         foreach ($packages as $package) {


### PR DESCRIPTION
As suggested by @drupol here: https://github.com/bolt/core/pull/559#pullrequestreview-270504069