### PR TITLE
fixed default homepage menu item

### DIFF
--- a/config/bolt/menu.yaml
+++ b/config/bolt/menu.yaml
@@ -4,7 +4,7 @@
 main:
   - label: Home
     title: This is the <b>first<b> menu item.
-    link: homepage
+    link: /
     class: homepage
   - label: About
     link: blocks/about


### PR DESCRIPTION
Fixed homepage menu item as discussed in the slack channel from `path: homepage` to `path: /`

But I don't know if `path`/`link` are the same or if one is preferred.