### PR TITLE
fix(messages.de.xlf): Standart to Standard

### DIFF
--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1060,7 +1060,7 @@
     <unit id="37kJiIe" name="view_locales.badge_default">
       <segment>
         <source>view_locales.badge_default</source>
-        <target>Standart</target>
+        <target>Standard</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">


### PR DESCRIPTION
The correct spelling is "Standard": https://www.korrekturen.de/beliebte_fehler/standart.shtml