### PR TITLE
Workaround for updating KnpLabs/DoctrineBehaviors, without breaking ` config/bundles.php` first

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -165,3 +165,8 @@ class Kernel extends BaseKernel
         throw new \Exception('The Public Folder could not be determined. Expected folder `public`, `public_html`, `www`, `web`, `httpdocs`, `wwwroot`, `htdocs`, `http_public` or `private_html` to exist.');
     }
 }
+
+// Note: This is here to ease the upgrade from Knp/DoctrineBehaviors 2.0.1 to 2.0.2
+// @see https://github.com/KnpLabs/DoctrineBehaviors/pull/534
+// @deprecated since 4.0.0
+class_alias('Knp\DoctrineBehaviors\DoctrineBehaviorsBundle', 'Knp\DoctrineBehaviors\Bundle\DoctrineBehaviorsBundle');

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -169,4 +169,4 @@ class Kernel extends BaseKernel
 // Note: This is here to ease the upgrade from Knp/DoctrineBehaviors 2.0.1 to 2.0.2
 // @see https://github.com/KnpLabs/DoctrineBehaviors/pull/534
 // @deprecated since 4.0.0
-class_alias('Knp\DoctrineBehaviors\DoctrineBehaviorsBundle', 'Knp\DoctrineBehaviors\Bundle\DoctrineBehaviorsBundle');
+class_alias(\Knp\DoctrineBehaviors\DoctrineBehaviorsBundle::class, 'Knp\DoctrineBehaviors\Bundle\DoctrineBehaviorsBundle');


### PR DESCRIPTION
See also #1249 