### PR TITLE
Update _base.scss

### DIFF
--- a/assets/scss/init/_base.scss
+++ b/assets/scss/init/_base.scss
@@ -57,9 +57,6 @@ small {
     margin-bottom: 1rem;
   }
 
-  a:not(.btn) {
-    text-decoration: underline;
-  }
 }
 
 .custom-select {


### PR DESCRIPTION
Removes underline from  Redactor and Article toolbar buttons, the underlines only appear when Redactor or Article are within a Collection card.

Before and After:
![Screen Shot 2020-09-24 at 8 02 18 PM](https://user-images.githubusercontent.com/1833020/94221893-ddf0f500-fea0-11ea-8cdb-3798f75fe984.png)
