### PR TITLE
Make order filter work with `ContentHelper::get()` options

### DIFF
--- a/public/theme/skeleton/custom/setcontent_1.twig
+++ b/public/theme/skeleton/custom/setcontent_1.twig
@@ -191,4 +191,19 @@
             {% endif %}
         </ul>
     </section>
+
+    <section id="thirteen">
+        <h1>Thirteen</h1>
+        {% setcontent showcases = 'showcases' printquery %}
+        {% set showcases = showcases|order('-floatfield') %}
+
+        Results: <span id="results-nine">{{ showcases|length > 0 ? 'yes' }}</span>
+        <ul>
+            {% for showcase in showcases %}
+                <li>showcase {{ showcase.id }}: {{ showcase.floatfield }}
+                    <span class="s{{ loop.index }}">{{ _self.issmaller(showcase.floatfield, last|default()) }}</span>
+                </li>
+                {% set last = showcase.floatfield %}
+            {% endfor %}
+    </section>
 {% endblock main %}


### PR DESCRIPTION
Fixes #1805 

As it uses the `ContentHelper::get`, there are some limitations compared to ordering with `setcontent`. Most notably you can't order by taxonomies.