### PR TITLE
Make sure Imagelist and Filelist API values work on all endpoints

### DIFF
--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -60,7 +60,7 @@ class FilelistField extends Field implements FieldInterface
             $value = [];
 
             foreach ($files as $file) {
-                $value[] = $file->getValue();
+                $value[] = $file->getApiValue();
             }
 
             $result[$locale] = $value;

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -54,7 +54,15 @@ class FilelistField extends Field implements FieldInterface
         foreach ($this->getTranslations() as $translation) {
             $locale = $translation->getLocale();
             $this->setCurrentLocale($locale);
-            $value = $this->getValue();
+            $files = $this->getValue();
+            // $files is an array of FileField.php
+            // In the API we need the actual value of those fields, not the object
+            $value = [];
+
+            foreach ($files as $file) {
+                $value[] = $file->getValue();
+            }
+
             $result[$locale] = $value;
         }
 

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -60,7 +60,7 @@ class ImagelistField extends Field implements FieldInterface
             $value = [];
 
             foreach ($images as $image) {
-                $value[] = $image->getValue();
+                $value[] = $image->getApiValue();
             }
 
             $result[$locale] = $value;

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -54,7 +54,15 @@ class ImagelistField extends Field implements FieldInterface
         foreach ($this->getTranslations() as $translation) {
             $locale = $translation->getLocale();
             $this->setCurrentLocale($locale);
-            $value = $this->getValue();
+            $images = $this->getValue();
+            // $images is an array of ImageField.php
+            // In the API we need the actual value of those fields, not the object
+            $value = [];
+
+            foreach ($images as $image) {
+                $value[] = $image->getValue();
+            }
+
             $result[$locale] = $value;
         }
 


### PR DESCRIPTION
Ensures Imagelist and Filelist values work on `contents/1.json`, where the getApiValue on the images and files within the list is not called automatically by api-platform.