### PR TITLE
add config media types to files list in dropdown

### DIFF
--- a/src/Controller/Backend/Async/FileListingController.php
+++ b/src/Controller/Backend/Async/FileListingController.php
@@ -48,7 +48,7 @@ class FileListingController implements AsyncZoneInterface
     private function getFilesIndex(string $path, string $type): Collection
     {
         if ($type === 'images') {
-            $glob = '*.{jpg,png,gif,jpeg,avif,webp}';
+            $glob = sprintf('*.{%s}', $this->config->getMediaTypes()->implode(','));
         } else {
             $glob = null;
         }


### PR DESCRIPTION
Fixes #1910

get rid from hardcoded types in "Library" files dropdown (was missing .svg type)

add support to configure this types from config media types

``` yaml
# src: config\bolt\config.yaml

accept_media_types: [ gif, jpg, jpeg, png, svg, pdf, mp3, tiff ]
```