### PR TITLE
Add ability to override routing with record_route

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Canonical
@@ -170,7 +171,14 @@ class Canonical
     {
         if (isset($params['_locale']) && $params['_locale'] === $this->defaultLocale) {
             unset($params['_locale']);
-            $route = str_replace('_locale', '', $route);
+            $routeWithoutLocale = str_replace('_locale', '', $route);
+
+            // If a route without the locale exists, use that. e.g. record_locale -> record
+            try {
+                $this->generateLink($routeWithoutLocale, $params);
+                $route = $routeWithoutLocale;
+            } catch (RouteNotFoundException $e) {
+            }
         }
 
         return $this->urlGenerator->generate(

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -170,6 +170,7 @@ class Canonical
     {
         if (isset($params['_locale']) && $params['_locale'] === $this->defaultLocale) {
             unset($params['_locale']);
+            $route = str_replace('_locale', '', $route);
         }
 
         return $this->urlGenerator->generate(

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt;
 
 use Bolt\Configuration\Config;
+use Bolt\Twig\ContentExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
@@ -150,13 +151,8 @@ class Canonical
         if ($this->path === null) {
             $route = $this->request->attributes->get('_route');
             $params = $this->request->attributes->get('_route_params');
-            $canonicalRoute = $this->getCanonicalRoute($route, $params);
 
-            $this->path = $this->urlGenerator->generate(
-                $canonicalRoute,
-                $params,
-                UrlGeneratorInterface::ABSOLUTE_PATH
-            );
+            $this->path = $this->generateLink($route, $params, false);
         }
 
         return $this->path;
@@ -170,46 +166,24 @@ class Canonical
             $route = $this->request->attributes->get('_route');
         }
 
-        $canonicalRoute = $this->getCanonicalRoute($route, $params);
-
         try {
-            $this->path = $this->urlGenerator->generate(
-                $canonicalRoute,
-                $params
-            );
+            $this->path = $this->generateLink($route, $params, false);
         } catch (InvalidParameterException | MissingMandatoryParametersException $e) {
             // Just use the current URL /shrug
-            $this->request->getUri();
+            $this->path = $this->request->getUri();
         }
     }
 
-    public function getCanonicalRoute(string $route, array &$params = []): string
+    public function generateLink(string $route, array $params, $canonical = false): ?string
     {
-        $routes = new Collection($this->router->getRouteCollection()->getIterator());
-        $currentController = $routes->get($route)->getDefault('_controller');
-
-        $routes = collect($routes->filter(function (Route $route) use ($currentController) {
-            return $route->getDefault('_controller') === $currentController;
-        })->keys());
-
-        // If only one route matched, return that.
-        if ($routes->count() === 1) {
-            return $routes->first();
+        if (isset($params['_locale']) && $params['_locale'] === $this->defaultLocale) {
+            unset($params['_locale']);
         }
 
-        // If no locale or locale is not default, get the first route which is named *_locale
-        if (array_key_exists('_locale', $params) && $params['_locale'] !== $this->defaultLocale) {
-            return $routes->filter(function (string $name) {
-                return fnmatch('*locale', $name);
-            })->first();
-        }
-
-        // Unset _locale so that it is not passed as query param to url.
-        unset($params['_locale']);
-
-        // Otherwise, get the first route that is not *_locale
-        return $routes->filter(function (string $name) {
-            return ! fnmatch('*locale', $name);
-        })->first();
+        return $this->urlGenerator->generate(
+                $route,
+                $params,
+                $canonical ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
+            );
     }
 }

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -5,15 +5,11 @@ declare(strict_types=1);
 namespace Bolt;
 
 use Bolt\Configuration\Config;
-use Bolt\Twig\ContentExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouterInterface;
-use Tightenco\Collect\Support\Collection;
 
 class Canonical
 {
@@ -38,18 +34,14 @@ class Canonical
     /** @var string */
     private $path = null;
 
-    /** @var RouterInterface */
-    private $router;
-
     /** @var string */
     private $defaultLocale;
 
-    public function __construct(Config $config, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, RouterInterface $router, string $defaultLocale)
+    public function __construct(Config $config, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, string $defaultLocale)
     {
         $this->config = $config;
         $this->urlGenerator = $urlGenerator;
         $this->request = $requestStack->getCurrentRequest();
-        $this->router = $router;
         $this->defaultLocale = $defaultLocale;
 
         $this->init();
@@ -181,9 +173,9 @@ class Canonical
         }
 
         return $this->urlGenerator->generate(
-                $route,
-                $params,
-                $canonical ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
-            );
+            $route,
+            $params,
+            $canonical ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
+        );
     }
 }

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -143,6 +143,9 @@ class ContentTypesParser extends BaseParser
         if (! isset($contentType['listing_template'])) {
             $contentType['listing_template'] = $contentType['slug'] . '.twig';
         }
+        if (! isset($contentType['record_route'])) {
+            $contentType['record_route'] = isset($contentType['locales']) ? 'record_locale' : 'record';
+        }
 
         if ($contentType['singleton']) {
             $contentType['listing_records'] = 1;

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -27,15 +27,11 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
     /** @var Request */
     private $request;
 
-    /** @var string */
-    private $defaultLocale;
-
-    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository, RequestStack $requestStack, string $defaultLocale)
+    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository, RequestStack $requestStack)
     {
         $this->templateChooser = $templateChooser;
         $this->contentRepository = $contentRepository;
         $this->request = $requestStack->getCurrentRequest();
-        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -63,15 +59,11 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
         }
 
         // Update the canonical, with the correct path
-        $params = [
+        $this->canonical->setPath(null, [
             'contentTypeSlug' => $record ? $record->getContentTypeSingularSlug() : null,
             'slugOrId' => $record ? $record->getSlug() : null,
             '_locale' => $this->request->getLocale(),
-        ];
-        if ($this->request->getLocale() !== $this->defaultLocale) {
-            $params['_locale'] = $this->request->getLocale();
-        }
-        $this->canonical->setPath(null, $params);
+        ]);
 
         return $this->renderSingle($record, $requirePublished);
     }

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -27,11 +27,15 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
     /** @var Request */
     private $request;
 
-    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository, RequestStack $requestStack)
+    /** @var string */
+    private $defaultLocale;
+
+    public function __construct(TemplateChooser $templateChooser, ContentRepository $contentRepository, RequestStack $requestStack, string $defaultLocale)
     {
         $this->templateChooser = $templateChooser;
         $this->contentRepository = $contentRepository;
         $this->request = $requestStack->getCurrentRequest();
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -59,11 +63,15 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
         }
 
         // Update the canonical, with the correct path
-        $this->canonical->setPath(null, [
+        $params = [
             'contentTypeSlug' => $record ? $record->getContentTypeSingularSlug() : null,
             'slugOrId' => $record ? $record->getSlug() : null,
             '_locale' => $this->request->getLocale(),
-        ]);
+        ];
+        if ($this->request->getLocale() !== $this->defaultLocale) {
+            $params['_locale'] = $this->request->getLocale();
+        }
+        $this->canonical->setPath(null, $params);
 
         return $this->renderSingle($record, $requirePublished);
     }

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -58,13 +58,6 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
             $record = $this->contentRepository->findOneBySlug($slugOrId, $contentType);
         }
 
-        // Update the canonical, with the correct path
-        $this->canonical->setPath(null, [
-            'contentTypeSlug' => $record ? $record->getContentTypeSingularSlug() : null,
-            'slugOrId' => $record ? $record->getSlug() : null,
-            '_locale' => $this->request->getLocale(),
-        ]);
-
         return $this->renderSingle($record, $requirePublished);
     }
 

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -58,6 +58,13 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
             $record = $this->contentRepository->findOneBySlug($slugOrId, $contentType);
         }
 
+        // Update the canonical, with the correct path
+        $this->canonical->setPath(null, [
+            'contentTypeSlug' => $record ? $record->getContentTypeSingularSlug() : null,
+            'slugOrId' => $record ? $record->getSlug() : null,
+            '_locale' => $this->request->getLocale(),
+        ]);
+
         return $this->renderSingle($record, $requirePublished);
     }
 

--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -143,7 +143,7 @@ class ContentRepository extends ServiceEntityRepository
             ->andWhere($where . ' = :slug')
             ->setParameter('slug', $slug);
 
-        if ($contentType) {
+        if ($contentType && $contentType->get('slug')) {
             $query->andWhere('content.contentType = :ct')
                 ->setParameter('ct', $contentType->get('slug'));
         }

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -345,7 +345,7 @@ class ContentExtension extends AbstractExtension
             'contentTypeSlug' => $content->getContentTypeSingularSlug(),
         ];
 
-        return $this->generateLink('record_locale', $params, $canonical);
+        return $this->generateLink($content->getDefinition()->get('record_route'), $params, $canonical);
     }
 
     public function getEditLink(Content $content): ?string
@@ -396,14 +396,8 @@ class ContentExtension extends AbstractExtension
 
     private function generateLink(string $route, array $params, $canonical = false): string
     {
-        $canonicalRoute = $this->canonical->getCanonicalRoute($route, $params);
-
         try {
-            $link = $this->urlGenerator->generate(
-                $canonicalRoute,
-                $params,
-                $canonical ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
-            );
+            $link = $this->canonical->generateLink($route, $params, $canonical);
         } catch (InvalidParameterException $e) {
             $this->logger->notice('Could not create URL for route \'' . $route . '\'. Perhaps the ContentType was changed or removed. Try clearing the cache');
             $link = '';

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -15,7 +15,7 @@ class ContentTypesParserTest extends ParserTestBase
 {
     public const NUMBER_OF_CONTENT_TYPES_IN_MINIMAL_FILE = 2;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 24;
+    public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 25;
 
     public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 24;
 


### PR DESCRIPTION
Fixes #1483 
Fixes #1470

One outstanding issue:

```
termsandconditions:
  path: /terms-and-conditions
  defaults:
    _controller: Bolt\Controller\Frontend\DetailController::record
    contentTypeSlug: 'terms-and-conditions'
    slugOrId: 31
```

The default slugOrId is set here.
Trying to get the `|link` on the `/terms-and-conditions` page breaks the url, because the ContentExtension::getLink always overrides the slugOrId param, hence the link becomes:
`/terms-and-conditions?slugOrId=someUnexpectedSlug`

where someUnexpectedSlug is the slug from the content.

I'm not sure how to fix this elegantly? @bobdenotter 
