### PR TITLE
`postfix` and `prefix` need `display: block`

### DIFF
--- a/assets/scss/modules/editor/fields/_pre_postfix.scss
+++ b/assets/scss/modules/editor/fields/_pre_postfix.scss
@@ -2,6 +2,6 @@
   font-size: 0.95rem;
   color: #666;
   max-width: 46em;
-  display: inline-block;
+  display: block;
   margin: 0.5rem 0;
 }


### PR DESCRIPTION
Fixes #1219 