### PR TITLE
Forbid console.log, but allow warnings and errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,8 +16,8 @@ module.exports = {
     "prettier/vue",
   ],
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
+    "no-console": ["error", {allow: ["error", "warn"]}],
+    "no-debugger": "error" ,
     "vue/require-default-prop": "off",
     "vue/require-prop-type-constructor": "off",
     "prettier/prettier": "error",

--- a/assets/js/app/editor/Components/Embed.vue
+++ b/assets/js/app/editor/Components/Embed.vue
@@ -193,7 +193,7 @@ export default {
           this.previewImage = json.thumbnail_url;
         })
         .catch(err => {
-          console.log(err);
+          console.warn(err);
         });
     },
   },


### PR DESCRIPTION
eslint will fail on `console.log` but will allow `warn` and `error`.