### PR TITLE
Fix `Notice: Array to string conversion` in `Field.php` by ensuring  the  array is one level deep.

### DIFF
--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -7,6 +7,7 @@ namespace Bolt\Entity;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use Bolt\Common\Arr;
 use Bolt\Configuration\Content\FieldType;
 use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
@@ -79,7 +80,7 @@ class Field implements FieldInterface, TranslatableInterface
         $value = $this->getTwigValue();
 
         if (is_array($value)) {
-            $value = implode('', $value);
+            $value = implode('', Arr::flatten($value, INF));
         }
 
         return (string) $value;

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -80,7 +80,7 @@ class Field implements FieldInterface, TranslatableInterface
         $value = $this->getTwigValue();
 
         if (is_array($value)) {
-            $value = implode('', Arr::flatten($value, INF));
+            $value = implode('', Arr::flatten($value, PHP_INT_MAX));
         }
 
         return (string) $value;


### PR DESCRIPTION
This happens for fields that don't implement their own `__toString()` method, like `type: data`, or potentially Fields added by extensions. 

![Schermafbeelding 2020-09-02 om 11 24 47](https://user-images.githubusercontent.com/1833361/91964328-49ff9380-ed0f-11ea-8866-a57c60f00a3c.png)
