### PR TITLE
Collections and Sets in API

### DIFF
--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -66,6 +66,22 @@ class CollectionField extends Field implements FieldInterface, FieldParentInterf
         return $fields->toArray();
     }
 
+    public function getApiValue()
+    {
+        $fields = $this->getValue();
+        $result = [];
+
+        foreach ($fields as $field) {
+            $result[] = [
+                'name' => $field->getName(),
+                'type' => $field->getType(),
+                'value' => $field->getApiValue(),
+            ];
+        }
+
+        return $result;
+    }
+
     public function getDefaultValue()
     {
         $default = parent::getDefaultValue();

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -45,4 +45,15 @@ class SetField extends Field implements FieldInterface, FieldParentInterface
 
         return $result;
     }
+
+    public function getApiValue()
+    {
+        $result = [];
+
+        foreach ($this->getValue() as $key => $value) {
+            $result[$key] = $value->getApiValue();
+        }
+
+        return $result;
+    }
 }

--- a/src/Utils/TranslationsManager.php
+++ b/src/Utils/TranslationsManager.php
@@ -72,7 +72,7 @@ class TranslationsManager
             throw new \InvalidArgumentException(sprintf("'%s'does not have translations", $field->getName()));
         }
 
-        if ($field->hasParent()) {
+        if ($field->hasParent() && $field->getParent()->getName() !== $collectionName) {
             $key = $this->keys[$collectionName][$field->getParent()->getName()][$orderId][$field->getName()];
         } else {
             $key = $this->keys[$collectionName][$field->getName()][$orderId];
@@ -98,7 +98,7 @@ class TranslationsManager
             return true;
         }
 
-        if ($field->hasParent()) {
+        if ($field->hasParent() && $field->getParent()->getName() !== $collectionName) {
             //find key for field with a parent
             if (! (array_key_exists($collectionName, $this->keys)
                 && array_key_exists($field->getParent()->getName(), $this->keys[$collectionName])
@@ -113,8 +113,7 @@ class TranslationsManager
             //find key for field without a parent
             if (! (array_key_exists($collectionName, $this->keys)
                 && array_key_exists($field->getName(), $this->keys[$collectionName])
-                && array_key_exists($orderId, $this->keys[$collectionName][$field->getName()])
-                && array_key_exists('value', $this->keys[$collectionName][$field->getName()][$orderId]))) {
+                && array_key_exists($orderId, $this->keys[$collectionName][$field->getName()]))) {
                 // if $this->keys[$collectionName][$name][$order] does not exist, we can return.
                 return false;
             }


### PR DESCRIPTION
As with Imagelists and Filelists, make sure to return the values of the fields, not the object. Also, for collections, include the `name`, `type`, and `value`, as collections have different fields within them.

This PR is based on:
#1246 (for collections)
#1245 (for sets)

Fixes #1241 