### PR TITLE
Allow multiple roles to be selected for users

### DIFF
--- a/assets/js/app/editor/Components/Password.vue
+++ b/assets/js/app/editor/Components/Password.vue
@@ -8,7 +8,7 @@
         type="password"
         :name="name"
         :value="value"
-        :required="required == 1"
+        :required="required"
         :readonly="readonly"
         :data-errormessage="errormessage"
         :pattern="pattern"
@@ -48,7 +48,7 @@ export default {
     id: String,
     hidden: Boolean,
     strength: Boolean,
-    required: Number,
+    required: Boolean,
     readonly: Boolean,
     errormessage: String | Boolean, //string if errormessage is set, and false otherwise
     pattern: String | Boolean,

--- a/src/Controller/Backend/UserEditController.php
+++ b/src/Controller/Backend/UserEditController.php
@@ -145,7 +145,7 @@ class UserEditController extends TwigAwareController implements BackendZoneInter
 
         $displayName = $user->getDisplayName();
         $locale = Json::findScalar($this->getFromRequest('locale'));
-        $roles = (array) Json::findScalar($this->getFromRequest('roles'));
+        $roles = Json::findArray($this->getFromRequest('roles'));
         $status = Json::findScalar($this->getFromRequest('ustatus', UserStatus::ENABLED));
 
         if (empty($user->getUsername())) {

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -11,7 +11,9 @@
     {% set options = select_options(field) %}
 {% endif %}
 
-{% set multiple = field.definition.get('multiple')|default ? 'true' : 'false' %}
+{% if multiple is not defined %}
+    {% set multiple = field.definition.get('multiple')|default ? 'true' : 'false' %}
+{% endif %}
 
 {% block field %}
     <editor-select

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -96,6 +96,7 @@
                 'value' : userEdit.roles,
                 'options' : roleOptions,
                 'required': true,
+                'multiple': true,
             } %}
 
             {% set statusOptions = [] %}

--- a/templates/users/edit.html.twig
+++ b/templates/users/edit.html.twig
@@ -75,7 +75,7 @@
                 'name' : 'locale',
                 'value' : userEdit.locale,
                 'options' : localeOptions,
-                'required': true,
+                'required': 'true',
             } %}
 
             {% set roleOptions = [] %}
@@ -95,8 +95,8 @@
                 'name' : 'roles',
                 'value' : userEdit.roles,
                 'options' : roleOptions,
-                'required': true,
-                'multiple': true,
+                'required': 'true',
+                'multiple': 'true',
             } %}
 
             {% set statusOptions = [] %}


### PR DESCRIPTION
Strictly speaking, 1 role should be more than enough given Symfony roles are hierarchical...

But at the same time, our `User` entity has multiple roles. + The `bolt/users` extension does not (yet?) use hierarchy.

In any event, it should not hurt that 1 user may have multiple roles.