### PR TITLE
Collection updates

### DIFF
--- a/assets/scss/modules/editor/fields/_collection.scss
+++ b/assets/scss/modules/editor/fields/_collection.scss
@@ -45,7 +45,6 @@
 
     .card-body {
       background: var(--background);
-      padding-bottom: 0;
     }
   }
 }

--- a/assets/scss/modules/editor/fields/_collection.scss
+++ b/assets/scss/modules/editor/fields/_collection.scss
@@ -47,6 +47,7 @@
       background: var(--background);
       // 1px solves the ghosted whitespace
       // @see https://github.com/bolt/core/pull/1904
+
       padding-bottom: 1px;
     }
   }

--- a/assets/scss/modules/editor/fields/_collection.scss
+++ b/assets/scss/modules/editor/fields/_collection.scss
@@ -45,6 +45,9 @@
 
     .card-body {
       background: var(--background);
+      // 1px solves the ghosted whitespace
+      // @see https://github.com/bolt/core/pull/1904
+      padding-bottom: 1px;
     }
   }
 }

--- a/templates/_partials/fields/_label.html.twig
+++ b/templates/_partials/fields/_label.html.twig
@@ -8,10 +8,6 @@
 
     <label for="{{ id }}" class="editor--label{% if type|default() == 'collection' %} sr-only{% endif %}">
 
-        {% if in_compound is defined %}
-            <span style="font-weight: normal;">{{ compound_label }} &raquo;</span>
-        {% endif %}
-
         {{- label -}}:
         {% if required %} <span class="required-label"></span> {% endif %}
 

--- a/tests/e2e/edit_record_1.feature
+++ b/tests/e2e/edit_record_1.feature
@@ -188,7 +188,6 @@ Feature: Edit record
 
     When I follow "Sets"
     Then I should be on "/bolt/edit/43#sets"
-    And I should see "This is my set" in the "#sets label[for='field-set-title']" element
 
     And I should see "Title" in the "#sets label[for='field-set-title']" element
     And I should see exactly one "sets[set][title]" element


### PR DESCRIPTION
### Removes faint white border from bottom of collection cards

**before & after:**

<img width="1500" alt="Screen Shot 2020-09-24 at 3 04 31 PM" src="https://user-images.githubusercontent.com/1833020/94205052-4aef9500-fe77-11ea-8381-67c614cf95bb.png">


### Removes unnecessary 'set >>' labels:

**before & after:**

<img width="1371" alt="Screen Shot 2020-09-24 at 1 31 03 PM" src="https://user-images.githubusercontent.com/1833020/94205139-77a3ac80-fe77-11ea-9a22-bd52c35ba9d5.png">
