### PR TITLE
fix test database transactional isolation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "cocur/slugify": "^3.2",
         "composer/composer": "^1.9",
         "doctrine/annotations": "^1.7",
-        "doctrine/dbal": "2.9.2",
+        "doctrine/dbal": "^2.9",
         "doctrine/doctrine-bundle": "^1.11",
         "doctrine/doctrine-cache-bundle": "^1.3.1",
         "doctrine/orm": "^2.6",

--- a/phpunit.bootstrap.php
+++ b/phpunit.bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__.'/vendor/autoload.php';
+
+$kernel = new \Bolt\Kernel('test', true);
+$kernel->boot();
+
+$application = new \Symfony\Bundle\FrameworkBundle\Console\Application($kernel);
+$application->setAutoExit(false);
+$application->setCatchExceptions(false);
+
+$application->run(new \Symfony\Component\Console\Input\StringInput('doctrine:database:drop --force --quiet'));
+$application->run(new \Symfony\Component\Console\Input\StringInput('doctrine:database:create --quiet'));
+$application->run(new \Symfony\Component\Console\Input\StringInput('doctrine:schema:create --quiet'));
+
+$kernel->shutdown();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="phpunit.bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" force="true"/>

--- a/tests/php/DbAwareTestCase.php
+++ b/tests/php/DbAwareTestCase.php
@@ -24,10 +24,6 @@ class DbAwareTestCase extends WebTestCase
 
     protected function setUp(): void
     {
-        self::runCommand('doctrine:database:drop --force');
-        self::runCommand('doctrine:database:create');
-        self::runCommand('doctrine:schema:create');
-
         $this->entityManager = static::createClient()->getContainer()
             ->get('doctrine')
             ->getManager();
@@ -49,6 +45,7 @@ class DbAwareTestCase extends WebTestCase
 
             self::$application = new Application($client->getKernel());
             self::$application->setAutoExit(false);
+            self::$application->setCatchExceptions(false);
         }
 
         // Since Symfony 4.3.0, the `doRun` method no longer triggers `->boot()`, so we do it ourselves.
@@ -60,8 +57,6 @@ class DbAwareTestCase extends WebTestCase
 
     protected function tearDown(): void
     {
-        self::runCommand('doctrine:database:drop --force');
-
         parent::tearDown();
 
         $this->entityManager->close();


### PR DESCRIPTION
Fixes https://github.com/bolt/core/issues/702

This doctrine bugfix actually made this issue visible :blush: 
https://github.com/doctrine/dbal/commit/a9b7bf855c6f391f96773f844d7158500394bcef#diff-7b1e94fb7dd408985f7b7973330dc2edR359

Here the issue was that dropping/creating the database is not transactional anymore. It was implicitly committing any open transaction on the underlying static connection from `dama/doctrine-test-bundle`. This is also mentioned in the readme of the bundle.

Before the doctrine bugfix this issue was hidden as the internal connection state (transaction nesting) was wrong.

So this PR fixes it by refactoring the database creation to be done **before** running any test. So there is no need anymore to do this within `setUp` or `tearDown`.