### PR TITLE
Awesome default option

### DIFF
--- a/assets/js/app/editor/Components/Embed.vue
+++ b/assets/js/app/editor/Components/Embed.vue
@@ -155,6 +155,9 @@ export default {
   },
   created: function() {
     this.debouncedFetchEmbed = _.debounce(this.fetchEmbed, 500);
+    if(this.url) {
+      this.debouncedFetchEmbed();
+    }
     this.previewImage = this.thumbnail;
   },
   updated() {

--- a/assets/js/app/editor/Components/Embed.vue
+++ b/assets/js/app/editor/Components/Embed.vue
@@ -130,16 +130,16 @@ export default {
     errormessage: String | Boolean, //string if errormessage is set, and false otherwise
     pattern: String | Boolean,
   },
-  data: () => {
+  data(){
     return {
-      authorurlData: null,
-      authornameData: null,
-      heightData: null,
-      htmlData: null,
-      thumbnailData: null,
-      titleData: null,
-      urlData: null,
-      widthData: null,
+      authorurlData: this.authorurl,
+      authornameData: this.authorname,
+      heightData: this.height,
+      htmlData: this.html,
+      thumbnailData: this.thumbnail,
+      titleData: this.title,
+      urlData: this.url,
+      widthData: this.width,
     };
   },
   watch: {

--- a/assets/js/app/editor/Components/Embed.vue
+++ b/assets/js/app/editor/Components/Embed.vue
@@ -130,7 +130,7 @@ export default {
     errormessage: String | Boolean, //string if errormessage is set, and false otherwise
     pattern: String | Boolean,
   },
-  data(){
+  data() {
     return {
       authorurlData: this.authorurl,
       authornameData: this.authorname,
@@ -155,7 +155,7 @@ export default {
   },
   created: function() {
     this.debouncedFetchEmbed = _.debounce(this.fetchEmbed, 500);
-    if(this.url) {
+    if (this.url) {
       this.debouncedFetchEmbed();
     }
     this.previewImage = this.thumbnail;

--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -148,6 +148,7 @@ export default {
   mixins: [field],
   props: {
     name: String,
+    filename: String,
     title: String,
     directory: String,
     media: String,

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -325,6 +325,7 @@ tests:
             type: text
             class: large
             group: content
+            default: "Title of a test contenttype"
         slug:
             type: slug
             uses: title
@@ -345,6 +346,8 @@ tests:
         image:
             type: image
             postfix: An image, actually _named_ image.
+            default:
+                filename: "foal.jpg"
         picture:
             type: image
             postfix: An image, named differently.

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -36,7 +36,7 @@ class FieldType extends Collection
             'prefix' => '',
             'placeholder' => '',
             'sort' => '',
-            'default' => '',
+            'default' => null,
             'allow_twig' => false,
             'allow_html' => false,
             'info' => '',

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -130,8 +130,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function get($key)
     {
-        if($this->isNew() && $this->getDefaultValue() !== null)
-        {
+        if ($this->isNew() && $this->getDefaultValue() !== null) {
             return $this->getDefaultValue()->get($key);
         }
 
@@ -148,7 +147,6 @@ class Field implements FieldInterface, TranslatableInterface
 
     /**
      * Returns the default value option
-     * @return mixed
      */
     public function getDefaultValue()
     {

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -142,6 +142,20 @@ class Field implements FieldInterface, TranslatableInterface
     }
 
     /**
+     * Returns the default value option
+     * @return mixed
+     */
+    public function getDefaultValue()
+    {
+        return $this->getDefinition()->get('default', null);
+    }
+
+    public function isNew(): bool
+    {
+        return $this->getId() === null;
+    }
+
+    /**
      * like getValue() but returns single value for single value fields
      *
      * @return array|mixed|null

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -130,6 +130,11 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function get($key)
     {
+        if($this->isNew() && $this->getDefaultValue() !== null)
+        {
+            return $this->getDefaultValue()->get($key);
+        }
+
         return $this->translate($this->getCurrentLocale(), ! $this->isTranslatable())->get($key);
     }
 
@@ -152,7 +157,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function isNew(): bool
     {
-        return $this->getId() === null;
+        return $this->getId() === 0;
     }
 
     /**

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -68,16 +68,14 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
     {
         $default = parent::getDefaultValue();
 
-        if($default === null)
-        {
+        if ($default === null) {
             return [];
         }
 
         $result = [];
 
         /** @var ContentType $type */
-        foreach($default as $key => $type)
-        {
+        foreach ($default as $key => $type) {
             $value = $type->toArray()['default'];
             $name = $type->toArray()['field'];
             $definition = $this->getDefinition()->get('fields')[$name];

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -75,7 +75,7 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
         $result = [];
 
         /** @var ContentType $type */
-        foreach ($default as $key => $type) {
+        foreach ($default as $type => $type) {
             $value = $type->toArray()['default'];
             $name = $type->toArray()['field'];
             $definition = $this->getDefinition()->get('fields')[$name];

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Entity\Field;
 
 use ArrayIterator;
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Field;
 use Bolt\Entity\FieldInterface;
 use Bolt\Entity\FieldParentInterface;
@@ -61,5 +62,30 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
         });
 
         return $fields->toArray();
+    }
+
+    public function getDefaultValue()
+    {
+        $default = parent::getDefaultValue();
+
+        if($default === null)
+        {
+            return [];
+        }
+
+        $result = [];
+
+        /** @var ContentType $type */
+        foreach($default as $key => $type)
+        {
+            $value = $type->toArray()['default'];
+            $name = $type->toArray()['field'];
+            $definition = $this->getDefinition()->get('fields')[$name];
+            $field = FieldRepository::factory($definition, $name);
+            $field->setValue($value);
+            $result[] = $field;
+        }
+
+        return $result;
     }
 }

--- a/src/Entity/Field/DateField.php
+++ b/src/Entity/Field/DateField.php
@@ -19,8 +19,7 @@ class DateField extends Field implements FieldInterface
     {
         $default = parent::getDefaultValue();
 
-        if($default !== null)
-        {
+        if ($default !== null) {
             // Flatpickr asks for milliseconds, strtotime returns unix timestmap in seconds
             return strtotime($default) * 1000;
         }

--- a/src/Entity/Field/DateField.php
+++ b/src/Entity/Field/DateField.php
@@ -14,4 +14,17 @@ use Doctrine\ORM\Mapping as ORM;
 class DateField extends Field implements FieldInterface
 {
     public const TYPE = 'date';
+
+    public function getDefaultValue()
+    {
+        $default = parent::getDefaultValue();
+
+        if($default !== null)
+        {
+            // Flatpickr asks for milliseconds, strtotime returns unix timestmap in seconds
+            return strtotime($default) * 1000;
+        }
+
+        return $default;
+    }
 }

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Entity\Field;
 
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Field;
 use Bolt\Entity\FieldInterface;
 use Doctrine\ORM\Mapping as ORM;
@@ -42,14 +43,41 @@ class FilelistField extends Field implements FieldInterface
         return $result;
     }
 
+    public function getDefaultValue(): array
+    {
+        $result = [];
+
+        $values = parent::getDefaultValue();
+
+        if($values !== null) {
+            /** @var ContentType $file */
+            foreach (parent::getDefaultValue() as $key => $file) {
+                $file = $file->toArray();
+                $fileField = new ImageField();
+                $fileField->setName((string)$key);
+                $fileField->setValue($file);
+                $result[] = $fileField;
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * Returns the value, where the contained Image fields are seperately
      * casted to arrays, including the "extras"
      */
     public function getJsonValue()
     {
+        if($this->isNew())
+        {
+            $values = $this->getDefaultValue();
+        } else {
+            $values = $this->getValue();
+        }
+
         return json_encode(array_map(function (FileField $i) {
             return $i->getValue();
-        }, $this->getValue()));
+        }, $values));
     }
 }

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -53,7 +53,7 @@ class FilelistField extends Field implements FieldInterface
             /** @var ContentType $file */
             foreach (parent::getDefaultValue() as $key => $file) {
                 $file = $file->toArray();
-                $fileField = new ImageField();
+                $fileField = new FileField();
                 $fileField->setName((string)$key);
                 $fileField->setValue($file);
                 $result[] = $fileField;

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -49,12 +49,12 @@ class FilelistField extends Field implements FieldInterface
 
         $values = parent::getDefaultValue();
 
-        if($values !== null) {
+        if ($values !== null) {
             /** @var ContentType $file */
             foreach (parent::getDefaultValue() as $key => $file) {
                 $file = $file->toArray();
                 $fileField = new FileField();
-                $fileField->setName((string)$key);
+                $fileField->setName((string) $key);
                 $fileField->setValue($file);
                 $result[] = $fileField;
             }
@@ -69,8 +69,7 @@ class FilelistField extends Field implements FieldInterface
      */
     public function getJsonValue()
     {
-        if($this->isNew())
-        {
+        if ($this->isNew()) {
             $values = $this->getDefaultValue();
         } else {
             $values = $this->getValue();

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -49,12 +49,12 @@ class ImagelistField extends Field implements FieldInterface
 
         $values = parent::getDefaultValue();
 
-        if($values !== null) {
+        if ($values !== null) {
             /** @var ContentType $image */
             foreach (parent::getDefaultValue() as $key => $image) {
                 $image = $image->toArray();
                 $imageField = new ImageField();
-                $imageField->setName((string)$key);
+                $imageField->setName((string) $key);
                 $imageField->setValue($image);
                 $result[] = $imageField;
             }
@@ -69,8 +69,7 @@ class ImagelistField extends Field implements FieldInterface
      */
     public function getJsonValue()
     {
-        if($this->isNew())
-        {
+        if ($this->isNew()) {
             $values = $this->getDefaultValue();
         } else {
             $values = $this->getValue();

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Entity\Field;
 
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Field;
 use Bolt\Entity\FieldInterface;
 use Doctrine\ORM\Mapping as ORM;
@@ -42,14 +43,37 @@ class ImagelistField extends Field implements FieldInterface
         return $result;
     }
 
+    public function getDefaultValue(): array
+    {
+        $result = [];
+
+        /** @var ContentType $image */
+        foreach(parent::getDefaultValue() as $key => $image) {
+            $image = $image->toArray();
+            $imageField = new ImageField();
+            $imageField->setName((string) $key);
+            $imageField->setValue($image);
+            $result[] = $imageField;
+        }
+
+        return $result;
+    }
+
     /**
      * Returns the value, where the contained Image fields are seperately
      * casted to arrays, including the "extras"
      */
     public function getJsonValue()
     {
+        if($this->isNew())
+        {
+            $values = $this->getDefaultValue();
+        } else {
+            $values = $this->getValue();
+        }
+
         return json_encode(array_map(function (ImageField $i) {
             return $i->getValue();
-        }, $this->getValue()));
+        }, $values));
     }
 }

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -47,13 +47,17 @@ class ImagelistField extends Field implements FieldInterface
     {
         $result = [];
 
-        /** @var ContentType $image */
-        foreach(parent::getDefaultValue() as $key => $image) {
-            $image = $image->toArray();
-            $imageField = new ImageField();
-            $imageField->setName((string) $key);
-            $imageField->setValue($image);
-            $result[] = $imageField;
+        $values = parent::getDefaultValue();
+
+        if($values !== null) {
+            /** @var ContentType $image */
+            foreach (parent::getDefaultValue() as $key => $image) {
+                $image = $image->toArray();
+                $imageField = new ImageField();
+                $imageField->setName((string)$key);
+                $imageField->setValue($image);
+                $result[] = $imageField;
+            }
         }
 
         return $result;

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -71,7 +71,7 @@
         {% set value = field.defaultValue %}
     {% else %}
         {% set value = field.value|default('') %}
-            {% if value is iterable and field|type != "select" %}
+            {% if value is iterable and field|type != "select" and field|type != "collection" %}
                 {% set value = value|first %}
             {% endif %}
     {% endif %}

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -67,9 +67,13 @@
 
 {# Set the value #}
 {% if not value|default %}
-    {% set value = field.value|default('') %}
-    {% if value is iterable and field|type != "select" %}
-        {% set value = value|first %}
+    {% if field.isNew|default(true) and field.defaultValue|default(null) is not null %}
+        {% set value = field.defaultValue %}
+    {% else %}
+        {% set value = field.value|default('') %}
+            {% if value is iterable and field|type != "select" %}
+                {% set value = value|first %}
+            {% endif %}
     {% endif %}
 {% endif %}
 

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -67,7 +67,7 @@
 
 {# Set the value #}
 {% if not value|default %}
-    {% if field.isNew|default(true) and field.defaultValue|default(null) is not null %}
+    {% if field.isNew|default and field.defaultValue|default(null) is not null %}
         {% set value = field.defaultValue %}
     {% else %}
         {% set value = field.value|default('') %}

--- a/templates/_partials/fields/collection.html.twig
+++ b/templates/_partials/fields/collection.html.twig
@@ -8,10 +8,7 @@
     {% set limit = field.definition.get('limit')|default(200) %}
 
     {# get the html for all collection field already in the database #}
-    {% set existing_fields = []|json_encode %}
-    {% if field.value is defined %}
-        {% set existing_fields %}{{ macro.generate_collection_fields(field, field.value, false) }}{% endset %}
-    {% endif %}
+    {% set existing_fields %}{{ macro.generate_collection_fields(field, value, false) }}{% endset %}
 
     {# get the html template for the collection fields defined in the field definition #}
     {% set templated_fields = "" %}

--- a/tests/e2e/edit_record_1.feature
+++ b/tests/e2e/edit_record_1.feature
@@ -278,3 +278,22 @@ Feature: Edit record
     When I press the 1st "Remove" button
     Then the "fields[image][filename]" field should contain ""
     And the "fields[image][alt]" field should contain ""
+
+  @javascript
+  Scenario: As an Admin, I want to see default values on new content
+    Given I am logged in as "admin"
+    And I am on "/bolt"
+
+    When I hover over the "Tests" element
+    And I follow "New Test"
+
+    Then I should be on "/bolt/new/tests"
+
+    And the "fields[title]" field should contain "Title of a test contenttype"
+    And the "fields[image][filename]" field should contain "foal.jpg"
+
+    When I scroll "Save changes" into view
+    And I press "Save changes"
+
+    Then the "fields[title]" field should contain "Title of a test contenttype"
+    And the "fields[image][filename]" field should contain "foal.jpg"


### PR DESCRIPTION
Fixes #929 
Fixes #1035 

Examples:

```
type: text
default: "Hello, Bolt"
```

```
type: date
default: "yesterday"
```

```
type: image
alt: true
default:
    filename: "foal.jpg"
    alt: "This is a nice animal"
```

```
type: filelist
default:
    0:
        filename: "something.pdf"
        title: "A file with something"
    1:
        filename: "another.pdf"
        title: "This comes second"
```

```
type: collection
fields:
    name:
        type: text
    age:
        type: number
default:
    0:
        field: name
        default: "Charlie Sheen"
    1:
        field: age
        default: 54
```
