### PR TITLE
Fix Buggy thumbnail url generation #1928

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -139,23 +139,23 @@ class ImageController
         $this->parameters = [
             'w' => is_numeric($raw[0]) ? (int) $raw[0] : 400,
             'h' => is_numeric($raw[1]) ? (int) $raw[1] : 300,
-			'fit' => 'default',
-			'location' => 'files',
+            'fit' => 'default',
+            'location' => 'files',
         ];
 
-		if (isset($raw[3])) {
-			$this->parameters['fit'] = $this->parseFit($raw[2]);
-			$this->parameters['location'] = $raw[3];
+        if (isset($raw[3])) {
+            $this->parameters['fit'] = $this->parseFit($raw[2]);
+            $this->parameters['location'] = $raw[3];
 
-		} else if (isset($raw[2])) {
-			$posible_fit = $this->parseFit($raw[2]);
+        } else if (isset($raw[2])) {
+            $posible_fit = $this->parseFit($raw[2]);
 
-			if ($this->testFit($posible_fit)) {
-				$this->parameters['fit'] = $posible_fit;
-			} else {
-				$this->parameters['location'] = $raw[2];
-			}
-		}
+            if ($this->testFit($posible_fit)) {
+                $this->parameters['fit'] = $posible_fit;
+            } else {
+                $this->parameters['location'] = $raw[2];
+            }
+        }
     }
 
     private function isSvg(string $filename): bool
@@ -174,9 +174,10 @@ class ImageController
         return array_key_exists('extension', $pathinfo) && in_array($pathinfo['extension'], $imageExtensions, true);
     }
 
-	private function testFit(string $fit): bool {
-		return (bool) preg_match('/^(contain|max|fill|stretch|crop)(-.+)?/', $fit);
-	}
+    private function testFit(string $fit): bool
+    {
+        return (bool) preg_match('/^(contain|max|fill|stretch|crop)(-.+)?/', $fit);
+    }
 
     public function parseFit(string $fit): string
     {

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -146,7 +146,6 @@ class ImageController
         if (isset($raw[3])) {
             $this->parameters['fit'] = $this->parseFit($raw[2]);
             $this->parameters['location'] = $raw[3];
-
         } elseif (isset($raw[2])) {
             $posible_fit = $this->parseFit($raw[2]);
 

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -20,8 +20,6 @@ class ImageController
     /** @var Config */
     private $config;
 
-    private $thumbnailOptions = ['w', 'h', 'fit'];
-
     /** @var Server */
     private $server;
 
@@ -136,24 +134,28 @@ class ImageController
 
     private function parseParameters(string $paramString): void
     {
-        $raw = explode('×', str_replace('x', '×', $paramString));
+        $raw = explode('×', $paramString);
 
         $this->parameters = [
             'w' => is_numeric($raw[0]) ? (int) $raw[0] : 400,
-            'h' => ! empty($raw[1]) && is_numeric($raw[1]) ? (int) $raw[1] : 300,
-            'fit' => ! empty($raw[2]) ? $this->parseFit($raw[2]) : 'default',
+            'h' => is_numeric($raw[1]) ? (int) $raw[1] : 300,
+			'fit' => 'default',
+			'location' => 'files',
         ];
 
-        foreach ($raw as $rawParameter) {
-            if (mb_strpos($rawParameter, '=') !== false) {
-                [$key, $value] = explode('=', $rawParameter);
+		if (isset($raw[3])) {
+			$this->parameters['fit'] = $this->parseFit($raw[2]);
+			$this->parameters['location'] = $raw[3];
 
-                // @todo Add more thumbnailing options here, perhaps.
-                if (in_array($key, $this->thumbnailOptions, true) && ! in_array($key, $this->parameters, true)) {
-                    $this->parameters[$key] = $value;
-                }
-            }
-        }
+		} else if (isset($raw[2])) {
+			$posible_fit = $this->parseFit($raw[2]);
+
+			if ($this->testFit($posible_fit)) {
+				$this->parameters['fit'] = $posible_fit;
+			} else {
+				$this->parameters['location'] = $raw[2];
+			}
+		}
     }
 
     private function isSvg(string $filename): bool
@@ -171,6 +173,10 @@ class ImageController
 
         return array_key_exists('extension', $pathinfo) && in_array($pathinfo['extension'], $imageExtensions, true);
     }
+
+	private function testFit(string $fit): bool {
+		return (bool) preg_match('/^(contain|max|fill|stretch|crop)(-.+)?/', $fit);
+	}
 
     public function parseFit(string $fit): string
     {

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -147,7 +147,7 @@ class ImageController
             $this->parameters['fit'] = $this->parseFit($raw[2]);
             $this->parameters['location'] = $raw[3];
 
-        } else if (isset($raw[2])) {
+        } elseif (isset($raw[2])) {
             $posible_fit = $this->parseFit($raw[2]);
 
             if ($this->testFit($posible_fit)) {

--- a/src/Utils/ThumbnailHelper.php
+++ b/src/Utils/ThumbnailHelper.php
@@ -17,7 +17,7 @@ class ThumbnailHelper
         $this->config = $config;
     }
 
-    public function parameters(?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null): string
+    private function parameters(?int $width = null, ?int $height = null, ?string $fit = null, ?string $location = null): string
     {
         if (! $width && ! $height) {
             $width = $this->config->get('general/thumbnails/default_thumbnail/0', 320);
@@ -30,21 +30,11 @@ class ThumbnailHelper
             $height = 10000;
         }
 
-        $paramString = sprintf('%s×%s', $width, $height);
-
-        if ($fit) {
-            $paramString .= '×' . $fit;
+        if ($location === 'files') {
+            $location = null;
         }
 
-        if ($location && $location !== 'files') {
-            $paramString .= '×location=' . $location;
-        }
-
-        if ($path) {
-            $paramString .= '×path=' . $path;
-        }
-
-        return $paramString;
+        return implode('×', array_filter([$width, $height, $fit, $location]));
     }
 
     public function path(?string $filename = null, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null): string
@@ -53,7 +43,11 @@ class ThumbnailHelper
             return '/assets/images/placeholder.png';
         }
 
-        $paramString = $this->parameters($width, $height, $location, $path, $fit);
+        if ($path) {
+            $filename = $path . '/' . $filename;
+        }
+
+        $paramString = $this->parameters($width, $height, $fit, $location);
         $filename = Str::ensureStartsWith($filename, '/');
 
         return sprintf('/thumbs/%s%s', $paramString, $filename);


### PR DESCRIPTION
- Do not split parameters using "x", could cause an other bug when the `location` or `fit` contains an "x".
- Do not use "parameter=value" syntax anymore.
- Assumes always sending both "WIDTH×HEIGHT" parameters.
