### PR TITLE
Always show slug in listing title, even if translations are available

### DIFF
--- a/assets/js/app/listing/Components/Table/Row/index.vue
+++ b/assets/js/app/listing/Components/Table/Row/index.vue
@@ -92,7 +92,6 @@ export default {
       ];
     },
     size() {
-      console.log(this.record);
       return this.$store.getters['general/getRowSize'];
     },
     sorting() {

--- a/assets/js/app/listing/Components/Table/Row/index.vue
+++ b/assets/js/app/listing/Components/Table/Row/index.vue
@@ -31,7 +31,7 @@
         <a
           class="listing__row--item-title"
           :href="record.extras.editLink"
-          :title="record.fieldValues.slug"
+          :title="slug"
         >
           {{ record.extras.title | trim(62) }}
         </a>
@@ -82,7 +82,17 @@ export default {
     labels: Object,
   },
   computed: {
+    slug() {
+      if (typeof this.record.fieldValues.slug === 'string') {
+        return this.record.fieldValues.slug;
+      }
+      // if slug has different locales, return the 0st one
+      return this.record.fieldValues.slug[
+        Object.keys(this.record.fieldValues.slug)[0]
+      ];
+    },
     size() {
+      console.log(this.record);
       return this.$store.getters['general/getRowSize'];
     },
     sorting() {


### PR DESCRIPTION
Since slugs are localisable, pages with translatable slugs showed "Object object" for the hover on the listing page. This fixes it