### PR TITLE
Do not persist set field for set in collection

### DIFF
--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -199,13 +199,14 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
                 $field = $this->loadCollectionField($content, $field, $fieldType, $contentType, $preset, $translationRepository);
             } elseif ($fieldType['type'] === 'set') {
                 $field = $this->loadSetField($content, $field, $contentType, $preset, $translationRepository);
+                $ignoreField = true;
             } else {
                 $field->setValue($this->getValuesforFieldType($name, $fieldType, $contentType['singleton']));
             }
         }
         $field->setSortorder($sortorder++ * 5);
 
-        $content->addField($field);
+        if(!isset($ignoreField)) $content->addField($field);
 
         if (isset($fieldType['localize']) && $fieldType['localize']) {
             foreach ($contentType['locales'] as $locale) {

--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -206,7 +206,9 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
         }
         $field->setSortorder($sortorder++ * 5);
 
-        if(!isset($ignoreField)) $content->addField($field);
+        if (! isset($ignoreField)) {
+            $content->addField($field);
+        }
 
         if (isset($fieldType['localize']) && $fieldType['localize']) {
             foreach ($contentType['locales'] as $locale) {

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -32,21 +32,23 @@ class CollectionField extends Field implements FieldInterface
 
         $i = 0;
         foreach ($thisFieldValues as $thisFieldValue) {
-            $fieldDBname = $this->getName() . '::' . $thisFieldValue['field_name'];
-            $field = $this->getContent()->getField($fieldDBname);
-
-//          The field value persists ALL the values for the same type collection items (e.g. all 'ages') in an array
-//          To display the value for the current item, we set the value for the specific key only
-//          As $this->getValue() is called multiple times, clone the object to ensure $field->setValue() is called once per instance
-            $field = clone $field;
-            $field->setName($thisFieldValue['field_name']);
-            $field->setDefinition($thisFieldValue['field_name'], $this->getDefinition()->get('fields')[$thisFieldValue['field_name']]);
-
-            if ($thisFieldValue['field_type'] !== 'set') {
-                //all collection item fields, except sets, have a different value than if they were outside of a collection
+            if ($thisFieldValue['field_type'] === 'set') {
+                $field = new SetField();
+                $field->setContent($this->getContent());
+                $field->setValue($thisFieldValue['field_reference']);
+                $field->setDefinition($thisFieldValue['field_name'], $this->getDefinition()->get('fields')[$thisFieldValue['field_name']]);
+                $field->setName($thisFieldValue['field_name']);
+            } else {
+                $fieldDBname = $this->getName() . '::' . $thisFieldValue['field_name'];
+                $field = $this->getContent()->getField($fieldDBname);
+//              The field value persists ALL the values for the same type collection items (e.g. all 'ages') in an array
+//              To display the value for the current item, we set the value for the specific key only
+//              As $this->getValue() is called multiple times, clone the object to ensure $field->setValue() is called once per instance
+                $field = clone $field;
+                $field->setName($thisFieldValue['field_name']);
                 $field->setValue($field->getValue()[$thisFieldValue['field_reference']]);
+                $field->setDefinition($thisFieldValue['field_name'], $this->getDefinition()->get('fields')[$thisFieldValue['field_name']]);
             }
-
             $result['fields'][$i] = $field;
             $i++;
         }

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -41,9 +41,9 @@ class CollectionField extends Field implements FieldInterface
             } else {
                 $fieldDBname = $this->getName() . '::' . $thisFieldValue['field_name'];
                 $field = $this->getContent()->getField($fieldDBname);
-//              The field value persists ALL the values for the same type collection items (e.g. all 'ages') in an array
-//              To display the value for the current item, we set the value for the specific key only
-//              As $this->getValue() is called multiple times, clone the object to ensure $field->setValue() is called once per instance
+                //The field value persists ALL the values for the same type collection items (e.g. all 'ages') in an array
+                //To display the value for the current item, we set the value for the specific key only
+                //As $this->getValue() is called multiple times, clone the object to ensure $field->setValue() is called once per instance
                 $field = clone $field;
                 $field->setName($thisFieldValue['field_name']);
                 $field->setValue($field->getValue()[$thisFieldValue['field_reference']]);

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -32,8 +32,10 @@ class SetField extends Field implements FieldInterface
         $hash = $this->getHash();
         $fieldDefinitions = $this->getDefinition()->get('fields');
         $result = [];
-        $i = 0;
 
+        if(! is_array($fieldDefinitions)) return $result;
+
+        $i = 0;
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
             $currentSetFieldName = $hash . '::' . $fieldName;
             if ($this->getContent() && $this->getContent()->hasField($currentSetFieldName)) {

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -33,7 +33,9 @@ class SetField extends Field implements FieldInterface
         $fieldDefinitions = $this->getDefinition()->get('fields');
         $result = [];
 
-        if(! is_array($fieldDefinitions)) return $result;
+        if (! is_array($fieldDefinitions)) {
+            return $result;
+        }
 
         $i = 0;
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -32,12 +32,8 @@ class SetField extends Field implements FieldInterface
         $hash = $this->getHash();
         $fieldDefinitions = $this->getDefinition()->get('fields');
         $result = [];
-
-        if (! is_array($fieldDefinitions)) {
-            return $result;
-        }
-
         $i = 0;
+
         foreach ($fieldDefinitions as $fieldName => $fieldDefinition) {
             $currentSetFieldName = $hash . '::' . $fieldName;
             if ($this->getContent() && $this->getContent()->hasField($currentSetFieldName)) {


### PR DESCRIPTION
The fix in #795 creates a Set field, so that the standalone set is persisted.
This means, the Set field is also created as part of the Collection.
This introduces the issue that Bolt tries to treat the set inside the collection as a standalone field. In this case, by default the definition of the field is not set. Attempting to iterate over null in SetField::getValue() throws an exception.

Two possible solutions:
- [x] Tweak the creation of the collection to omit the set field being persisted
- [ ] Add a flag in the database to ignore certain fields

For now, the first one does the job.