### PR TITLE
A number of smaller fixes to overview pages

### DIFF
--- a/assets/js/app/listing/Components/Table/Row/_Meta.vue
+++ b/assets/js/app/listing/Components/Table/Row/_Meta.vue
@@ -7,7 +7,7 @@
           :class="`is-${record.status}`"
           :title="record.status"
         ></span
-        >{{ record.publishedAt | date }}
+        >{{ record.publishedAt ? record.publishedAt : record.createdAt | date }}
       </li>
       <li v-if="size === 'normal'">
         <i class="fas fa-user"></i> {{ record.authorName }}

--- a/assets/js/app/listing/Components/Table/Row/index.vue
+++ b/assets/js/app/listing/Components/Table/Row/index.vue
@@ -18,27 +18,27 @@
       :class="`is-${size}`"
       @mouseleave="leave"
     >
-      <!-- column thumbnail -->
-      <div
-        v-if="size === 'normal' && record.extras.image"
-        class="listing__row--item is-thumbnail"
-        :style="`background-image: url('${record.extras.image.thumbnail}')`"
-      ></div>
-      <!-- end column -->
-
-      <!-- column details -->
+      <!-- column details / excerpt -->
       <div class="listing__row--item is-details">
         <a
           class="listing__row--item-title"
           :href="record.extras.editLink"
           :title="slug"
         >
-          {{ record.extras.title | trim(62) }}
+          {{ record.extras.title | trim(62) | raw }}
         </a>
         <span class="listing__row--item-title-excerpt">{{
-          record.extras.excerpt
+          record.extras.excerpt | raw
         }}</span>
       </div>
+      <!-- end column -->
+
+      <!-- column thumbnail -->
+      <div
+        v-if="size === 'normal' && record.extras.image"
+        class="listing__row--item is-thumbnail"
+        :style="`background-image: url('${record.extras.image.thumbnail}')`"
+      ></div>
       <!-- end column -->
 
       <!-- column meta -->

--- a/assets/js/filters/string.js
+++ b/assets/js/filters/string.js
@@ -19,6 +19,14 @@ Vue.filter('strip', string => {
   }
 });
 
+Vue.filter('raw', string => {
+  if (string) {
+    let node = document.createElement("textarea");
+    node.innerHTML = string;
+    return node.value;
+  }
+});
+
 Vue.filter('uppercase', string => {
   if (string) return string.toUpperCase();
 });

--- a/assets/js/filters/string.js
+++ b/assets/js/filters/string.js
@@ -21,7 +21,7 @@ Vue.filter('strip', string => {
 
 Vue.filter('raw', string => {
   if (string) {
-    let node = document.createElement("textarea");
+    let node = document.createElement('textarea');
     node.innerHTML = string;
     return node.value;
   }

--- a/assets/scss/layout/_admin.scss
+++ b/assets/scss/layout/_admin.scss
@@ -110,13 +110,13 @@ body {
         //grid with autofit to make columns expand full width if other column(s) not present
         grid-template-columns: repeat(12, 1fr);
         grid-template-rows: auto;
-        grid-column-gap: 2rem;
-        padding: $spacer $spacer*2 $spacer $spacer*2; //do not just change this as it's tied to the main grid and other paddings/gutters
+        grid-column-gap: 3rem;
+        padding: $spacer $spacer*2 $spacer $spacer*3; //do not just change this as it's tied to the main grid and other paddings/gutters
       }
 
       @include media-breakpoint-up(xw) {
-        grid-column-gap: 3rem;
-        padding: $spacer $spacer*3 $spacer $spacer*3; //do not just change this as it's tied to the main grid and other paddings/gutters
+        grid-column-gap: 4rem;
+        padding: $spacer $spacer*3 $spacer $spacer*4; //do not just change this as it's tied to the main grid and other paddings/gutters
       }
 
       &--has-sidebar {

--- a/assets/scss/modules/admin/_header.scss
+++ b/assets/scss/modules/admin/_header.scss
@@ -78,11 +78,11 @@
     }
 
     @include media-breakpoint-up(wd) {
-      padding: $spacer*1.25 $spacer*2 1rem $spacer*2; //do not just change this as it's tied to the main grid and other paddings/gutters
+      padding: $spacer*1.25 $spacer*2 1rem $spacer*3; //do not just change this as it's tied to the main grid and other paddings/gutters
     }
 
     @include media-breakpoint-up(xw) {
-      padding: $spacer*1.25 $spacer*3 1rem $spacer*3; //do not just change this as it's tied to the main grid and other paddings/gutters
+      padding: $spacer*1.25 $spacer*3 1rem $spacer*4; //do not just change this as it's tied to the main grid and other paddings/gutters
     }
   }
 

--- a/assets/scss/modules/listing/row/row.scss
+++ b/assets/scss/modules/listing/row/row.scss
@@ -82,7 +82,7 @@ $checkbox-row-width: 32px;
       }
 
       @include media-breakpoint-up(md) {
-        order: 1;
+        order: 2;
         top: 0;
         max-height: none;
       }
@@ -111,7 +111,7 @@ $checkbox-row-width: 32px;
       max-height: 4.75rem;
 
       @include media-breakpoint-up(md) {
-        order: 2;
+        order: 1;
         flex: 1 0 290px;
         padding: $spacer*0.4 $spacer $spacer*0.5 $spacer*0.625;
         margin-bottom: 0;
@@ -149,7 +149,7 @@ $checkbox-row-width: 32px;
       }
 
       @include media-breakpoint-up(md) {
-        order: 2;
+        order: 1;
         flex: 1 1 auto;
       }
 

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -98,6 +98,7 @@ pages:
             filter: '*.twig'
     taxonomy: [ groups ]
     listing_records: 6
+    sort: id
     locales: ['en', 'nl', 'ja', 'nb']
 
 # Entries can be used for things like 'news' or 'blogpostings'. They have a

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -315,7 +315,7 @@ class ContentTypesParser extends BaseParser
 
     private function determineSort(array $contentType): string
     {
-        $sort = $contentType['sort'] ?? 'id';
+        $sort = $contentType['sort'] ?? '-createdAt';
 
         $replacements = [
             'created' => 'createdAt',
@@ -336,8 +336,8 @@ class ContentTypesParser extends BaseParser
         $sortname = trim($sort, '-');
 
         if (! in_array($sortname, array_keys($contentType['fields']), true) &&
-            ! in_array($sortname, ['createdAt', 'modifiedAt', 'publishedAt'], true)) {
-            $sort = 'id';
+            ! in_array($sortname, ['createdAt', 'modifiedAt', 'publishedAt', 'id'], true)) {
+            $sort = '-createdAt';
         }
 
         return $sort;

--- a/src/Controller/Backend/ContentOverviewController.php
+++ b/src/Controller/Backend/ContentOverviewController.php
@@ -31,6 +31,8 @@ class ContentOverviewController extends TwigAwareController implements BackendZo
 
         if ($request->get('sortBy')) {
             $params['order'] = $request->get('sortBy');
+        } else {
+            $params['order'] = $contentTypeObject->get('sort');
         }
 
         if ($request->get('filter')) {

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -407,7 +407,7 @@ class Content
         return $this->getField($fieldName)->getParsedValue();
     }
 
-    public function setFieldValue(string $fieldName, $value, string $locale = null): void
+    public function setFieldValue(string $fieldName, $value, ?string $locale = null): void
     {
         if (! $this->hasField($fieldName)) {
             $this->addFieldByName($fieldName);

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -120,7 +120,7 @@ class ContentTypesParserTest extends ParserTestBase
         $this->assertSame('bar', $config['bars']['singular_slug']);
         $this->assertTrue($config['bars']['show_on_dashboard']);
         $this->assertTrue($config['bars']['show_in_menu']);
-        $this->assertSame('id', $config['bars']['sort']);
+        $this->assertSame('-createdAt', $config['bars']['sort']);
         $this->assertFalse($config['bars']['viewless']);
         $this->assertSame('fa-file', $config['bars']['icon_one']);
         $this->assertSame('fa-copy', $config['bars']['icon_many']);


### PR DESCRIPTION
 - Show 'dateCreated' if no 'datePublish' is set
 - Inverse order of title+excerpt and thumbnail (so it looks less wonky if _some_ records have no thumbnail)
 - Increase margins and gap a tiny bit
 - Don't output `&` as `&amp;`
 - Improve default sorting order