### PR TITLE
Avoid caching slug uses definition for new records

### DIFF
--- a/src/Entity/Field/SlugField.php
+++ b/src/Entity/Field/SlugField.php
@@ -33,9 +33,4 @@ class SlugField extends Field implements FieldInterface, ScalarCastable
 
         return $this;
     }
-
-    public function getSlugUseFields(): array
-    {
-        return Collection::wrap($this->getDefinition()->get('uses'))->toArray();
-    }
 }

--- a/src/Entity/Field/SlugField.php
+++ b/src/Entity/Field/SlugField.php
@@ -8,7 +8,6 @@ use Bolt\Common\Str;
 use Bolt\Entity\Field;
 use Bolt\Entity\FieldInterface;
 use Doctrine\ORM\Mapping as ORM;
-use Tightenco\Collect\Support\Collection;
 
 /**
  * @ORM\Entity

--- a/templates/_partials/fields/slug.html.twig
+++ b/templates/_partials/fields/slug.html.twig
@@ -10,7 +10,7 @@
         :field-class='{{ class|json_encode }}'
         :required='{{ required|json_encode }}'
         :readonly='{{ readonly|json_encode }}'
-        :generate='{{ field.slugUseFields|join(',')|json_encode }}'
+        :generate='{{ field.definition.uses|join(',')|json_encode }}'
         :errormessage='{{ errormessage|json_encode }}'
         :pattern='{{ pattern|json_encode }}'
         :labels='{{ {


### PR DESCRIPTION
Fixes #1785 

Issue is with cache (hence why it only happens _sometimes_ in production?). The method call is, for some reason, cached. Could be that on new objects it's cached the wrong way.

Calling the `definition.uses` in Twig directly resolves it.

I'm not super comfortable with the caching problem itself, however...