### PR TITLE
Set default locale for existing fields

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -465,6 +465,7 @@ class Content
 
         $this->fields[] = $field;
         $field->setContent($this);
+        $field->setDefaultLocaleFromContent();
 
         return $this;
     }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -274,7 +274,7 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function setDefaultLocaleFromContent(): self
     {
-        if($this->getContent() === null) {
+        if ($this->getContent() === null) {
             return $this;
         }
 

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -272,6 +272,25 @@ class Field implements FieldInterface, TranslatableInterface
         return $this->getCurrentLocale();
     }
 
+    public function setDefaultLocaleFromContent(): self
+    {
+        if($this->getContent() === null) {
+            return $this;
+        }
+
+        $locales = $this->getContent()->getDefinition()->get('locales');
+
+        if ($locales->isEmpty()) {
+            return $this;
+        }
+
+        $defaultLocale = $locales->first();
+
+        $this->setDefaultLocale($defaultLocale);
+
+        return $this;
+    }
+
     public function getVersion(): ?int
     {
         return $this->version;

--- a/src/Event/Listener/ContentFillListener.php
+++ b/src/Event/Listener/ContentFillListener.php
@@ -54,6 +54,7 @@ class ContentFillListener
     {
         $entity->setDefinitionFromContentTypesConfig($this->config->get('contenttypes'));
         $entity->setContentExtension($this->contentExtension);
+        $this->setFieldsDefaultLocales($entity);
     }
 
     private function guesstimateAuthor($contenttype): User
@@ -65,5 +66,21 @@ class ContentFillListener
         }
 
         return $user;
+    }
+
+    private function setFieldsDefaultLocales(Content $entity): void
+    {
+        $locales = $entity->getDefinition()->get('locales');
+
+        if ($locales->isEmpty()) {
+            return;
+        }
+
+        $defaultLocale = $entity->getDefinition()->get('locales')->first();
+
+        foreach ($entity->getRawFields() as $field) {
+            $field->setDefaultLocale($defaultLocale);
+            $field->setLocale($field->getDefaultLocale());
+        }
     }
 }

--- a/src/Event/Listener/ContentFillListener.php
+++ b/src/Event/Listener/ContentFillListener.php
@@ -70,17 +70,8 @@ class ContentFillListener
 
     private function setFieldsDefaultLocales(Content $entity): void
     {
-        $locales = $entity->getDefinition()->get('locales');
-
-        if ($locales->isEmpty()) {
-            return;
-        }
-
-        $defaultLocale = $entity->getDefinition()->get('locales')->first();
-
         foreach ($entity->getRawFields() as $field) {
-            $field->setDefaultLocale($defaultLocale);
-            $field->setLocale($field->getDefaultLocale());
+            $field->setDefaultLocaleFromContent();
         }
     }
 }


### PR DESCRIPTION
All existing fields have the default locale as the first locale from the content definition.
Fixes issue with 'Untitled' record when 'en' is not a locale.