### PR TITLE
Try and resolve Extension classes from the DI container

### DIFF
--- a/src/Extension/ExtensionRegistry.php
+++ b/src/Extension/ExtensionRegistry.php
@@ -92,7 +92,11 @@ class ExtensionRegistry
         $this->addComposerPackages();
 
         foreach ($this->getExtensionClasses() as $extensionClass) {
-            $extension = new $extensionClass();
+            // If the container has a public entry then resolve from there
+            $extension = $objects['container']->has($extensionClass)
+                ? $objects['container']->get($extensionClass)
+                : new $extensionClass();
+
             $extension->injectObjects($objects);
 
             if (! $runCli && method_exists($extension, 'initialize')) {


### PR DESCRIPTION
This is useful if the base extension has a complex dependency graph.

You can configure the base extension class in `services.yaml` eg:

```yml
Bolt\Extension\SomeCompany\CoolExtension:
        public: true
```

and it will then be constructed with dependencies resolved.