### PR TITLE
Admin panel doesn't break when a collection is removed form contenttypes.yaml

### DIFF
--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -59,8 +59,8 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
         $fields = new ArrayCollection(iterator_to_array($iterator));
 
         $fields->map(function (Field $field): void {
-            $definition = $this->getDefinition('fields')[$field->getName()] ?? new Collection();
-            $field->setDefinition($field->getName(),$definition);
+            $definition = $this->getDefinition()->get('fields')[$field->getName()] ?? new Collection();
+            $field->setDefinition($field->getName(), $definition);
         });
 
         return $fields->toArray();

--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -13,6 +13,7 @@ use Bolt\Entity\FieldParentTrait;
 use Bolt\Repository\FieldRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Tightenco\Collect\Support\Collection;
 
 /**
  * @ORM\Entity
@@ -58,7 +59,8 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
         $fields = new ArrayCollection(iterator_to_array($iterator));
 
         $fields->map(function (Field $field): void {
-            $field->setDefinition($field->getName(), $this->getDefinition()->get('fields')[$field->getName()]);
+            $definition = $this->getDefinition('fields')[$field->getName()] ?? new Collection();
+            $field->setDefinition($field->getName(),$definition);
         });
 
         return $fields->toArray();


### PR DESCRIPTION
When a collection with fields in the database exists, make sure not to break the backend if the collection is removed from contenttypes.yaml