### PR TITLE
Access fields inside a set by their name

### DIFF
--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -40,7 +40,7 @@ class SetField extends Field implements FieldInterface, FieldParentInterface
             }
 
             $field->setName($name);
-            $result[] = $field;
+            $result[$name] = $field;
         }
 
         return $result;


### PR DESCRIPTION
Pretty sure I saw an issue about it today, but I can't find it :/ 

Basically:

`{{ set.title}}` does not work before this PR.