### PR TITLE
Put `localedatetime` with previous format and deprecated notice. Use `localdate` with new format

### DIFF
--- a/src/Twig/LocaleExtension.php
+++ b/src/Twig/LocaleExtension.php
@@ -47,7 +47,7 @@ class LocaleExtension extends AbstractExtension
 
         return [
             new TwigFilter('localedatetime', [$this, 'localedatetime'], $safe),
-            new TwigFilter('localdate', [$this, 'localedatetime'], $safe),
+            new TwigFilter('localdate', [$this, 'localedate'], $safe),
         ];
     }
 
@@ -121,9 +121,42 @@ class LocaleExtension extends AbstractExtension
     }
 
     /**
+     * @deprecated
+     *
      * @param string|\DateTime $dateTime
      */
-    public function localedatetime($dateTime, ?string $format = null, ?string $locale = null): string
+    public function localedatetime($dateTime, string $format = '%B %e, %Y %H:%M', ?string $locale = '0'): string
+    {
+        if (! $dateTime instanceof \DateTime) {
+            $dateTime = new \DateTime((string) $dateTime);
+        }
+
+        // Check for Windows to find and replace the %e modifier correctly
+        // @see: http://php.net/strftime
+        $os = mb_strtoupper(mb_substr(PHP_OS, 0, 3));
+        $format = $os !== 'WIN' ? $format : preg_replace('#(?<!%)((?:%%)*)%e#', '\1%#d', $format);
+        $timestamp = $dateTime->getTimestamp();
+
+        // According to http://php.net/manual/en/function.setlocale.php manual
+        // if the second parameter is "0", the locale setting is not affected,
+        // only the current setting is returned.
+        $result = setlocale(LC_ALL, $locale);
+
+        if ($result === false) {
+            // This shouldn't occur, but.. Dude!
+            // You ain't even got locale or English on your platform??
+            // Various things we could do. We could fail miserably, but a more
+            // graceful approach is to use the datetime to display a default
+            // format
+            // $this->systemLogger->error('No valid locale detected. Fallback on DateTime active.', ['event' => 'system']);
+
+            return $dateTime->format('Y-m-d H:i:s');
+        }
+
+        return strftime($format, $timestamp);
+    }
+
+    public function localdate($dateTime, ?string $format = null, ?string $locale = null): string
     {
         if ($dateTime instanceof \Datetime) {
             $dateTime = Carbon::createFromTimestamp($dateTime->getTimestamp(), $dateTime->getTimezone());

--- a/src/Twig/LocaleExtension.php
+++ b/src/Twig/LocaleExtension.php
@@ -47,7 +47,8 @@ class LocaleExtension extends AbstractExtension
 
         return [
             new TwigFilter('localedatetime', [$this, 'localedatetime'], $safe),
-            new TwigFilter('localdate', [$this, 'localedate'], $safe),
+            new TwigFilter('localedate', [$this, 'localedatetime'], $safe),
+            new TwigFilter('localdate', [$this, 'localdate'], $safe),
         ];
     }
 

--- a/templates/_macro/_macro.html.twig
+++ b/templates/_macro/_macro.html.twig
@@ -77,7 +77,7 @@
 
 
 {% macro relative_datetime(datetime) %}{% apply spaceless %}
-    <abbr class="datetime-relative" title="{{ datetime|localedatetime }}">
+    <abbr class="datetime-relative" title="{{ datetime|localdate }}">
         {{- datetime|date('c') -}}
     </abbr>
 {% endapply %}{% endmacro %}

--- a/templates/_partials/fields/date.html.twig
+++ b/templates/_partials/fields/date.html.twig
@@ -36,7 +36,7 @@
     :errormessage='{{ errormessage|json_encode }}'
   ></editor-date>
   {% else %}
-    {{ value|localedatetime(format|default(null), locale|default(null)) }}
+    {{ value|localdate(format|default(null), locale|default(null)) }}
       <small>({{ macro.relative_datetime(value) }})</small>
   {% endif %}
   


### PR DESCRIPTION
Fixes #1604 