### PR TITLE
Removed faulty definition to show timeSelection in Date Picker

### DIFF
--- a/assets/scss/vendor/flatpickr/flatpickr.scss
+++ b/assets/scss/vendor/flatpickr/flatpickr.scss
@@ -93,7 +93,7 @@
     }
   }
 
-  &.showTimeInput.hasTime {
+  &.hasTime {
     .flatpickr-time {
       height: $timeHeight;
       border-top: 1px solid $calendarBorderColor;


### PR DESCRIPTION
Fixed the visiblity of time selection area when setting  ```mode: datetime``` on a date field.