### PR TITLE
Change travis-ci build status in README.md to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,4 +230,4 @@ Sponsors:
 
 --------
 
-[![Build Status](https://travis-ci.org/bolt/core.svg?branch=master)](https://travis-ci.org/bolt/core) [![SymfonyInsight](https://insight.symfony.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5/mini.svg)](https://insight.symfony.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5) [![Total Downloads](https://poser.pugx.org/bolt/core/downloads)](https://packagist.org/packages/bolt/core) ![PHP from Packagist](https://img.shields.io/packagist/php-v/bolt/core)
+[![Build Status](https://travis-ci.com/bolt/core.svg?branch=master)](https://travis-ci.com/bolt/core) [![SymfonyInsight](https://insight.symfony.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5/mini.svg)](https://insight.symfony.com/projects/4d1713e3-be44-4c2e-ad92-35f65eee6bd5) [![Total Downloads](https://poser.pugx.org/bolt/core/downloads)](https://packagist.org/packages/bolt/core) ![PHP from Packagist](https://img.shields.io/packagist/php-v/bolt/core)


### PR DESCRIPTION
Clicking on the build status in the old README.md just displayed a page of travis-ci.org showing, that the repository has been migrated to travis-ci.com

This PR adjusts the image and link in the README.md to the new travis-ci.com

Don't know why the image still says "build | failing" because all the builds are green but 🤷 