### PR TITLE
Edit user fixes

### DIFF
--- a/src/Controller/Backend/ProfileController.php
+++ b/src/Controller/Backend/ProfileController.php
@@ -87,6 +87,7 @@ class ProfileController extends TwigAwareController implements BackendZone
             return $this->renderTemplate('@bolt/users/edit.html.twig', [
                 'display_name' => $displayName,
                 'user' => $user,
+                'suggestedPassword' => sprintf('%s_1234', $user->getUsername()),
             ]);
         }
 

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -63,7 +63,7 @@
 
             {% set roleOptions = [] %}
 
-            {% for roleName, roleHierarchy in roles %}
+            {% for roleName, roleHierarchy in roles ?? [] %}
                 {% set roleOptions = roleOptions|merge([
                     {
                         'key': roleName,

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1163,6 +1163,14 @@
         <source>listing.title_actions</source>
         <target>Actions</target>
       </trans-unit>
+      <trans-unit id="fkXL.k6" resname="user.not_valid_email">
+        <source>user.not_valid_email</source>
+        <target>Invalid email</target>
+      </trans-unit>
+      <trans-unit id="HjWW.NS" resname="user.not_valid_password">
+        <source>user.not_valid_password</source>
+        <target>Invalid password</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -1171,6 +1171,14 @@
         <source>listing.title_actions</source>
         <target>Műveletek</target>
       </trans-unit>
+      <trans-unit id="fkXL.k6" resname="user.not_valid_email">
+        <source>user.not_valid_email</source>
+        <target>Érvénytelen email cím</target>
+      </trans-unit>
+      <trans-unit id="HjWW.NS" resname="user.not_valid_password">
+        <source>user.not_valid_password</source>
+        <target>Érvénytelen jelszó</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -922,6 +922,14 @@
         <source>listing.title_actions</source>
         <target>__listing.title_actions</target>
       </trans-unit>
+      <trans-unit id="fkXL.k6" resname="user.not_valid_email">
+        <source>user.not_valid_email</source>
+        <target>Invalid email</target>
+      </trans-unit>
+      <trans-unit id="HjWW.NS" resname="user.not_valid_password">
+        <source>user.not_valid_password</source>
+        <target>Invalid password</target>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
# Various fixes for cases in User Edit

Found some bug in backend User Edit (or Profile Edit) page in v4.0.0 beta 1.7

## Symtoms

- entring invalid or short password leads twig error (missing variable) while notification yields a warning
- notification box contains dummy texts are missing from xlf files
- for admins allowed empty roles selection but template doesn't handles and leads error

## Illustrations
![Peek 2019-08-08 16-15](https://user-images.githubusercontent.com/761149/62712884-04817180-b9fc-11e9-9841-b6817af92f73.gif)
![Peek 2019-08-08 16-21](https://user-images.githubusercontent.com/761149/62712887-08ad8f00-b9fc-11e9-9b36-36f35ab7c72e.gif)

ps.: _accidentally I pushed here this branch, I hope didn't make a mess_ :blush:
