### PR TITLE
Allow getting extensions by partial name.

### DIFF
--- a/src/Extension/ExtensionRegistry.php
+++ b/src/Extension/ExtensionRegistry.php
@@ -69,7 +69,7 @@ class ExtensionRegistry
         }
 
         foreach ($this->extensions as $key => $extension) {
-            if (strpos($key, $name) !== false) {
+            if (mb_strpos($key, $name) !== false) {
                 return $extension;
             }
         }

--- a/src/Extension/ExtensionRegistry.php
+++ b/src/Extension/ExtensionRegistry.php
@@ -68,6 +68,12 @@ class ExtensionRegistry
             return $this->extensions[$name];
         }
 
+        foreach ($this->extensions as $key => $extension) {
+            if (strpos($key, $name) !== false) {
+                return $extension;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
I can foresee a lot of people getting stuck when getting (the config of) extensions, if it requires the full name. For example, before you _had_ to do this:

```php 
/** @var ExtensionRegistry $extensionRegistry */
$extensionRegistry->getExtension('Bolt\\BoltForms\\Extension');
```

Now you can do this: 

```php 
/** @var ExtensionRegistry $extensionRegistry */
$extensionRegistry->getExtension('Bolt\\BoltForms');

// or even
$extensionRegistry->getExtension('BoltForms');
```