### PR TITLE
modification to SelectQuery.php related to #1619

### DIFF
--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -396,7 +396,7 @@ class SelectQuery implements QueryInterface
             } else {
                 //added to include taxonomies to be searched as part of contenttype filter at the backend and frontend if anyField param is set.
                 foreach ($filter->getParameters() as $value) {
-                    $innerQuery->innerJoin($contentAlias . '.taxonomies', 'taxonomies_' . $index);
+                    $innerQuery->leftJoin($contentAlias . '.taxonomies', 'taxonomies_' . $index);
                     $this->qb->setParameter($key . '_1', $value);
                     $filterExpression = sprintf('LOWER(taxonomies_%s.slug) LIKE :%s', $index, $key . '_1');
                     $innerQuery->orWhere($filterExpression);


### PR DESCRIPTION
innerJoin replaced with leftJoin. "anyField" search/filter was only being performed on records which have Taxonomies assigned. LeftJoin resolves this problem,  searching/filtering records with "anyField" on all fields and taxonomies even if the record does not have any Taxonomies assigned.