### PR TITLE
replaces luxon toRelativeCalendar() with toRelative()

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -53,6 +53,6 @@ $(document).ready(function() {
    ** Convert all ISO dates with class .datetime-relative to relative time
    */
   $('.datetime-relative').each(function() {
-    $(this).text(DateTime.fromISO($(this).text()).toRelativeCalendar());
+    $(this).text(DateTime.fromISO($(this).text()).toRelative());
   });
 });


### PR DESCRIPTION
From luxon doc:
toRelativeCalendar() - Returns a string representation of this date relative to today, such as "yesterday" or "next month".
toRelative() - Returns a string representation of a this time relative to now, such as "in two days".