### PR TITLE
Use translated bootbox 

### DIFF
--- a/assets/js/app/confirmation.js
+++ b/assets/js/app/confirmation.js
@@ -1,13 +1,22 @@
 import bootbox from 'bootbox';
 import $ from 'jquery';
 
+let bootboxDefaults = {
+  locale: 'en'
+}
+
+bootbox.setDefaults(bootboxDefaults);
+
+let locale = $('html').attr('lang');
+
+if(locale){
+  bootbox.setLocale(locale);
+}
+
 $('*[data-confirmation]').on('click', function() {
   const thisElem = $(this);
   const thisHref = $(this).attr('href');
   const confirmation = $(this).data('confirmation');
-
-  let locale = $('html').attr('lang');
-  bootbox.setLocale(locale);
 
   if (!thisElem.data('confirmed')) {
     bootbox.confirm(confirmation, function(result) {

--- a/assets/js/app/confirmation.js
+++ b/assets/js/app/confirmation.js
@@ -6,6 +6,9 @@ $('*[data-confirmation]').on('click', function() {
   const thisHref = $(this).attr('href');
   const confirmation = $(this).data('confirmation');
 
+  let locale = $('html').attr('lang');
+  bootbox.setLocale(locale);
+
   if (!thisElem.data('confirmed')) {
     bootbox.confirm(confirmation, function(result) {
       if (result && thisHref) {

--- a/assets/js/app/confirmation.js
+++ b/assets/js/app/confirmation.js
@@ -2,14 +2,14 @@ import bootbox from 'bootbox';
 import $ from 'jquery';
 
 let bootboxDefaults = {
-  locale: 'en'
-}
+  locale: 'en',
+};
 
 bootbox.setDefaults(bootboxDefaults);
 
 let locale = $('html').attr('lang');
 
-if(locale){
+if (locale) {
   bootbox.setLocale(locale);
 }
 

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -1,7 +1,7 @@
 {# Check if aside has value and set hasAside variable #}
 {% set hasAside = block('aside')|trim is not empty ? true : false %}
 <!DOCTYPE html>
-<html lang={{ app.user.locale }} {% if block('html_id') %}id="{% block html_id %}{% endblock %}"{% endif %}>
+<html lang="{{ app.user.locale }}" {% if block('html_id') %}id="{% block html_id %}{% endblock %}"{% endif %}>
 
 <head>
     <meta charset="utf-8">

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -1,7 +1,7 @@
 {# Check if aside has value and set hasAside variable #}
 {% set hasAside = block('aside')|trim is not empty ? true : false %}
 <!DOCTYPE html>
-<html {% if block('html_id') %}id="{% block html_id %}{% endblock %}"{% endif %}>
+<html lang={{ app.user.locale }} {% if block('html_id') %}id="{% block html_id %}{% endblock %}"{% endif %}>
 
 <head>
     <meta charset="utf-8">

--- a/tests/php/Menu/FrontendMenuBuilderTest.php
+++ b/tests/php/Menu/FrontendMenuBuilderTest.php
@@ -57,10 +57,10 @@ class FrontendMenuBuilderTest extends DbAwareTestCase
 
         $this->assertSame('The Bolt site', $lastItem->get('label'));
         $this->assertSame('Visit the excellent Bolt website!', $lastItem->get('title'));
-        $this->assertSame('https://bolt.cm', $lastItem->get('link'));
+        $this->assertSame('https://boltcms.io', $lastItem->get('link'));
         $this->assertSame('bolt-site', $lastItem->get('class'));
         $this->assertNull($lastItem->get('submenu'));
-        $this->assertSame('https://bolt.cm', $lastItem->get('uri'));
+        $this->assertSame('https://boltcms.io', $lastItem->get('uri'));
         $this->assertNull($lastItem->get('foobar'));
     }
 


### PR DESCRIPTION
This PR translates the bootbox modals.

'en' locale is used by default and if there is another locale set then that is the locale bootbox will use to show translated text in the modals.

More info here: http://bootboxjs.com/documentation.html#bb-function-setLocale