### PR TITLE
Issue [#514](https://github.com/bolt/core/issues/514)

### DIFF
--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -20,4 +20,27 @@ class UserRepository extends ServiceEntityRepository
         $user = $this->findOneBy(['username' => $username]);
         return $user instanceof User ? $user : null;
     }
+
+    public function findOneByCredentials(string $username): ?User
+    {
+        $qb = $this->createQueryBuilder('user');
+        if (filter_var($username, FILTER_VALIDATE_EMAIL)) {
+            $qb->andWhere(
+                $qb->expr()->eq(
+                    $qb->expr()->lower('user.email'),
+                    $qb->expr()->lower(':username')
+                )
+            );
+        } else {
+            $qb->andWhere(
+                $qb->expr()->eq(
+                    $qb->expr()->lower('user.username'),
+                    $qb->expr()->lower(':username')
+                )
+            );
+        }
+        $qb->setParameter('username', $username);
+        $user = $qb->getQuery()->getOneOrNullResult();
+        return $user instanceof User ? $user : null;
+    }
 }

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -74,7 +74,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
             throw new InvalidCsrfTokenException();
         }
 
-        return $this->userRepository->findOneByUsername($credentials['username']);
+        return $this->userRepository->findOneByCredentials($credentials['username']);
     }
 
     public function checkCredentials($credentials, UserInterface $user)

--- a/tests/php/Repository/UserRepositoryTest.php
+++ b/tests/php/Repository/UserRepositoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Repository;
+
+use Bolt\Entity\User;
+use Bolt\Tests\DbAwareTestCase;
+
+class UserRepositoryTest extends DbAwareTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // fixtures loading takes a lot of time, it would be better to load database dump for tests
+        self::runCommand('doctrine:fixtures:load --no-interaction --group=without-images');
+    }
+
+    public function testFindOneByUsername()
+    {
+        $admin = $this->getEm()->getRepository(User::class)->findOneByUsername('admin');
+        $this->assertInstanceOf(User::class, $admin);
+
+        $administrator = $this->getEm()->getRepository(User::class)->findOneByUsername('administrator');
+        $this->assertNull($administrator);
+    }
+
+    public function testFindOneByCredentials()
+    {
+        $admin = $this->getEm()->getRepository(User::class)->findOneByCredentials('admin');
+        $this->assertInstanceOf(User::class, $admin);
+
+        $adminEmail = $this->getEm()->getRepository(User::class)->findOneByCredentials('admin@example.org');
+        $this->assertInstanceOf(User::class, $adminEmail);
+
+        $janeAdmin = $this->getEm()->getRepository(User::class)->findOneByCredentials('Jane_Admin');
+        $this->assertInstanceOf(User::class, $janeAdmin);
+
+        $janeAdminEmail = $this->getEm()->getRepository(User::class)->findOneByCredentials('Jane_Admin@Example.Org');
+        $this->assertInstanceOf(User::class, $janeAdminEmail);
+
+        $administrator = $this->getEm()->getRepository(User::class)->findOneByCredentials('administrator');
+        $this->assertNull($administrator);
+    }
+}

--- a/tests/php/Security/LoginFormAuthenticatorTest.php
+++ b/tests/php/Security/LoginFormAuthenticatorTest.php
@@ -37,7 +37,7 @@ class LoginFormAuthenticatorTest extends TestCase
     public function testGetUser(): void
     {
         $userRepository = $this->createConfiguredMock(UserRepository::class, [
-            'findOneByUsername' => $this->createMock(User::class),
+            'findOneByCredentials' => $this->createMock(User::class),
         ]);
         $csrfTokenManager = $this->createConfiguredMock(CsrfTokenManagerInterface::class, [
             'isTokenValid' => true,

--- a/tests/spec/Bolt/Security/LoginFormAuthenticatorSpec.php
+++ b/tests/spec/Bolt/Security/LoginFormAuthenticatorSpec.php
@@ -41,7 +41,7 @@ class LoginFormAuthenticatorSpec extends ObjectBehavior
 
     public function it_gets_user(CsrfTokenManagerInterface $csrfTokenManager, UserProviderInterface $userProvider, UserRepository $userRepository, User $user): void
     {
-        $userRepository->findOneByUsername(self::TEST_TOKEN['username'])->shouldBeCalledOnce()->wilLReturn($user);
+        $userRepository->findOneByCredentials(self::TEST_TOKEN['username'])->shouldBeCalledOnce()->wilLReturn($user);
         $csrfTokenManager->isTokenValid(Argument::type(CsrfToken::class))->willReturn(true);
         $this->getUser(self::TEST_TOKEN, $userProvider)->shouldBeAnInstanceOf(User::class);
     }


### PR DESCRIPTION
Changed the repository method to accept the credential(string) and has
the storage engine compare the lowercase values. At least this is
consistent to the strings compared so it should be a consistent
experience