### PR TITLE
Prevent recursion in `title_format`

### DIFF
--- a/src/Utils/ContentHelper.php
+++ b/src/Utils/ContentHelper.php
@@ -175,6 +175,13 @@ class ContentHelper
                     return $field;
                 }
 
+                // We must ensure this method is not called recursively. For example
+                // `title_format: {title}` would otherwise result in an endless loop
+                // @see https://github.com/bolt/core/issues/1825
+                if (Recursion::detect()) {
+                    return '(recursion)';
+                }
+
                 if (array_key_exists($match[1], $record->getExtras())) {
                     // If it's the icon, return an html element
                     if ($match[1] === 'icon') {

--- a/src/Utils/Recursion.php
+++ b/src/Utils/Recursion.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Utils;
+
+class Recursion
+{
+    public static function detect(): bool
+    {
+        $backtrace = [];
+
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $call) {
+            if (array_key_exists('class', $call)) {
+                $backtrace[] = $call['class'] . $call['type'] . $call['function'];
+            } else {
+                $backtrace[] = basename($call['file']) . '::' . $call['function'];
+            }
+        }
+
+        // The one we called from is [1]
+        $callee = $backtrace[1];
+
+        $count = count(array_filter($backtrace, function ($a) use ($callee) {
+            return $a === $callee;
+        }));
+
+        return $count > 1;
+    }
+}


### PR DESCRIPTION
Now `title_format: '{title} pom {foo}'` will result in: 

![Schermafbeelding 2020-09-03 om 13 03 56](https://user-images.githubusercontent.com/1833361/92107374-f449ea80-ede5-11ea-85b6-5fc60c7fe89a.png)

Fixes #1825 