### PR TITLE
Prevent breakage when trying to excerpt a Field

### DIFF
--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -8,6 +8,7 @@ use Bolt\Canonical;
 use Bolt\Configuration\Config;
 use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Content;
+use Bolt\Entity\Field;
 use Bolt\Entity\Field\Excerptable;
 use Bolt\Entity\Field\ImageField;
 use Bolt\Entity\Field\ImagelistField;
@@ -242,7 +243,7 @@ class ContentExtension extends AbstractExtension
      */
     public function getExcerpt($content, int $length = 280, bool $includeTitle = false, $focus = null): string
     {
-        if (is_string($content) || $content instanceof Markup) {
+        if (is_string($content) || $content instanceof Markup || $content instanceof Field) {
             return Excerpt::getExcerpt((string) $content, $length, $focus);
         }
 

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -238,7 +238,7 @@ class ContentExtension extends AbstractExtension
     }
 
     /**
-     * @param string|Markup|Content $content
+     * @param string|Markup|Content|Field $content
      * @param string|array|null $focus
      */
     public function getExcerpt($content, int $length = 280, bool $includeTitle = false, $focus = null): string


### PR DESCRIPTION
For example, when doing this: 

```twig
<p>{{ record.content|excerpt(200, false, search|default('')) }}</p>
```

Bolt would break with this error: 

![Screenshot 2020-08-23 at 17 32 51](https://user-images.githubusercontent.com/1833361/90982332-c69fae80-e566-11ea-89df-c96dd3af0787.png)
