### PR TITLE
Get correct field value depending on localization settings

### DIFF
--- a/templates/content/_fields.html.twig
+++ b/templates/content/_fields.html.twig
@@ -9,7 +9,7 @@
                     {# If the field is translatable, we want the translated value in the current locale #}
                     {% set field = field|translated(currentlocale) %}
                 {% else %}
-                    {# Othewise, we want the value in the default locale, exlicitly in case it is something else #}
+                    {# Otherwise, we want the value in the default locale, explicitly in case it is something else #}
                     {% set field = field|translated(field.defaultLocale) %}
                 {% endif %}
             {% else %}

--- a/templates/content/_fields.html.twig
+++ b/templates/content/_fields.html.twig
@@ -4,7 +4,14 @@
          aria-labelledby="{{ group|slug }}-tab">
         {% for key, fielddefinition in record.definition.fields|filter(fielddefinition => fielddefinition.group == group) %}
             {% if record.hasField(key) %}
-                {% set field = record.getField(key)|translated(currentlocale) %}
+                {% set field = record.getField(key) %}
+                {% if field.isTranslatable %}
+                    {# If the field is translatable, we want the translated value in the current locale #}
+                    {% set field = field|translated(currentlocale) %}
+                {% else %}
+                    {# Othewise, we want the value in the default locale #}
+                    {% set field = field|translated(field.defaultLocale) %}
+                {% endif %}
             {% else %}
                 {% set field = field_factory(key, fielddefinition) %}
             {% endif %}

--- a/templates/content/_fields.html.twig
+++ b/templates/content/_fields.html.twig
@@ -9,7 +9,7 @@
                     {# If the field is translatable, we want the translated value in the current locale #}
                     {% set field = field|translated(currentlocale) %}
                 {% else %}
-                    {# Othewise, we want the value in the default locale #}
+                    {# Othewise, we want the value in the default locale, exlicitly in case it is something else #}
                     {% set field = field|translated(field.defaultLocale) %}
                 {% endif %}
             {% else %}


### PR DESCRIPTION
Okay so an explanation about this...

We only want to get the the translated field if the field is translatable.
If it is not, we want the default value. By getting it explicitly, we make sure that even if `setLocale` was called somewhere earlier, we will override it.

Main cause for this is that the [DoctrineBehaviors translate method](https://github.com/KnpLabs/DoctrineBehaviors/blob/ebb188c6c29b09ede700e90f31201f6cefa2ab5b/src/Contract/Entity/TranslatableInterface.php#L33) does too much things at once. Sometimes you want to get the translated value _without_ changing the object. At other times, you want to _prepare_ the object for future use by changing its current locale.