### PR TITLE
Use `travis_retry` command on frequently failing behat tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
   # run API tests
   - make behat-api-quiet
   # run JS e2e tests
-  - make behat-js-quiet
+  - travis_retry make behat-js-quiet
   # Upload Behat logs
   - ./vendor/bin/upload-textfiles "var/log/behat-reports/*.log"
 


### PR DESCRIPTION
According to the [docs](https://docs.travis-ci.com/user/common-build-problems/), we can re-run failing commands within the same build, by default up to 3 times!

Hopefully, that makes behat behave!