### PR TITLE
Update from Stretch to Buster

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,5 @@
-# https://github.com/docker-library/php/blob/master/7.3/stretch/fpm/Dockerfile
-FROM php:7.3-fpm
+# https://github.com/docker-library/php/blob/master/7.3/buster/fpm/Dockerfile
+FROM php:7.3-fpm-buster
 
 ENV PATH /path/to/bin/folder:$PATH
 ENV PHP_MEMORYLIMIT 2048M
@@ -33,7 +33,7 @@ RUN extBuildDeps=" \
             zip unzip \
             acl \
             iproute2 \
-            ttf-freefont \
+            fonts-freefont-ttf \
             fontconfig \
             dbus \
             openssh-client \


### PR DESCRIPTION
- Update the base container to explicitly use Buster (or the same issue we ran into now is going to crop up whenever Debian has a new release out)
- Use the appropriate ttf-fonts package for Buster