### PR TITLE
Exclude relations from `Content::toArray()`

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -711,7 +711,6 @@ class Content
         $result['fields'] = $this->getFieldValues();
 
         $result['taxonomies'] = $this->getTaxonomyValues();
-        $result['relations'] = [];
 
         unset($result['contentTypeDefinition']);
         unset($result['contentExtension']);


### PR DESCRIPTION
Fixes #1900 

Right now there's ways to get relations both in code (using the repository) or in twig using the various filters.

I'm not sure that's the _most desirable_ way to go, but as @simongroenewolt points out it's better to _not_ have them than return something wrong.

