### PR TITLE
Fix `doctrine/dbal` to `2.9.2`, to prevent breakage in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "cocur/slugify": "^3.2",
         "composer/composer": "^1.9",
         "doctrine/annotations": "^1.7",
+        "doctrine/dbal": "2.9.2",
         "doctrine/doctrine-bundle": "^1.11",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
         "doctrine/orm": "^2.6",


### PR DESCRIPTION
Very Temporary workaround, until #702 is fixed.