### PR TITLE
Allow "focus" parameter for excerpts of plain strings

### DIFF
--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -237,7 +237,7 @@ class ContentExtension extends AbstractExtension
     public function getExcerpt($content, int $length = 280, bool $includeTitle = false, $focus = null): string
     {
         if (is_string($content) || $content instanceof Markup) {
-            return Excerpt::getExcerpt((string) $content, $length);
+            return Excerpt::getExcerpt((string) $content, $length, $focus);
         }
 
         if (ContentHelper::isSuitable($content, 'excerpt_format')) {


### PR DESCRIPTION
With this PR you can now highlight words using both `Content`, as well as plain strings. 

Example: 

```twig
    {{ "Cenasti in vita numquam bene, cum omnia in ista Consumis squilla atque acupensere cum decimano."|excerpt(30, focus = 'omnia') }}
    {{ record|excerpt(100, focus = 'omnis') }}
```

Fixes #1590 