### PR TITLE
Don't break line on date field with valueonly

### DIFF
--- a/templates/_partials/fields/date.html.twig
+++ b/templates/_partials/fields/date.html.twig
@@ -36,7 +36,6 @@
     :errormessage='{{ errormessage|json_encode }}'
   ></editor-date>
   {% else %}
-      <br>
     {{ value|localedatetime('%B %e, %Y - %H:%M<small>%p</small>') }}
       <small>({{ macro.relative_datetime(value) }})</small>
   {% endif %}


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/7093518/86128534-c690ae80-bae1-11ea-97c2-1d3178ff796c.png)
