### PR TITLE
fix(config): fix form_themes in twig config

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,8 +2,8 @@ twig:
     debug: '%kernel.debug%'
     strict_variables: true
     form_themes:
-        - 'form/layout.twig'
-        - 'form/fields.twig'
+        - '@bolt/form/layout.html.twig'
+        - '@bolt/form/fields.html.twig'
     paths:
         # Since the name of the theme folder is dynamic, we shouldn't set it here, but dynamically
         # See TwigAwareController::setTwigLoader()

--- a/templates/form/layout.html.twig
+++ b/templates/form/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'bootstrap_3_layout.html.html.twig' %}
+{% extends 'bootstrap_3_layout.html.twig' %}
 
 {# Errors #}
 


### PR DESCRIPTION
This PR fix this errors:

[X] Fix form_themes key in twig config
[X] Update `bootstrap_3_layout.html.twig`

![bootstrap_3_layout html html twig](https://user-images.githubusercontent.com/42312426/65511604-e0102480-ded7-11e9-8bd6-dd68e7ad866d.png)
