### PR TITLE
Bugfix ContentEditController when saving new Field with localize:true 

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -322,7 +322,10 @@ class ContentEditController extends TwigAwareController implements BackendZone
 
         if ($field->getDefinition()->get('localize')) {
             $field->setLocale($locale);
-            $this->em->refresh($field);
+            
+            if ($this->em->contains($field)) {
+                $this->em->refresh($field);
+            }
         }
 
         // If the value is an array that contains a string of JSON, parse it

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -322,7 +322,7 @@ class ContentEditController extends TwigAwareController implements BackendZone
 
         if ($field->getDefinition()->get('localize')) {
             $field->setLocale($locale);
-            
+
             if ($this->em->contains($field)) {
                 $this->em->refresh($field);
             }


### PR DESCRIPTION
When adding new fields with` localize: true` to new or existing Content entities and then saving the content for the first time the Controller breaks on trying to refresh the Field entity, but the Field Entity is not persisted yet and can not refresh because of that.