### PR TITLE
Persist non-translatable field with correct default locale

### DIFF
--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -93,7 +93,7 @@ class Config
         $taxonomy = new TaxonomyParser($this->projectDir);
         $config['taxonomies'] = $taxonomy->parse();
 
-        $contentTypes = new ContentTypesParser($this->projectDir,  $config->get('general'), $this->defaultLocale, $this->locales);
+        $contentTypes = new ContentTypesParser($this->projectDir, $config->get('general'), $this->defaultLocale, $this->locales);
         $config['contenttypes'] = $contentTypes->parse();
 
         $menu = new MenuParser($this->projectDir);

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -36,12 +36,17 @@ class Config
     /** @var string */
     private $locales;
 
-    public function __construct(string $locales, Stopwatch $stopwatch, string $projectDir, CacheInterface $cache, string $publicFolder)
+    /** @var string */
+    private $defaultLocale;
+
+    public function __construct(string $locales, string $defaultLocale, Stopwatch $stopwatch, string $projectDir, CacheInterface $cache, string $publicFolder)
     {
         $this->locales = $locales;
         $this->stopwatch = $stopwatch;
         $this->cache = $cache;
         $this->projectDir = $projectDir;
+        $this->defaultLocale = $defaultLocale;
+
         $this->data = $this->getConfig();
 
         // @todo PathResolver shouldn't be part of Config. Refactor to separate class
@@ -88,7 +93,7 @@ class Config
         $taxonomy = new TaxonomyParser($this->projectDir);
         $config['taxonomies'] = $taxonomy->parse();
 
-        $contentTypes = new ContentTypesParser($this->locales, $this->projectDir, $config->get('general'));
+        $contentTypes = new ContentTypesParser($this->projectDir,  $config->get('general'), $this->defaultLocale, $this->locales);
         $config['contenttypes'] = $contentTypes->parse();
 
         $menu = new MenuParser($this->projectDir);

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -48,12 +48,15 @@ class FieldType extends Collection
             'error' => false,
             'pattern' => false,
             'hidden' => false,
+            'default_locale' => 'en',
         ]);
     }
 
     public static function factory(string $name, ContentType $contentType): self
     {
-        return new self($contentType->get('fields')->get($name, []));
+        $defaults = static::defaults();
+        $fromContentType = new self($contentType->get('fields')->get($name, []));
+        return new self($defaults->merge($fromContentType));
     }
 
     public static function mock(string $name, ?Collection $definition = null): self

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -56,6 +56,7 @@ class FieldType extends Collection
     {
         $defaults = static::defaults();
         $fromContentType = new self($contentType->get('fields')->get($name, []));
+
         return new self($defaults->merge($fromContentType));
     }
 

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -20,10 +20,14 @@ class ContentTypesParser extends BaseParser
     /** @var array */
     private $localeCodes = [];
 
-    public function __construct(?string $locales = null, string $projectDir, Collection $generalConfig, string $filename = 'contenttypes.yaml')
+    /** @var string defaultLocale */
+    private $defaultLocale;
+
+    public function __construct(string $projectDir, Collection $generalConfig, string $defaultLocale, ?string $locales = null, string $filename = 'contenttypes.yaml')
     {
         $this->localeCodes = empty($locales) ? [] : explode('|', $locales);
         $this->generalConfig = $generalConfig;
+        $this->defaultLocale = $defaultLocale;
         parent::__construct($projectDir, $filename);
     }
 
@@ -305,6 +309,11 @@ class ContentTypesParser extends BaseParser
             $field['group'] = $currentGroup;
         } else {
             $currentGroup = $field['group'];
+        }
+
+        // Initialise default_locale, if not explicit
+        if (! isset($field['default_locale'])) {
+            $field['default_locale'] = $this->defaultLocale;
         }
     }
 

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -520,7 +520,6 @@ class Content
 
         $this->fields[] = $field;
         $field->setContent($this);
-        $field->setDefaultLocaleFromContent();
 
         return $this;
     }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -308,25 +308,6 @@ class Field implements FieldInterface, TranslatableInterface
         return $this->getCurrentLocale();
     }
 
-    public function setDefaultLocaleFromContent(): self
-    {
-        if ($this->getContent() === null) {
-            return $this;
-        }
-
-        $locales = $this->getContent()->getDefinition()->get('locales');
-
-        if (empty($locales) || $locales->isEmpty()) {
-            return $this;
-        }
-
-        $defaultLocale = $locales->first();
-
-        $this->setDefaultLocale($defaultLocale);
-
-        return $this;
-    }
-
     public function getVersion(): ?int
     {
         return $this->version;

--- a/src/Event/Listener/ContentFillListener.php
+++ b/src/Event/Listener/ContentFillListener.php
@@ -80,7 +80,6 @@ class ContentFillListener
     {
         $entity->setDefinitionFromContentTypesConfig($this->config->get('contenttypes'));
         $entity->setContentExtension($this->contentExtension);
-        $this->setFieldsDefaultLocales($entity);
     }
 
     private function guesstimateAuthor($contenttype): User
@@ -92,12 +91,5 @@ class ContentFillListener
         }
 
         return $user;
-    }
-
-    private function setFieldsDefaultLocales(Content $entity): void
-    {
-        foreach ($entity->getRawFields() as $field) {
-            $field->setDefaultLocaleFromContent();
-        }
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -58,12 +58,14 @@ class Kernel extends BaseKernel
 
         $this->setBoltParameters($container, $confDir);
         $this->setContentTypeRequirements($container);
-        $this->setTaxonomyRequirements($container);
-
         $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
+
+        $this->setBoltParameters($container, $confDir);
+        $this->setContentTypeRequirements($container);
+        $this->setTaxonomyRequirements($container);
 
         try {
             $loader->load($confDir . '/{services}_bolt' . self::CONFIG_EXTS, 'glob');
@@ -123,7 +125,9 @@ class Kernel extends BaseKernel
      */
     private function setContentTypeRequirements(ContainerBuilder $container): void
     {
-        $ContentTypesParser = new ContentTypesParser(null, $this->getProjectDir(), new Collection());
+        /** @var string $defaultLocale */
+        $defaultLocale = $container->getParameter('locale');
+        $ContentTypesParser = new ContentTypesParser($this->getProjectDir(), new Collection(), $defaultLocale);
         $contentTypes = $ContentTypesParser->parse();
 
         $pluralslugs = $contentTypes->pluck('slug')->implode('|');

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -56,8 +56,6 @@ class Kernel extends BaseKernel
         $container->setParameter('container.dumper.inline_factories', true);
         $confDir = $this->getProjectDir() . '/config';
 
-        $this->setBoltParameters($container, $confDir);
-        $this->setContentTypeRequirements($container);
         $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');

--- a/src/Repository/FieldRepository.php
+++ b/src/Repository/FieldRepository.php
@@ -85,6 +85,9 @@ class FieldRepository extends ServiceEntityRepository
             $field->setLabel($label);
         }
 
+        $field->setDefaultLocale($definition['default_locale']);
+        $field->setLocale($definition['default_locale']);
+
         return $field;
     }
 }

--- a/tests/php/Configuration/ConfigTest.php
+++ b/tests/php/Configuration/ConfigTest.php
@@ -17,7 +17,7 @@ class ConfigTest extends TestCase
     {
         $projectDir = dirname(dirname(dirname(__DIR__)));
         $cache = new TraceableAdapter(new FilesystemAdapter());
-        $config = new Config('', new Stopwatch(), $projectDir, $cache, 'public');
+        $config = new Config('', '', new Stopwatch(), $projectDir, $cache, 'public');
 
         $this->assertInstanceOf(Config::class, $config);
     }
@@ -26,7 +26,7 @@ class ConfigTest extends TestCase
     {
         $projectDir = dirname(dirname(dirname(__DIR__)));
         $cache = new TraceableAdapter(new FilesystemAdapter());
-        $config = new Config('', new Stopwatch(), $projectDir, $cache, 'public');
+        $config = new Config('', '', new Stopwatch(), $projectDir, $cache, 'public');
 
         $this->assertSame('Bolt Core Git Clone', $config->get('general/sitename'));
     }
@@ -35,7 +35,7 @@ class ConfigTest extends TestCase
     {
         $projectDir = dirname(dirname(dirname(__DIR__)));
         $cache = new TraceableAdapter(new FilesystemAdapter());
-        $config = new Config('', new Stopwatch(), $projectDir, $cache, 'public');
+        $config = new Config('', '', new Stopwatch(), $projectDir, $cache, 'public');
 
         $this->assertTrue($config->has('general/payoff'));
         $this->assertFalse($config->has('general/payoffXXXXX'));
@@ -45,7 +45,7 @@ class ConfigTest extends TestCase
     {
         $projectDir = dirname(dirname(dirname(__DIR__)));
         $cache = new TraceableAdapter(new FilesystemAdapter());
-        $config = new Config('', new Stopwatch(), $projectDir, $cache, 'public');
+        $config = new Config('', '', new Stopwatch(), $projectDir, $cache, 'public');
 
         /** @var Collection $mediaTypes */
         $mediaTypes = $config->getMediaTypes();

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -17,14 +17,16 @@ class ContentTypesParserTest extends ParserTestBase
 
     public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 24;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 23;
+    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 24;
 
     public const ALLOWED_LOCALES = 'en|nl|es|fr|de|pl|it|hu|pt_BR|ja|nb|nn|nl_NL|nl_BE';
+
+    public const DEFAULT_LOCALE = 'nl';
 
     public function testCanParse(): void
     {
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse());
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES);
         $config = $contentTypesParser->parse();
 
         $this->assertInstanceOf(Collection::class, $config);
@@ -34,7 +36,7 @@ class ContentTypesParserTest extends ParserTestBase
     {
         $file = self::getBasePath() . 'bogus.yaml';
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse(), $file);
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES, $file);
 
         $this->expectException(ConfigurationException::class);
 
@@ -45,7 +47,7 @@ class ContentTypesParserTest extends ParserTestBase
     {
         $file = self::getBasePath() . 'broken.yaml';
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse(), $file);
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES, $file);
 
         $this->expectException(ParseException::class);
 
@@ -55,7 +57,7 @@ class ContentTypesParserTest extends ParserTestBase
     public function testBreakOnMissingFileParse(): void
     {
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse(), 'foo.yml');
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES, 'foo.yml');
 
         $this->expectException(FileLocatorFileNotFoundException::class);
 
@@ -65,7 +67,7 @@ class ContentTypesParserTest extends ParserTestBase
     public function testHasConfig(): void
     {
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse());
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES);
         $config = $contentTypesParser->parse();
 
         $this->assertCount(6, $config);
@@ -87,6 +89,8 @@ class ContentTypesParserTest extends ParserTestBase
         $this->assertSame('fa-home', $config['homepage']['icon_one']);
         $this->assertFalse($config['homepage']['allow_numeric_slugs']);
         $this->assertContains('nl', $config['homepage']['locales']);
+        $this->assertContains('ja', $config['homepage']['locales']);
+        $this->assertSame('nl', $config['homepage']['fields']['title']['default_locale']);
     }
 
     public function testBrokenContentTypeValues(): void
@@ -94,7 +98,7 @@ class ContentTypesParserTest extends ParserTestBase
         $file = self::getBasePath() . 'broken_content_types.yaml';
 
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse(), $file);
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES, $file);
 
         $this->expectException(ConfigurationException::class);
         $contentTypesParser->parse();
@@ -105,7 +109,7 @@ class ContentTypesParserTest extends ParserTestBase
         $file = self::getBasePath() . 'minimal_content_types.yaml';
 
         $generalParser = new GeneralParser($this->getProjectDir());
-        $contentTypesParser = new ContentTypesParser(self::ALLOWED_LOCALES, $this->getProjectDir(), $generalParser->parse(), $file);
+        $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES, $file);
 
         $config = $contentTypesParser->parse();
 


### PR DESCRIPTION
So far all non-translatable fields were persisted with locale `en`.

In this PR, the fields are persisted with the provided `locale` from `services.yaml`