### PR TITLE
Allow for more control over formatting of prefix and postfix

### DIFF
--- a/assets/scss/modules/editor/fields/_pre_postfix.scss
+++ b/assets/scss/modules/editor/fields/_pre_postfix.scss
@@ -3,4 +3,8 @@
   color: #666;
   display: block;
   margin: 0.5rem 0;
+
+  p {
+    max-width: 40em;
+  }
 }

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -174,6 +174,13 @@ showcases:
             error: "The Title field is required, and must contain at least 2 characters"
             placeholder: "Placeholder for the title"
             group: Text
+            postfix: |
+                This is an example of a longer "postfix". Simple text is capped at a reasonable width
+                to enhance legibility. Necessitatibus dolor corrupti assumenda placeat quia occati
+                aut. Facere porro placeat molestiae fuga. Laboriosam et asperiores atque impedit
+                dolorem dicta aut. Harum inventore ipsa voluptas consectetur quaerat eius ad.
+                <div class="alert alert-secondary" role="alert"><strong>Tip:</strong> You can even
+                use HTML in a prefix! Note that this one does take the full available width.</div>
         slug:
             type: slug
             uses: [ title ]

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -105,13 +105,13 @@
 
 {# Set the prefix and postfix attributes #}
 {% set prefix = prefix|default(field.definition.prefix|default) %}
-{% if prefix and not ('<p' in prefix or '<span' in prefix or '<div' in prefix) %}
-    {% set prefix = '<span id="' ~ id ~ '_prefix" class="form--helper">' ~ prefix ~ '</span>' %}
+{% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
+    {% set prefix = '<div id="' ~ id ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
 {% endif %}
 
 {% set postfix = postfix|default(field.definition.postfix|default) %}
-{% if postfix and not ('<p' in postfix or '<span' in postfix or '<div' in postfix) %}
-    {% set postfix = '<span id="' ~ id ~ '_postfix" class="form--helper">' ~ postfix ~ '</span>' %}
+{% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
+    {% set postfix = '<div id="' ~ id ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
 {% endif %}
 
 {%- endapply -%}

--- a/tests/e2e/kitchensink.feature
+++ b/tests/e2e/kitchensink.feature
@@ -15,4 +15,4 @@ Feature: Visiting the Kitchensink
 
     And I should see "Title:" in the "label[for='field-title']" element
     And I should see an "input#field-title" element
-    And I should see "shown on the homepage" in the "span#field-title_postfix" element
+    And I should see "shown on the homepage" in the "div#field-title_postfix" element


### PR DESCRIPTION
Additional change to #1796

```yaml
    fields:
        title:
            type: text
            class: large
            required: true
            pattern: ".{2,255}" # see: http://html5pattern.com/
            error: "The Title field is required, and must contain at least 2 characters"
            placeholder: "Placeholder for the title"
            group: Text
            postfix: |
                This is an example of a longer "postfix". Simple text is capped at a reasonable width
                to enhance legibility. Necessitatibus dolor corrupti assumenda placeat quia occati
                aut. Facere porro placeat molestiae fuga. Laboriosam et asperiores atque impedit
                dolorem dicta aut. Harum inventore ipsa voluptas consectetur quaerat eius ad.
                <div class="alert alert-secondary" role="alert"><strong>Tip:</strong> You can even
                use HTML in a prefix! Note that this one does take the full available width.</div>
```

![Screenshot 2020-09-02 at 07 04 28](https://user-images.githubusercontent.com/1833361/91934186-faa76c00-ecea-11ea-8ea0-d851c2089b31.png)
