### PR TITLE
Feature/make slugs localizable

### DIFF
--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -51,12 +51,7 @@ class DetailController extends TwigAwareController implements FrontendZone
         if (is_numeric($slugOrId)) {
             $record = $this->contentRepository->findOneBy(['id' => (int) $slugOrId]);
         } else {
-            // @todo this should search only by slug or any other unique field
-            $field = $this->fieldRepository->findOneBySlug($slugOrId);
-            if ($field === null) {
-                throw new NotFoundHttpException('Content does not exist.');
-            }
-            $record = $field->getContent();
+            $record = $this->contentRepository->findOneBySlug($slugOrId);
         }
 
         if (! $record) {

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -7,7 +7,6 @@ namespace Bolt\Controller\Frontend;
 use Bolt\Controller\TwigAwareController;
 use Bolt\Enum\Statuses;
 use Bolt\Repository\ContentRepository;
-use Bolt\Repository\FieldRepository;
 use Bolt\TemplateChooser;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -21,14 +20,10 @@ class DetailController extends TwigAwareController implements FrontendZone
     /** @var ContentRepository */
     private $contentRepository;
 
-    /** @var FieldRepository */
-    private $fieldRepository;
-
-    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository, FieldRepository $fieldRepository)
+    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository)
     {
         $this->templateChooser = $templateChooser;
         $this->contentRepository = $contentRepository;
-        $this->fieldRepository = $fieldRepository;
     }
 
     /**

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -183,9 +183,29 @@ class Content
         return $this->contentTypeDefinition;
     }
 
-    public function getSlug(): ?string
+    public function getSlug($locale = null): ?string
     {
-        return $this->getFieldValue('slug');
+
+        $slug = null;
+        if($locale === null)
+        {
+            // get slug with locale the slug already has
+            $slug = $this->getFieldValue('slug');
+        } else {
+            // get slug with the requested locale
+            $slug = $this->getField('slug')->setLocale($locale)->getParsedValue();
+        }
+
+        if($slug === null)
+        {
+            // if no slug exists for the current/requested locale, default back
+            $slug = $this
+                ->getField('slug')
+                ->setLocale($this->getField('slug')->getDefaultLocale())
+                ->getParsedValue();
+        }
+
+        return $slug;
     }
 
     public function getContentType(): ?string

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -185,10 +185,8 @@ class Content
 
     public function getSlug($locale = null): ?string
     {
-
         $slug = null;
-        if($locale === null)
-        {
+        if ($locale === null) {
             // get slug with locale the slug already has
             $slug = $this->getFieldValue('slug');
         } else {
@@ -196,8 +194,7 @@ class Content
             $slug = $this->getField('slug')->setLocale($locale)->getParsedValue();
         }
 
-        if($slug === null)
-        {
+        if ($slug === null) {
             // if no slug exists for the current/requested locale, default back
             $slug = $this
                 ->getField('slug')

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -207,9 +207,11 @@ class Field implements FieldInterface, TranslatableInterface
         return $this;
     }
 
-    public function setLocale(?string $locale): void
+    public function setLocale(?string $locale): self
     {
         $this->setCurrentLocale($locale);
+
+        return $this;
     }
 
     public function getLocale(): ?string

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -130,7 +130,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function get($key)
     {
-        return $this->translate($this->getCurrentLocale())->get($key);
+        return $this->translate($this->getCurrentLocale(), false)->get($key);
     }
 
     /**
@@ -138,7 +138,7 @@ class Field implements FieldInterface, TranslatableInterface
      */
     public function getValue(): ?array
     {
-        return $this->translate($this->getCurrentLocale())->getValue();
+        return $this->translate($this->getCurrentLocale(), false)->getValue();
     }
 
     /**
@@ -182,7 +182,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function set(string $key, $value): self
     {
-        $this->translate($this->getCurrentLocale())->set($key, $value);
+        $this->translate($this->getCurrentLocale(), false)->set($key, $value);
 
         return $this;
     }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -130,7 +130,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function get($key)
     {
-        return $this->translate($this->getCurrentLocale(), false)->get($key);
+        return $this->translate($this->getCurrentLocale(), ! $this->isTranslatable())->get($key);
     }
 
     /**
@@ -138,7 +138,7 @@ class Field implements FieldInterface, TranslatableInterface
      */
     public function getValue(): ?array
     {
-        return $this->translate($this->getCurrentLocale(), false)->getValue();
+        return $this->translate($this->getCurrentLocale(), ! $this->isTranslatable())->getValue();
     }
 
     /**
@@ -182,14 +182,14 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function set(string $key, $value): self
     {
-        $this->translate($this->getCurrentLocale(), false)->set($key, $value);
+        $this->translate($this->getCurrentLocale(), ! $this->isTranslatable())->set($key, $value);
 
         return $this;
     }
 
     public function setValue($value): self
     {
-        $this->translate($this->getLocale(), false)->setValue($value);
+        $this->translate($this->getLocale(), ! $this->isTranslatable())->setValue($value);
         $this->mergeNewTranslations();
 
         return $this;
@@ -291,5 +291,10 @@ class Field implements FieldInterface, TranslatableInterface
         $entityClass = array_pop($explodedNamespace);
 
         return '\\' . implode('\\', $explodedNamespace) . '\\' . $entityClass . 'Translation';
+    }
+
+    private function isTranslatable(): bool
+    {
+        return $this->getDefinition()->get('localize') === true;
     }
 }

--- a/src/Entity/FieldParentTrait.php
+++ b/src/Entity/FieldParentTrait.php
@@ -43,12 +43,14 @@ trait FieldParentTrait
         })->toArray();
     }
 
-    public function setLocale(?string $locale): void
+    public function setLocale(?string $locale): Field
     {
         parent::setLocale($locale);
         /** @var Field $child */
         foreach ($this->getChildren() as $child) {
             $child->setLocale($locale);
         }
+
+        return $this;
     }
 }

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -71,8 +71,10 @@ class LocaleHelper
             return $locales;
         }
 
-        if (isset($routeParams['id']) || is_numeric($routeParams['slugOrId'])) {
+        if (isset($routeParams['id'])) {
             $content = $this->contentRepository->findOneById((int) $routeParams['id']);
+        } elseif (is_numeric($routeParams['slugOrId'])) {
+            $content = $this->contentRepository->findOneById((int) $routeParams['slugOrId']);
         } else {
             $content = $this->contentRepository->findOneBySlug($routeParams['slugOrId']);
         }

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -73,17 +73,19 @@ class LocaleHelper
 
         if (isset($routeParams['id'])) {
             $content = $this->contentRepository->findOneById((int) $routeParams['id']);
-        } elseif (is_numeric($routeParams['slugOrId'])) {
+        } elseif (isset($routeParams['slugOrId']) && is_numeric($routeParams['slugOrId'])) {
             $content = $this->contentRepository->findOneById((int) $routeParams['slugOrId']);
-        } else {
+        } elseif (isset($routeParams['slugOrId'])) {
             $content = $this->contentRepository->findOneBySlug($routeParams['slugOrId']);
         }
 
         foreach ($localeCodes as $localeCode) {
             $locale = $this->localeInfo($localeCode);
 
-            $slug = $content->getSlug($localeCode);
-            $routeParams['slugOrId'] = $slug;
+            if (isset($content)) {
+                $slug = $content->getSlug($localeCode);
+                $routeParams['slugOrId'] = $slug;
+            }
 
             $locale->put('link', $this->getLink($route, $routeParams, $locale));
             $locale->put('current', $currentLocale === $localeCode);

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -71,7 +71,11 @@ class LocaleHelper
             return $locales;
         }
 
-        $content = $this->contentRepository->findOneBySlug($routeParams['slugOrId']);
+        if (isset($routeParams['id']) || is_numeric($routeParams['slugOrId'])) {
+            $content = $this->contentRepository->findOneById((int) $routeParams['id']);
+        } else {
+            $content = $this->contentRepository->findOneBySlug($routeParams['slugOrId']);
+        }
 
         foreach ($localeCodes as $localeCode) {
             $locale = $this->localeInfo($localeCode);

--- a/templates/content/view_locales.html.twig
+++ b/templates/content/view_locales.html.twig
@@ -34,13 +34,16 @@
                 </td>
                 {% set localizedValues = find_translations(field) %}
                 {% for locale in locales %}
+                    {% set translated = field|translated(locale) %}
                     <td>
-                        {% if not field.definition.localize and not loop.first %}
+                        {% if not field.definition.localize %}
                             <span class="badge badge-info">{{ 'view_locales.badge_default'|trans }}</span>
-                        {% elseif localizedValues[locale]|default and localizedValues[locale].value is not empty %}
-                            <span class="badge badge-success">{{ 'view_locales.badge_ok'|trans }}</span>
+                        {% elseif localizedValues[locale] is not defined %}
+                            <span class="badge badge-danger">{{ 'view_locales.badge_missing'|trans }}</span>
+                        {% elseif localizedValues[locale] is defined and translated.twigvalue is empty %}
+                            <span class="badge badge-warning">{{ 'view_locales.badge_empty'|trans }}</span>
                         {% else %}
-                            <span class="badge badge-warning">{{ 'view_locales.badge_missing'|trans }}</span>
+                            <span class="badge badge-success">{{ 'view_locales.badge_ok'|trans }}</span>
                         {% endif %}
                     </td>
                 {% endfor %}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2180,6 +2180,12 @@
         <source>general.phrase.empty-database</source>
         <target>It looks like the database is empty. Write some content in the Bolt backend, or run the command to add some fixtures (dummy content). </target>
       </segment>
+    </unit>    
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Empty</target>
+      </segment>
     </unit>
   </file>
 </xliff>


### PR DESCRIPTION
Makes slugs localizable by adding localize: true to slug fields.

If the slug does not exist with the requested locale, use the default locale's slug instead.