### PR TITLE
Better feedback when `|related` and their ilk fail

### DIFF
--- a/templates/_partials/notification.html.twig
+++ b/templates/_partials/notification.html.twig
@@ -94,14 +94,16 @@
     <h1> {{ subject|markdown|striptags('<em><i><code>')|raw }}</h1>
     {{ body|markdown|raw }}
     <ul>
-    {% for frame in backtrace|slice(2) %}
-        <li>
-            <code>{%- if frame.type|default() is not empty -%}
+        {% for frame in backtrace|slice(2) %}
+            <li>
+                <code>{%- if frame.type|default() is not empty -%}
                     <abbr title="{{ frame.class }}">
-                    {{- frame.class|split('\\')|last()|excerpt(24) -}}</abbr>{{- frame.type -}}
-            {%- endif -%}
-            <strong>{{- frame.function -}}()</strong></code>{% if frame.line|default() %} - line {{ frame.line }}{% endif %}
+                        {{- frame.class|split('\\')|last()|excerpt(24) -}}</abbr>{{- frame.type -}}
+                    {%- endif -%}
+                    <strong>{{- frame.function -}}()</strong>
+                </code>{% if prevline|default() %} - line {{ prevline }}{% endif %}
+                {% set prevline = frame.line|default() %}
             </li>
-    {% endfor %}
+        {% endfor %}
     </ul>
 </div>


### PR DESCRIPTION
Before, when using `{% set foo = bar|related %}` was used and `bar` wasn't a Content, it'd fail like this: 

![Schermafbeelding 2020-10-02 om 16 19 38](https://user-images.githubusercontent.com/1833361/94935794-c7185700-04cd-11eb-8d73-41ff8243f970.png)

Now it shows a more helpful note: 

![Schermafbeelding 2020-10-02 om 16 19 16](https://user-images.githubusercontent.com/1833361/94935848-da2b2700-04cd-11eb-99d1-083d77cdfd8e.png)
