### PR TITLE
Fix jumping dropdowns

### DIFF
--- a/assets/js/app/toolbar/Components/Toolbar.vue
+++ b/assets/js/app/toolbar/Components/Toolbar.vue
@@ -47,6 +47,7 @@
         class="btn new-item__dropdown-toggler dropdown-toggle"
         type="button"
         data-toggle="dropdown"
+        data-display="static"
         aria-haspopup="true"
         aria-expanded="false"
       >
@@ -69,6 +70,7 @@
         class="btn user profile__dropdown-toggler dropdown-toggle"
         type="button"
         data-toggle="dropdown"
+        data-display="static"
         aria-haspopup="true"
         aria-expanded="false"
       >

--- a/assets/js/app/toolbar/Components/Toolbar.vue
+++ b/assets/js/app/toolbar/Components/Toolbar.vue
@@ -9,6 +9,7 @@
         class="btn brand__dropdown-toggler dropdown-toggle"
         type="button"
         data-toggle="dropdown"
+        data-display="static"
         aria-haspopup="true"
         aria-expanded="false"
       >


### PR DESCRIPTION
Fixes #775 
There seem to be some [positioning issues](https://github.com/popperjs/popper.js/issues) with popper.js (the library Bootstrap uses to dynamically align dropdowns), so this disables dynamic positioning.