### PR TITLE
Fix Preview by removing EntityManager flush

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -315,13 +315,14 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         return $content;
     }
 
-    private function removeFieldChildren(FieldParentInterface $field): void
+    private function removeFieldChildren(Content $content, Field $field): void
     {
         foreach ($field->getChildren() as $child) {
             if ($child instanceof FieldParentInterface && $child->hasChildren()) {
-                $this->removeFieldChildren($child);
+                $this->removeFieldChildren($content, $child);
             }
 
+            $content->removeField($child);
             $this->em->remove($child);
         }
     }
@@ -336,13 +337,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $tm = new TranslationsManager($collections, $keys);
 
         foreach ($collections as $collection) {
-            $this->removeFieldChildren($collection);
-        }
-
-        // We flush the entityManager here, because otherwise fields wouldn't persist properly. However, if we're
-        // "previewing" we most certainly do _not_ want to do this, because we'd effectively 'save' the Record.
-        if (! $forPreview) {
-            $this->em->flush();
+            $this->removeFieldChildren($content, $collection);
         }
 
         if (isset($formData['collections'])) {

--- a/tests/e2e/edit_record_2.feature
+++ b/tests/e2e/edit_record_2.feature
@@ -9,3 +9,7 @@ Feature: Preview record after editing
     And I press "Preview"
     And I switch to tab "1"
     Then I should see "Check preview" in the ".title" element
+
+    When I switch to tab "0"
+    And I reload the page
+    Then the "field-title" field should not contain "Check preview"


### PR DESCRIPTION
We can avoid flushing by removing the fields from the EntityManager _and_ from the current content, which allows the Preview to work as expected.

And fixes #1264 