### PR TITLE
Dont create folders if the image can't be created

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -88,8 +88,9 @@ class ImageController
         $fileMode = $this->config->get('general/filepermissions/files', 0664);
 
         try {
+            $imageBlob = $this->buildImage($filename);
             $filesystem->mkdir(dirname($filePath), $folderMode);
-            $filesystem->dumpFile($filePath, $this->buildImage($filename));
+            $filesystem->dumpFile($filePath, $imageBlob);
             $filesystem->chmod($filePath, $fileMode);
         } catch (\Throwable $e) {
             // Fail silently, output user-friendly exception elsewhere.


### PR DESCRIPTION
I tried to fix #1928, in the meantime i found out that a folder was created in the `thumbs` directory.
This folder will also be created if the image could not be created.