### PR TITLE
Update content updated successfully message

### DIFF
--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -466,7 +466,7 @@
       </notes>
       <segment>
         <source>content.updated_successfully</source>
-        <target>Media item updated successfully</target>
+        <target>Content updated successfully</target>
       </segment>
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">


### PR DESCRIPTION
Fixes #1330
Turns out it's just the wording, not to do with using incorrect message.