### PR TITLE
Bugfix/datetime picker

### DIFF
--- a/assets/scss/modules/editor/fields/_date.scss
+++ b/assets/scss/modules/editor/fields/_date.scss
@@ -9,3 +9,14 @@
     background-color: $input-disabled-bg;
   }
 }
+
+/* Remove up/down arrows on datetime picker: Chrome, Safari, Edge, Opera  */
+.flatpickr-calendar input[type=number]::-webkit-inner-spin-button,
+.flatpickr-calendar input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+/* Remove up/down arrows on datetime picker: Firefox  */
+.flatpickr-calendar input[type=number] {
+  -moz-appearance:textfield;
+}

--- a/assets/scss/modules/editor/fields/_date.scss
+++ b/assets/scss/modules/editor/fields/_date.scss
@@ -16,7 +16,8 @@
   -webkit-appearance: none;
   margin: 0;
 }
+
 /* Remove up/down arrows on datetime picker: Firefox  */
 .flatpickr-calendar input[type=number] {
-  -moz-appearance:textfield;
+  -moz-appearance: textfield;
 }

--- a/assets/scss/modules/editor/fields/_date.scss
+++ b/assets/scss/modules/editor/fields/_date.scss
@@ -21,3 +21,7 @@
 .flatpickr-calendar input[type=number] {
   -moz-appearance: textfield;
 }
+
+.flatpickr-month {
+  height: 34px !important; // 34px is latest flatpickr repo value
+}


### PR DESCRIPTION
Fixes #911 

```
.flatpickr-month {
  height: 34px !important; // 34px is latest flatpickr repo value
}
```

The height used to be 24px or 28px in the official flickr repo, however this was changed some months ago. That change, however, is not reflected in the `vue-flatpickr-component` package that we use (not sure why?)

Is this too ugly @bobdenotter ?