### PR TITLE
phpstan: remove lock on container and database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -134,28 +134,6 @@
     },
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "scripts": {
-        "post-install-cmd": [
-            "php bin/console extensions:configure --with-config",
-            "@auto-scripts",
-            "php bin/console bolt:info"
-        ],
-        "pre-package-uninstall": [
-            "php bin/console extensions:configure --remove-services"
-        ],
-        "post-update-cmd": [
-            "php bin/console extensions:configure",
-            "@auto-scripts",
-            "php bin/console bolt:info"
-        ],
-        "auto-scripts": {
-            "cache:clear --no-warmup": "symfony-cmd",
-            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
-        },
-        "periodical-tasks": [
-            "security-checker security:check"
-        ]
-    },
     "replace": {
         "container-interop/container-interop": "*"
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,9 +5,6 @@ parameters:
     paths:
         - src
 
-    symfony:
-        container_xml_path: '%rootDir%/../../../var/cache/dev/Bolt_KernelDevDebugContainer.xml'
-
     scanDirectories:
         # In order to 'recognize' Twig functions in global scope
         - %currentWorkingDirectory%/vendor/twig/twig/src/Extension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,4 @@
 parameters:
-    tmpDir: var/cache/ecs
     level: 5
 
     paths:


### PR DESCRIPTION
Follow up to https://github.com/bolt/core/pull/1918#discussion_r496020968

## Reasoning Behind Changes

I see some first complications - https://github.com/bolt/core/runs/1177089242

It might be caused by incorrect `composer.json` setup:

```bash
       "post-install-cmd": [
            "php bin/console extensions:configure --with-config",
            "@auto-scripts",
            "php bin/console bolt:info"
        ],
        "pre-package-uninstall": [
            "php bin/console extensions:configure --remove-services"
        ],
        "post-update-cmd": [
            "php bin/console extensions:configure",
            "@auto-scripts",
            "php bin/console bolt:info"
        ],
        "auto-scripts": {
            "cache:clear --no-warmup": "symfony-cmd",
            "assets:install --symlink --relative %PUBLIC_DIR%": "symfony-cmd"
        },
```

This is seems like a **project `composer.json`**, e.g [symfony/demo](https://github.com/symfony/demo/blob/e5e5a8fff048351ea8a8fe2b418f0256eabeee12/composer.json#L75-L85) or [laravel/laravel](https://github.com/laravel/laravel/blob/a6ca5778391b150102637459ac3b2a42d78d495b/composer.json#L50-L59)


I've found these lines in [bolt/project](https://github.com/bolt/project/blob/b42dc1feb5c82952e12875096586ec6d4afc4fff/composer.json#L25-L43)

Saying that, this should be part of build script or Dockerfile, not `composer.json`.