### PR TITLE
Allow auto-generated extension services to be overridden

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -56,15 +56,16 @@ class Kernel extends BaseKernel
         $container->setParameter('container.dumper.inline_factories', true);
         $confDir = $this->getProjectDir() . '/config';
 
-        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
-
+        // Load auto-generated extension services first. Any overrides after take precedence.
         try {
             $loader->load($confDir . '/{services}_bolt' . self::CONFIG_EXTS, 'glob');
         } catch (\Throwable $e) {
             // Ignore errors. The file will be updated on next `cache:clear` or whenever
             // the container gets refreshed
         }
+
+        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
+        $loader->load($confDir . '/{packages}/' . $this->environment . '/*' . self::CONFIG_EXTS, 'glob');
 
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');


### PR DESCRIPTION
By making sure the auto-generated extension services are loaded first, we allow custom extension services + implementors to override them as they see fit.