### PR TITLE
Don't "warm up" cache on `composer update`, to save time and prevent dreaded `ProcessTimedOutException` after 10 seconds..

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,7 @@
             "php bin/console bolt:info"
         ],
         "auto-scripts": {
-            "cache:clear": "symfony-cmd",
+            "cache:clear --no-warmup": "symfony-cmd",
             "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
         },
         "periodical-tasks": [


### PR DESCRIPTION
Fixes #1525 