### PR TITLE
Compose value works with allowed yaml key names + i18n

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -138,7 +138,7 @@ entries:
     relations:
         pages:
             multiple: false
-            order: title
+            order: heading
             label: Select a page
     taxonomy: [ categories, tags, groups ]
     record_template: entry.twig

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -264,6 +264,28 @@ class Content
         return $this->getDefinition()->get('singular_name') ?: $this->getContentTypeSlug();
     }
 
+    public function hasContentTypeLocales(): bool
+    {
+        if ($this->getDefinition() === null) {
+            throw new \RuntimeException('Content not fully initialized');
+        }
+
+        return ! $this->getDefinition()->get('locales')->isEmpty();
+    }
+
+    public function getContentTypeDefaultLocale(): string
+    {
+        if ($this->getDefinition() === null) {
+            throw new \RuntimeException('Content not fully initialized');
+        }
+
+        if (! $this->hasContentTypeLocales()) {
+            throw new \RuntimeException('Content does not have locales defined');
+        }
+
+        return $this->getDefinition()->get('locales')->first();
+    }
+
     public function getIcon(): ?string
     {
         if ($this->getDefinition() === null) {

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -370,7 +370,7 @@ class Field implements FieldInterface, TranslatableInterface
         return '\\' . implode('\\', $explodedNamespace) . '\\' . $entityClass . 'Translation';
     }
 
-    protected function isTranslatable(): bool
+    public function isTranslatable(): bool
     {
         return $this->getDefinition()->get('localize') === true;
     }


### PR DESCRIPTION
- compose value uses less restrictive regex for matching field names (e.g. `_` is valid in yaml key names)
- compose value uses first contenttype locale, if field is translatable
- small fix to contenttypes.yaml since pages have `heading`, not `title`