### PR TITLE
Several improvements to how you can handle `type: select` fields in the Frontend

### DIFF
--- a/src/Entity/Field/SelectField.php
+++ b/src/Entity/Field/SelectField.php
@@ -47,6 +47,38 @@ class SelectField extends Field implements FieldInterface
         return (array) $value;
     }
 
+    public function getOptions()
+    {
+        return $this->getDefinition()->get('values');
+    }
+
+    public function getSelected()
+    {
+        // "ContentSelect" select, with ids of other content
+        if ($this->isContentSelect()) {
+            return new Collection(parent::getValue());
+        }
+
+        // "Normal" select, with options
+        return $this->getOptions()->intersectByKeys(array_flip(parent::getValue()));
+    }
+
+    public function getSelectedIds()
+    {
+        return implode(' || ', parent::getValue());
+    }
+
+    public function getContentType()
+    {
+        $values = $this->getDefinition()->get('values');
+
+        if (is_string($values) && mb_strpos($values, '/') !== false) {
+            return current(explode('/', $values));
+        }
+
+        return false;
+    }
+
     public function isContentSelect(): bool
     {
         $values = $this->getDefinition()->get('values');

--- a/templates/helpers/_field_blocks.twig
+++ b/templates/helpers/_field_blocks.twig
@@ -61,9 +61,19 @@
 
     {# Special case for 'select' fields: if it's a multiple select, the field is an array. #}
     {% if type == "select" and field is not empty %}
-        <p><strong>{{ field|label }}: </strong>
-            {{ dump(field) }}
-        </p>
+        <p><strong>{{ field|label }}: </strong></p>
+            <ul>
+            {% if field.contentSelect %}
+                {% setcontent selected = field.contentType where {'id': field.selectedIds} %}
+                {% for record in selected %}
+                <li><a href="{{ record|link }}">{{ record|title }}</a></li>
+                {% endfor %}
+            {% else %}
+                {% for key, value in field.selected %}
+                    <li>{{ value }} <small>(key: <code>{{ key }}</code>)</small></li>
+                {% endfor %}
+            {% endif %}
+            </ul>
     {% endif %}
 
     {# Checkbox fields #}

--- a/templates/helpers/_fields.twig
+++ b/templates/helpers/_fields.twig
@@ -51,7 +51,7 @@
         {% endif %}
 
         {# The rest of the built-in types #}
-        {% if extended|default(false) and (type not in exclude|default([])) %}
+        {% if extended|default(true) and (type not in exclude|default([])) %}
             {{ block('extended_fields') }}
         {% endif %}
 


### PR DESCRIPTION
Fixes #835 

You can now do things like: 

```twig
            {% if field.contentSelect %}

                {% setcontent selected = field.contentType where {'id': field.selectedIds} %}
                {% for record in selected %}
                <li><a href="{{ record|link }}">{{ record|title }}</a></li>
                {% endfor %}

            {% else %}

                {% for key, value in field.selected %}
                    <li>{{ value }} <small>(key: <code>{{ key }}</code>)</small></li>
                {% endfor %}

            {% endif %}
            </ul>
```

and 

```twig
{{ dump(field.value) }}
{{ dump(field.options) }}
{{ dump(field.selected) }}
```