### PR TITLE
Make ordering in `{% setcontent %}` more robust

### DIFF
--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -159,6 +159,13 @@ class ContentTypesParser extends BaseParser
 
         $contentType['sort'] = $this->determineSort($contentType);
 
+        // Make sure title_format is set
+        if (isset($contentType['title_format'])) {
+            $contentType['title_format'] = (array) $contentType['title_format'];
+        } else {
+            $contentType['title_format'] = (array) $contentType['fields']['slug']['uses'];
+        }
+
         // Make sure taxonomy is an array.
         if (isset($contentType['taxonomy'])) {
             $contentType['taxonomy'] = (array) $contentType['taxonomy'];

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -162,8 +162,10 @@ class ContentTypesParser extends BaseParser
         // Make sure title_format is set
         if (isset($contentType['title_format'])) {
             $contentType['title_format'] = (array) $contentType['title_format'];
-        } else {
+        } elseif (isset($contentType['fields']['slug']['uses'])) {
             $contentType['title_format'] = (array) $contentType['fields']['slug']['uses'];
+        } else {
+            $contentType['title_format'] = (array) key($contentType['fields']);
         }
 
         // Make sure taxonomy is an array.

--- a/src/Storage/QueryInterface.php
+++ b/src/Storage/QueryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Storage;
 
+use Bolt\Configuration\Config;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -44,4 +45,8 @@ interface QueryInterface
      * Sets the value of a parameter by key name.
      */
     public function setParameter(string $key, $value): void;
+
+    public function getCoreFields(): array;
+
+    public function getConfig(): Config;
 }

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Storage;
 
+use Bolt\Configuration\Config;
 use Bolt\Doctrine\JsonHelper;
 use Doctrine\ORM\Query\Expr\Base;
 use Doctrine\ORM\Query\ParameterTypeInferer;
@@ -67,13 +68,17 @@ class SelectQuery implements QueryInterface
     /** @var array */
     private $fieldJoins = [];
 
+    /** @var Config */
+    private $config;
+
     /**
      * Constructor.
      */
-    public function __construct(?QueryBuilder $qb = null, QueryParameterParser $parser)
+    public function __construct(?QueryBuilder $qb = null, QueryParameterParser $parser, Config $config)
     {
         $this->qb = $qb;
         $this->parser = $parser;
+        $this->config = $config;
     }
 
     /**
@@ -380,5 +385,15 @@ class SelectQuery implements QueryInterface
         $this->incrementIndex();
 
         return $this->getIndex();
+    }
+
+    public function getCoreFields(): array
+    {
+        return $this->coreFields;
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->config;
     }
 }

--- a/templates/content/listing.html.twig
+++ b/templates/content/listing.html.twig
@@ -41,8 +41,11 @@
       :csrftoken="{{ csrf_token('batch')|json_encode }}"
     ></listing-select-box>
 
+    {% set titleField = contentType.title_format|first %}
+    {% set titleLabel = contentType.fields[titleField].label %}
+
     {% set filterOptions = {
-        'id': "Id", 'title': 'Title', 'author': 'Author', 'status': 'Status', 'createdAt': 'Created date',
+        'id': "Id", (titleField): titleLabel, 'author': 'Author', 'status': 'Status', 'createdAt': 'Created date',
         'modifiedAt': 'Modified date', 'publishedAt': 'Published date', 'depublishedAt': 'Depublished date'
     } %}
 

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -15,7 +15,7 @@ class ContentTypesParserTest extends ParserTestBase
 {
     public const NUMBER_OF_CONTENT_TYPES_IN_MINIMAL_FILE = 2;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 22;
+    public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 23;
 
     public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 22;
 


### PR DESCRIPTION
In the backend no longer _always_ sort on `title`, but rather on the actual setting of `title_format` -> 

![Screenshot_2020-03-15_at_15_44_26](https://user-images.githubusercontent.com/1833361/76703732-f8693b00-66d3-11ea-9435-ecfa448e955c.png)

In frontend, ordering by a non-existent field, will produce debug output:  

![Screenshot_2020-03-15_at_15_45_47](https://user-images.githubusercontent.com/1833361/76703754-2cdcf700-66d4-11ea-93ea-dc3200a3b545.png)
