### PR TITLE
Remove max-width

### DIFF
--- a/assets/scss/modules/editor/fields/_pre_postfix.scss
+++ b/assets/scss/modules/editor/fields/_pre_postfix.scss
@@ -1,7 +1,6 @@
 .form--helper {
   font-size: 0.95rem;
   color: #666;
-  max-width: 46em;
   display: block;
   margin: 0.5rem 0;
 }


### PR DESCRIPTION
max-width was keeping pre and postfix from using 100% of the width of its container