### PR TITLE
[WIP] Feature/server side validation support

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -129,21 +129,19 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
     /**
      * @Route("/edit/{id}", name="bolt_content_edit_post", methods={"POST"}, requirements={"id": "\d+"})
      */
-    public function save(?Content $content = null, ContentValidatorInterface $contentValidator = null): Response
+    public function save(?Content $content = null, ?ContentValidatorInterface $contentValidator = null): Response
     {
         $this->validateCsrf('editrecord');
 
         [$content, $relations] = $this->contentFromPost($content);
 
         if ($contentValidator) {
-
             // Question: do we want to validate the formData, or do we want to validate the content created
             // based on the formdata?
             // currently we do the latter.
 //            $formData = $this->request->request->all();
 //            $locale = $this->getPostedLocale($formData) ?: $content->getDefaultLocale();
 
-            //
             // about relations:
             // there might be weird edge-cases when a relation is added in the form, but not
             // existing in the db anymore, combined with min/max validation rules that will fail/succeed
@@ -151,8 +149,6 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
             // that are in the form of the user.
             // This should only be an issue of date is being deleted from another place while an end-user
             // is creating content via the backend forms.
-            //
-
             $constraintViolations = $contentValidator->validate($content, $relations);
             if (count($constraintViolations) > 0) {
                 return $this->renderEditor($content, $constraintViolations);
@@ -527,6 +523,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
             $this->em->persist($relation);
             $relationsResult[] = $id;
         }
+
         return $relationsResult;
     }
 
@@ -551,10 +548,6 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         return $post['_edit_locale'] ?: null;
     }
 
-    /**
-     * @param Content $content
-     * @return Response
-     */
     private function renderEditor(Content $content, $errors = null): Response
     {
         $twigvars = [

--- a/src/Demo/DemoContentValidator.php
+++ b/src/Demo/DemoContentValidator.php
@@ -1,8 +1,8 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Bolt\Demo;
-
 
 use Bolt\Entity\Content;
 use Symfony\Component\Validator\Constraints\Collection;
@@ -21,9 +21,9 @@ class DemoContentValidator implements \Bolt\Validator\ContentValidatorInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritdoc}
      */
-    public function validate(Content $content, array $relations)
+    public function validate(Content $content, array $relations): array
     {
         // manually created validator for showcases
         if ($content->getContentType() === 'showcases') {
@@ -32,34 +32,42 @@ class DemoContentValidator implements \Bolt\Validator\ContentValidatorInterface
             $value = [
                 'fields' => $content->getFieldValues(),
                 'taxonomy' => $content->getTaxonomyValues(),
-                'relationship' => $relations
+                'relationship' => $relations,
             ];
 
             // handwritten constraints - keep as is for really small validation needs, and otherwise
             // devise a system to read validation from contenttypes.yaml
             $constraints = new Collection([
-                'fields' => [ // <-- 'fields' attribute of collection constraint
-                    'fields' =>  new Collection([ // <-- 'fields' property of bolt Content class / form
-                        'fields' => [ // <-- 'fields' attribute of collection constraint
-                            'title' => new Length(['min' => 10])
+                // 'fields' attribute of collection constraint
+                'fields' => [
+                    // 'fields' property of bolt Content class / form
+                    'fields' => new Collection([
+                        // 'fields' attribute of collection constraint
+                        'fields' => [
+                            'title' => new Length(['min' => 10]),
                         ],
-                        'allowExtraFields' => true
+                        'allowExtraFields' => true,
                     ]),
                     'taxonomy' => new Collection([
-                        'fields' => [ // <-- 'fields' attribute of collection constraint
-                            'categories' => new Count(['max' => 2]) // allow max 2 categories
+                        // 'fields' attribute of collection constraint
+                        'fields' => [
+                            // allow max 2 categories
+                            'categories' => new Count(['max' => 2]),
                         ],
-                        'allowExtraFields' => true
+                        'allowExtraFields' => true,
                     ]),
-                    'relationship' => new Collection([ // <-- 'relationship' property of form - this is not part of the Content class
-                        'fields' => [ // <-- 'fields' attribute of collection constraint
-                            'pages' => new Count(['min' => 2])
+                    // 'relationship' property of form - this is not part of the Content class
+                    'relationship' => new Collection([
+                        // 'fields' attribute of collection constraint
+                        'fields' => [
+                            'pages' => new Count(['min' => 2]),
                         ],
-                        'allowExtraFields' => true
+                        'allowExtraFields' => true,
                     ]),
                 ],
-                'allowExtraFields' => true
+                'allowExtraFields' => true,
             ]);
+
             return $this->validator->validate($value, $constraints);
         }
         // everything that was not matched before is ignored for validation -> this means it will always pass

--- a/src/Demo/DemoContentValidator.php
+++ b/src/Demo/DemoContentValidator.php
@@ -23,7 +23,7 @@ class DemoContentValidator implements \Bolt\Validator\ContentValidatorInterface
     /**
      * {@inheritdoc}
      */
-    public function validate(Content $content, array $relations): array
+    public function validate(Content $content, array $relations)
     {
         // manually created validator for showcases
         if ($content->getContentType() === 'showcases') {

--- a/src/Demo/DemoContentValidator.php
+++ b/src/Demo/DemoContentValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace Bolt\Demo;
+
+
+use Bolt\Entity\Content;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class DemoContentValidator implements \Bolt\Validator\ContentValidatorInterface
+{
+    /** @var ValidatorInterface */
+    private $validator;
+
+    public function __construct(ValidatorInterface $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(Content $content)
+    {
+        // handcrafted validator for the length of the title in entries
+        if ($content->getContentType() === 'entries') {
+            // set up a fake value that looks like an 'Entry' to validate -- this is how I see a simple solution
+            // being added. Of course this is not flexible at all!
+            $value = [
+                'fields' => [
+                    'title' => $content->getFieldValue('title')
+                ]
+            ];
+            // handwritten validation - title >= 10 characters
+            $constraints = new Collection([
+                'fields' => [
+                    'fields' =>  new Collection([
+                        'fields' => [
+                            'title' => new Length(['min' => 10])
+                        ],
+                        'allowExtraFields' => true
+                    ])
+                ],
+                'allowExtraFields' => true
+            ]);
+            return $this->validator->validate($value, $constraints);
+        }
+        // everything that is not of type 'entries' is ignored for validation.
+        return [];
+    }
+}

--- a/src/Validator/ContentValidatorInterface.php
+++ b/src/Validator/ContentValidatorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Bolt\Validator;
 
 use Bolt\Entity\Content;
-use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 interface ContentValidatorInterface
 {

--- a/src/Validator/ContentValidatorInterface.php
+++ b/src/Validator/ContentValidatorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Validator;
+
+use Bolt\Entity\Content;
+
+interface ContentValidatorInterface
+{
+    /**
+     * Validates the content provided, returns a list of constraint violations if there are any.
+     *
+     * This function is modeled on the ValidatorInterface->validate() that is part of the symfony/validation package.
+     * The intention is to support Symfony Validation, but not require it.
+     *
+     * The function should return an array-like structure, for example ConstraintViolationListInterface, an array, or
+     * a class implementing \Traversable, \Countable, \ArrayAccess. Basically anything that will allow php to show
+     * the violations to the user.
+     *
+     * The items in the array should follow the format used by ConstraintViolationInterface from the symfony/validator
+     * package - in the form of an associative array, class with public members, or class with getters.
+     *
+     * How to validate the content is up to the implementer of the interface.
+     *
+     * @return array or array-like structure with constraint violations
+     */
+    public function validate(Content $content);
+}

--- a/src/Validator/ContentValidatorInterface.php
+++ b/src/Validator/ContentValidatorInterface.php
@@ -23,10 +23,10 @@ interface ContentValidatorInterface
      *
      * How to validate the content is up to the implementer of the interface.
      *
-     * @param Content $content
-     * @param array $relations with relation name as keys, arrays with ids of related items as values
+     * @param Content $content main content to validate
+     * @param array $relations array with relation name as keys and arrays with ids of related items as values
      *
      * @return array or array-like structure with constraint violations
      */
-    public function validate(Content $content, array $relations);
+    public function validate(Content $content, array $relations): array;
 }

--- a/src/Validator/ContentValidatorInterface.php
+++ b/src/Validator/ContentValidatorInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Validator;
 
 use Bolt\Entity\Content;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 interface ContentValidatorInterface
 {
@@ -26,7 +27,7 @@ interface ContentValidatorInterface
      * @param Content $content main content to validate
      * @param array $relations array with relation name as keys and arrays with ids of related items as values
      *
-     * @return array or array-like structure with constraint violations
+     * returns array|ConstraintViolationListInterface or array-like structure with constraint violations
      */
-    public function validate(Content $content, array $relations): array;
+    public function validate(Content $content, array $relations);
 }

--- a/src/Validator/ContentValidatorInterface.php
+++ b/src/Validator/ContentValidatorInterface.php
@@ -23,7 +23,10 @@ interface ContentValidatorInterface
      *
      * How to validate the content is up to the implementer of the interface.
      *
+     * @param Content $content
+     * @param array $relations with relation name as keys, arrays with ids of related items as values
+     *
      * @return array or array-like structure with constraint violations
      */
-    public function validate(Content $content);
+    public function validate(Content $content, array $relations);
 }

--- a/templates/content/edit.html.twig
+++ b/templates/content/edit.html.twig
@@ -45,6 +45,14 @@
         </div>
     {% endif %}
 
+    {% if errors is defined %}
+        {%for error in errors %}
+            <div class="alert alert-danger" role="alert">
+                {{ error.propertyPath }}: {{error.message}}
+            </div>
+        {%endfor%}
+    {% endif %}
+
     <form method="post" id="editcontent">
 
         <input type="hidden" name="_csrf_token" value="{{ csrf_token('editrecord') }}">


### PR DESCRIPTION
NOTE: this PR is meant for discussion, see https://github.com/bolt/core/issues/1931 -- please don't merge it just yet.

These changes show a possible change to bolt to make it _support_ server side validation. This change is not meant to add validation itself to bolt (at the moment), just to make it possible for other developers without touching the core.

At the moment a class Bolt\Demo\DemoContentValidator is included to test the changes. Without using the suggested support structure it's hard to see if it is good enough.

Currently missing: field-level feedback in the editor.