### PR TITLE
Allow textarea `height` option

### DIFF
--- a/assets/js/app/editor/Components/Textarea.vue
+++ b/assets/js/app/editor/Components/Textarea.vue
@@ -4,12 +4,13 @@
       v-model="rawVal"
       class="form-control field--textarea"
       :name="name"
-      rows="10"
+      :rows="rows"
       :required="required"
       :readonly="readonly"
       :data-errormessage="errormessage"
       :pattern="pattern"
       :placeholder="placeholder"
+      :style="{ height: styleHeight }"
     ></textarea>
   </div>
 </template>
@@ -28,6 +29,15 @@ export default {
     errormessage: String | Boolean,
     pattern: String | Boolean,
     placeholder: String | Boolean,
+    height: String | Number,
+  },
+  data() {
+    return {
+      // If height is 50px/vh/vw/%, set css height.
+      // If height is 50 (a number), set rows attribute.
+      rows: isNaN(this.height) ? false : this.height,
+      styleHeight: isNaN(this.height) ? this.height : false,
+    };
   },
 };
 </script>

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -186,6 +186,7 @@ showcases:
         textarea:
             type: textarea
             postfix: "This is a plain text area. the contents will <em><strong>not</em></strong> be processed."
+            height: 200px # or 15 for 15 rows
         markdown:
             type: markdown
             postfix: "This field gets parsed as <a href='https://help.github.com/articles/markdown-basics'>Markdown</a>, when rendered on the site."

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -49,6 +49,7 @@ class FieldType extends Collection
             'pattern' => false,
             'hidden' => false,
             'default_locale' => 'en',
+            'height' => '10', // 10 rows by default
         ]);
     }
 

--- a/templates/_partials/fields/textarea.html.twig
+++ b/templates/_partials/fields/textarea.html.twig
@@ -10,5 +10,6 @@
         :errormessage='{{ errormessage|json_encode }}'
         :pattern='{{ pattern|json_encode }}'
         :placeholder='{{ placeholder|json_encode }}'
+        :height='{{ field.definition.height|json_encode }}'
     ></editor-textarea>
 {% endblock %}

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -17,7 +17,7 @@ class ContentTypesParserTest extends ParserTestBase
 
     public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 25;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 24;
+    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 25;
 
     public const ALLOWED_LOCALES = 'en|nl|es|fr|de|pl|it|hu|pt_BR|ja|nb|nn|nl_NL|nl_BE';
 


### PR DESCRIPTION
Fixes #1663 

Set textarea height like so:

```
height: 10 # 10 rows
height: 150px # 150 pixels
height: 50vh # 50% of viewport
```