### PR TITLE
Don't throw exception in listener for timedpublish

### DIFF
--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -6,6 +6,7 @@ namespace Bolt\Event\Subscriber;
 
 use Bolt\Common\Str;
 use Carbon\Carbon;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -34,14 +35,17 @@ class TimedPublishSubscriber implements EventSubscriberInterface
         $conn = $this->entityManager->getConnection();
         $now = (new Carbon())->tz('UTC');
 
-        // Publish timed Content records when 'publish_at' has passed.
-        // Note: Placeholders in DBAL don't work for tablenames.
-        $query = sprintf('update %scontent SET status = "published", published_at = :now  WHERE status = "timed" AND published_at < :now', $this->prefix);
-        $conn->executeUpdate($query, [':now' => $now]);
+        // Publish timed Content records when 'publish_at' has passed and Depublish published Content
+        // records when 'depublish_at' has passed. Note: Placeholders in DBAL don't work for tablenames.
+        $queryPublish = sprintf('update %scontent SET status = "published", published_at = :now  WHERE status = "timed" AND published_at < :now', $this->prefix);
+        $queryDepublish = sprintf('update %scontent SET status = "held", depublished_at = :now WHERE status = "published" AND depublished_at < :now', $this->prefix);
 
-        // Depublish published Content records when 'depublish_at' has passed.
-        $query = sprintf('update %scontent SET status = "held", depublished_at = :now WHERE status = "published" AND depublished_at < :now', $this->prefix);
-        $conn->executeUpdate($query, [':now' => $now]);
+        try {
+            $conn->executeUpdate($queryPublish, [':now' => $now]);
+            $conn->executeUpdate($queryDepublish, [':now' => $now]);
+        } catch (TableNotFoundException $e) {
+            // Fail silently, output user-friendly exception elsewhere.
+        }
     }
 
     /**


### PR DESCRIPTION
For UX: If we don't have a DB set up yet, we'll now get a descriptive error, instead of a blank `500` server error.