### PR TITLE
Split off `get_definition` from `get_content` for Serializer purposes

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -193,7 +193,7 @@ class Content
     }
 
     /**
-     * @Groups("get_content")
+     * @Groups("get_definition")
      */
     public function getDefinition(): ?ContentType
     {

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -20,7 +20,7 @@ use Tightenco\Collect\Support\Collection as LaravelCollection;
 
 /**
  * @ApiResource(
- *     normalizationContext={"groups"={"get_content"}},
+ *     normalizationContext={"groups"={"get_content","get_definition"}},
  *     collectionOperations={"get"},
  *     itemOperations={"get"}
  * )

--- a/src/Twig/JsonExtension.php
+++ b/src/Twig/JsonExtension.php
@@ -15,6 +15,10 @@ class JsonExtension extends AbstractExtension
 {
     private const SERIALIZE_GROUP = 'get_content';
 
+    private const SERIALIZE_GROUP_DEFINITION = 'get_definition';
+
+    private $includeDefinition = true;
+
     /** @var NormalizerInterface */
     private $normalizer;
 
@@ -44,9 +48,11 @@ class JsonExtension extends AbstractExtension
         ];
     }
 
-    public function jsonRecords($records): string
+    public function jsonRecords($records, ?bool $includeDefinition = true, int $options = 0): string
     {
-        return Json::json_encode($this->normalizeRecords($records));
+        $this->includeDefinition = $includeDefinition;
+
+        return Json::json_encode($this->normalizeRecords($records), $options);
     }
 
     /**
@@ -69,10 +75,16 @@ class JsonExtension extends AbstractExtension
 
     private function contentToArray(Content $content): array
     {
+        $group = [self::SERIALIZE_GROUP];
+
+        if ($this->includeDefinition) {
+            $group[] = self::SERIALIZE_GROUP_DEFINITION;
+        }
+
         // we do it that way because in current API Platform version a Resource
         // can't implement \JsonSerializable
         return $this->normalizer->normalize($content, null, [
-            'group' => [self::SERIALIZE_GROUP],
+            'groups' => $group,
         ]);
     }
 


### PR DESCRIPTION
Pinging @I-Valchev : I had to make a modification to this. In the frontend you don't always want to include `definition` in the results. Can you verify it still works with the API like this? 

followup to #1164
