### PR TITLE
fix edit file in File management subfolders

### DIFF
--- a/src/Controller/Backend/FileEditController.php
+++ b/src/Controller/Backend/FileEditController.php
@@ -150,7 +150,11 @@ class FileEditController extends TwigAwareController implements BackendZoneInter
         $this->addFlash('success', 'file.delete_success');
 
         $folder = pathinfo($path, PATHINFO_DIRNAME);
-        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName, 'path' => $folder]);
+
+        return $this->redirectToRoute('bolt_filemanager', [
+            'location' => $locationName,
+            'path' => $folder,
+        ]);
     }
 
     /**
@@ -184,7 +188,11 @@ class FileEditController extends TwigAwareController implements BackendZoneInter
 
         $this->addFlash('success', 'file.duplicate_success');
         $folder = pathinfo($path, PATHINFO_DIRNAME);
-        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName, 'path' => $folder]);
+
+        return $this->redirectToRoute('bolt_filemanager', [
+            'location' => $locationName,
+            'path' => $folder,
+        ]);
     }
 
     /**

--- a/src/Controller/Backend/FileEditController.php
+++ b/src/Controller/Backend/FileEditController.php
@@ -149,7 +149,8 @@ class FileEditController extends TwigAwareController implements BackendZoneInter
 
         $this->addFlash('success', 'file.delete_success');
 
-        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName]);
+        $folder = pathinfo($path, PATHINFO_DIRNAME);
+        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName, 'path' => $folder]);
     }
 
     /**
@@ -181,9 +182,9 @@ class FileEditController extends TwigAwareController implements BackendZoneInter
             throw $e;
         }
 
-        $this->addFlash('success', 'file.delete_success');
-
-        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName]);
+        $this->addFlash('success', 'file.duplicate_success');
+        $folder = pathinfo($path, PATHINFO_DIRNAME);
+        return $this->redirectToRoute('bolt_filemanager', ['location' => $locationName, 'path' => $folder]);
     }
 
     /**

--- a/templates/finder/_files_actions.html.twig
+++ b/templates/finder/_files_actions.html.twig
@@ -26,14 +26,14 @@
         </a>
         <a class="dropdown-item"
            href="{{ path('bolt_file_duplicate',
-               {'location': location.key|default('files'), 'path': file.getRelativePathname, '_csrf_token': csrf_token('file-duplicate')}) }}">
+               {'location': location.key|default('files'), 'path': path ~ file.getRelativePathname, '_csrf_token': csrf_token('file-duplicate')}) }}">
             <i class="far fa-w fa-copy"></i>
             {{ 'files_cards.action_duplicate'|trans }} {{ file.getRelativePathname|excerpt(22) }}
         </a>
 
         <a class="dropdown-item delete" ,
            href="{{ path('bolt_file_delete',
-               {'location': location.key|default('files'), 'path': file.getRelativePathname, '_csrf_token': csrf_token('file-delete')}) }}"
+               {'location': location.key|default('files'), 'path': path ~ file.getRelativePathname, '_csrf_token': csrf_token('file-delete')}) }}"
            data-confirmation="{{ 'file.delete_confirm'|trans }}">
             <i class="fas fa-w fa-trash"></i>
             {{ 'files_cards.action_delete'|trans }} {{ file.getRelativePathname|excerpt(22) }}


### PR DESCRIPTION
Fixes #1914 

- add path for subfolder to delete/duplicate action
- add path to return after action
- replace success notification label for duplicate action 