### PR TITLE
Localize collections with easier contenttype config

### DIFF
--- a/src/Entity/FieldParentInterface.php
+++ b/src/Entity/FieldParentInterface.php
@@ -12,4 +12,6 @@ interface FieldParentInterface
     public function setLocale(string $locale): Field;
 
     public function getValue(): ?array;
+
+    public function isTranslatable(): bool;
 }

--- a/src/Entity/FieldParentTrait.php
+++ b/src/Entity/FieldParentTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bolt\Entity;
 
+use Bolt\Configuration\Content\FieldType;
+
 /**
  * Implements the methods of the FieldParentInterface.
  */
@@ -24,5 +26,23 @@ trait FieldParentTrait
         }
 
         return $this;
+    }
+
+    /**
+     * Override isTranslatable so that if one child definition
+     * has localize: true, the whole field is considered localizable.
+     *
+     * @return bool
+     */
+    public function isTranslatable(): bool
+    {
+        /** @var FieldType $fieldDefinition */
+        foreach($this->getDefinition()->get('fields', []) as $fieldDefinition) {
+            if ($fieldDefinition->get('localize', false)) {
+                return true;
+            }
+        }
+
+        return parent::isTranslatable();
     }
 }

--- a/src/Entity/FieldParentTrait.php
+++ b/src/Entity/FieldParentTrait.php
@@ -31,13 +31,11 @@ trait FieldParentTrait
     /**
      * Override isTranslatable so that if one child definition
      * has localize: true, the whole field is considered localizable.
-     *
-     * @return bool
      */
     public function isTranslatable(): bool
     {
         /** @var FieldType $fieldDefinition */
-        foreach($this->getDefinition()->get('fields', []) as $fieldDefinition) {
+        foreach ($this->getDefinition()->get('fields', []) as $fieldDefinition) {
             if ($fieldDefinition->get('localize', false)) {
                 return true;
             }


### PR DESCRIPTION
Works like this:
set `localize: true` only on the child elements and it still works.

Fixes 1/2 of #1432  