### PR TITLE
Two fixes for Frontend menus

### DIFF
--- a/src/Menu/FrontendMenuBuilder.php
+++ b/src/Menu/FrontendMenuBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Menu;
 
 use Bolt\Collection\DeepCollection;
+use Bolt\Common\Str;
 use Bolt\Configuration\Config;
 use Bolt\Entity\Content;
 use Bolt\Repository\ContentRepository;
@@ -79,7 +80,7 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
         $trimmedLink = trim($link, '/');
 
         // Special case for "Homepage"
-        if ($trimmedLink === 'homepage') {
+        if ($trimmedLink === 'homepage' || $trimmedLink === $this->config->get('general/homepage')) {
             return ['Home', $this->urlGenerator->generate('homepage')];
         }
 
@@ -92,7 +93,7 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
         }
 
         // Otherwise trust the user. ¯\_(ツ)_/¯
-        return ['', $link];
+        return ['', Str::ensureStartsWith($link, '/')];
     }
 
     private function getContent(string $link): ?Content

--- a/src/Menu/FrontendMenuBuilder.php
+++ b/src/Menu/FrontendMenuBuilder.php
@@ -93,7 +93,16 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
         }
 
         // Otherwise trust the user. ¯\_(ツ)_/¯
-        return ['', Str::ensureStartsWith($link, '/')];
+        return ['', $this->makeAbsoluteLink($link)];
+    }
+
+    private function makeAbsoluteLink(string $link): string
+    {
+        if (mb_strpos($link, '://') !== false || mb_substr($link, 0, 2) === '//') {
+            return $link;
+        }
+
+        return Str::ensureStartsWith($link, '/');
     }
 
     private function getContent(string $link): ?Content


### PR DESCRIPTION
 - Recognizes `homepage: …` setting as correct link to homepage and generates correct url
 - Relative links like `pages/` work correct now