### PR TITLE
Fix iffy details/summary marker

### DIFF
--- a/assets/js/app/editor/Components/Collection.vue
+++ b/assets/js/app/editor/Components/Collection.vue
@@ -37,42 +37,44 @@
     </div>
 
     <div class="row">
-      <span class="my-auto" style="margin: 1rem;">{{ labels.add_collection_item }}:</span>
-      <div v-if="templates.length > 1" class="dropdown">
-        <button
-          id="dropdownMenuButton"
-          :disabled="!allowMore"
-          class="btn btn-secondary dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-          aria-haspopup="true"
-          aria-expanded="false"
-        >
-          <i class="fas fa-fw fa-plus"></i> {{ labels.select }}
-        </button>
-        <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-          <a
-            v-for="template in templates"
-            :key="template.label"
-            class="dropdown-item"
-            :data-template="template.label"
-            @click="addCollectionItem($event)"
+      <div class="col-12">
+      <p class="mt-4 mb-1">{{ labels.add_collection_item }}:</p>
+        <div v-if="templates.length > 1" class="dropdown">
+          <button
+            id="dropdownMenuButton"
+            :disabled="!allowMore"
+            class="btn btn-secondary dropdown-toggle"
+            type="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
           >
-            <i :class="[template.icon, 'fas fa-fw']" />
-            {{ template.label }}
-          </a>
+            <i class="fas fa-fw fa-plus"></i> {{ labels.select }}
+          </button>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+            <a
+              v-for="template in templates"
+              :key="template.label"
+              class="dropdown-item"
+              :data-template="template.label"
+              @click="addCollectionItem($event)"
+            >
+              <i :class="[template.icon, 'fas fa-fw']" />
+              {{ template.label }}
+            </a>
+          </div>
         </div>
+        <button
+          v-else
+          type="button"
+          class="btn btn-secondary btn-small"
+          :data-template="templates[0].label"
+          @click="addCollectionItem($event)"
+        >
+          <i :class="[templates[0].icon, 'fas fa-fw']" />
+          {{ labels.add_collection_item }}
+        </button>
       </div>
-      <button
-        v-else
-        type="button"
-        class="btn btn-secondary btn-small"
-        :data-template="templates[0].label"
-        @click="addCollectionItem($event)"
-      >
-        <i :class="[templates[0].icon, 'fas fa-fw']" />
-        {{ labels.add_collection_item }}
-      </button>
     </div>
   </div>
 </template>

--- a/assets/js/app/editor/Components/Collection.vue
+++ b/assets/js/app/editor/Components/Collection.vue
@@ -15,17 +15,20 @@
       </div>
     </div>
 
-    <div v-for="element in elements" :key="element.hash" class="card collection-item">
-      <details :open="state === 'expanded'">
-        <summary class="card-header d-flex align-items-center">
-          <!-- Initial title. This is replaced by dynamic title in JS below. -->
-          <div class="collection-item-title" :data-label="element.label">
-            <i :class="[element.icon, 'fas fa-fw']" />
-            {{ element.label }}
-          </div>
+    <div v-for="element in elements" :key="element.hash" class="collection-item">
+      <details :open="state === 'expanded'" class="card">
+        <summary class="d-block"
+          <div class="card-header d-flex align-items-center"> 
+            <!-- Initial title. This is replaced by dynamic title in JS below. -->
+            <i class="card-marker-caret fa fa-caret-right"></i>
+            <div class="collection-item-title" :data-label="element.label">
+              <i :class="[element.icon, 'fas fa-fw']" />
+              {{ element.label }}
+            </div>
 
-          <!-- Navigation buttons -->
-          <div :is="compile(element.buttons)"></div>
+            <!-- Navigation buttons -->
+            <div :is="compile(element.buttons)"></div>
+          </div>
         </summary>
 
         <!-- The actual field -->

--- a/assets/js/app/editor/Components/Collection.vue
+++ b/assets/js/app/editor/Components/Collection.vue
@@ -17,7 +17,7 @@
 
     <div v-for="element in elements" :key="element.hash" class="collection-item">
       <details :open="state === 'expanded'" class="card">
-        <summary class="d-block"
+        <summary class="d-block">
           <div class="card-header d-flex align-items-center"> 
             <!-- Initial title. This is replaced by dynamic title in JS below. -->
             <i class="card-marker-caret fa fa-caret-right"></i>


### PR DESCRIPTION
Please also add the following CSS:

```
.collection-item details summary::-webkit-details-marker {
    display: none;
}

.collection-item details summary i.card-marker-caret {
    margin-right: 0.75rem;
}

.collection-item details[open] summary i.card-marker-caret {
    transform: rotate(90deg);
}
```

And remove these CSS rules: 
```
.collection-container .collection-item summary::before {
    content: "►";
    vertical-align: 25%;
    margin-right: .5rem;
    width: 15px;
    display: inline-block;
}
.collection-container .collection-item details[open] summary::before {
    content: "▼";
    vertical-align: 25%;
    margin-right: .5rem;
    width: 15px;
    display: inline-block;
}
```

Codepen demo:
https://codepen.io/thisiseduardo/pen/ExKONzV