### PR TITLE
Content Extras gets any title, so that Relations break less often.

### DIFF
--- a/src/Entity/ContentExtrasTrait.php
+++ b/src/Entity/ContentExtrasTrait.php
@@ -33,7 +33,7 @@ trait ContentExtrasTrait
         $content = $this;
 
         return array_filter([
-            'title' => $this->contentExtension->getTitle($content),
+            'title' => $this->contentExtension->getAnyTitle($content),
             'image' => $this->contentExtension->getImage($content, true),
             'excerpt' => $this->contentExtension->getExcerpt($content),
             'link' => $this->contentExtension->getLink($content),

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -96,6 +96,29 @@ class ContentExtension extends AbstractExtension
         ];
     }
 
+    public function getAnyTitle(Content $content): string
+    {
+        $title = $this->getTitle($content);
+
+        if (! empty($title)) {
+            return $title;
+        }
+
+        if ($content->getDefinition()->has('locales')) {
+            $locales = $content->getDefinition()->get('locales');
+
+            foreach ($locales as $locale) {
+                $title = $this->getTitle($content, $locale);
+
+                if (! empty($title)) {
+                    return $title;
+                }
+            }
+        }
+
+        return '';
+    }
+
     public function getTitle(Content $content, string $locale = ''): string
     {
         $titleParts = [];


### PR DESCRIPTION
A page with relations breaks if the relations' title is not available in 'en' locale, but it should not.

Instead, try to get a title for any of the defined content locales, in order to break less often (or not at all).