### PR TITLE
Field::getValue() returns defaultLocale value (if current locale value is empty empty) for non-localizable fields

### DIFF
--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -186,7 +186,19 @@ class Field implements FieldInterface, TranslatableInterface
 
     public function getValue(): ?array
     {
-        return $this->translate($this->getCurrentLocale(), ! $this->isTranslatable())->getValue();
+        $value = $this->translate($this->getCurrentLocale(), false)->getValue();
+
+        // If the field is not translatable, return the value without fallback to defaultLocale
+        if ($this->isTranslatable()) {
+            return $value;
+        }
+
+        // If value is empty, get the defaultLocale as fallback.
+        if (empty($value)) {
+            $value = $this->translate($this->getDefaultLocale(), false)->getValue();
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -165,7 +165,13 @@ class ContentExtension extends AbstractExtension
                 $field->setCurrentLocale($locale);
             }
 
-            $titleParts[] = $content->getField($fieldName)->__toString();
+            $value = $field->getParsedValue();
+
+            if (empty($value)) {
+                $value = $field->setLocale($field->getDefaultLocale())->getParsedValue();
+            }
+
+            $titleParts[] = $value;
         }
 
         $maxLength = 80; // Should we make this configurable, or is that overkill?


### PR DESCRIPTION
 🤦‍♂️

For months I worked under the assumption that non-translatable fields fallback to the default locale. But this is not how the doctrine-behaviors `translate()` method works. The fallback option is for `en_GB` to fallback to `en`, not to fallback to the `defaultLocale`.

My misunderstanding led to wrong implementation further down the line, which convoluted the problem further.