### PR TITLE
image contenttype extensions config now works

### DIFF
--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -88,6 +88,7 @@
       class="editor__image--upload"
       :name="fieldName"
       type="file"
+      :accept="acceptedExtensions"
       @change="uploadFile($event.target.files[0])"
     />
   </div>
@@ -115,6 +116,7 @@ export default {
     'csrfToken',
     'labels',
     'filelist',
+    'extensions'
   ],
   data: () => {
     return {
@@ -130,6 +132,9 @@ export default {
     },
     token() {
       return this.csrfToken;
+    },
+    acceptedExtensions() {
+      return this.extensions.map(ext => "." + ext).join();
     },
   },
   mounted() {

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -116,7 +116,7 @@ export default {
     'csrfToken',
     'labels',
     'filelist',
-    'extensions'
+    'extensions',
   ],
   data: () => {
     return {
@@ -134,7 +134,7 @@ export default {
       return this.csrfToken;
     },
     acceptedExtensions() {
-      return this.extensions.map(ext => "." + ext).join();
+      return this.extensions.map(ext => '.' + ext).join();
     },
   },
   mounted() {

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -162,7 +162,7 @@ export default {
           bootbox.prompt({
             title: 'Select a file',
             inputType: 'select',
-            inputOptions: res.data,
+            inputOptions: this.filterServerFiles(res.data),
             callback: function(result) {
               if (result) {
                 thisField.filename = result;
@@ -219,6 +219,13 @@ export default {
           console.warn(err);
           this.progress = 0;
         });
+    },
+    filterServerFiles(files) {
+      let self = this;
+      return files.filter(function(file) {
+        let ext = /(?:\.([^.]+))?$/.exec(file.text)[1];
+        return self.extensions.includes(ext);
+      });
     },
   },
 };

--- a/templates/_partials/fields/image.html.twig
+++ b/templates/_partials/fields/image.html.twig
@@ -11,6 +11,7 @@
         'placeholder_alt_text': 'image.placeholder_alt_text'|trans,
         'placeholder_title': 'image.placeholder_title'|trans,
     }|json_encode %}
+    {% set extensions = field.definition.get('extensions')|default('') %}
     <editor-image
         :name='{{ name|json_encode }}'
         :filename='{{ field.get('filename')|json_encode }}'
@@ -22,6 +23,6 @@
         :filelist='{{ filelist|json_encode }}'
         :csrf-token='{{ csrf_token('upload')|json_encode }}'
         :labels='{{ labels }}'
+        :extensions='{{ extensions|json_encode }}'
     ></editor-image>
-
 {% endblock %}


### PR DESCRIPTION
This implements the extensions limitations e.g.:
```
image:
    extensions: [ gif, jpg, png ]
```