### PR TITLE
Export fields as actual (not interpreted) values

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -355,11 +355,11 @@ class Content
     /**
      * @Groups("get_content")
      */
-    public function getFieldValues(): array
+    public function getFieldValues(bool $parsed = true): array
     {
         $fieldValues = [];
         foreach ($this->getFields() as $field) {
-            $fieldValues[$field->getName()] = $field->getValue();
+            $fieldValues[$field->getName()] = $parsed ? $field->getParsedValue() : $field->getValue();
         }
 
         return $fieldValues;
@@ -621,7 +621,7 @@ class Content
             ];
         }
 
-        $result['fields'] = $this->getFieldValues();
+        $result['fields'] = $this->getFieldValues(false);
 
         $result['taxonomies'] = $this->getTaxonomyValues();
         $result['relations'] = [];

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -359,7 +359,7 @@ class Content
     {
         $fieldValues = [];
         foreach ($this->getFields() as $field) {
-            $fieldValues[$field->getName()] = $field->getParsedValue();
+            $fieldValues[$field->getName()] = $field->getValue();
         }
 
         return $fieldValues;


### PR DESCRIPTION
Note: This is needed for exporting content.. In that case, we don't want to have markdown parsed, like we _do_ want in the API, for example.