### PR TITLE
Use ->loadEnv() instead of ->load() to support the 'standard' Symfony…

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -19,7 +19,7 @@ if (!isset($_SERVER['APP_ENV'])) {
     if (!class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
-    (new Dotenv())->load(__DIR__.'/../.env');
+    (new Dotenv())->loadEnv(__DIR__.'/../.env');
 }
 
 $input = new ArgvInput();

--- a/public/index.php
+++ b/public/index.php
@@ -14,7 +14,7 @@ if (! isset($_SERVER['APP_ENV'])) {
     if (! class_exists(Dotenv::class)) {
         throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
     }
-    (new Dotenv())->load(__DIR__.'/../.env');
+    (new Dotenv())->loadEnv(__DIR__.'/../.env');
 }
 
 $env = $_SERVER['APP_ENV'] ?? 'dev';


### PR DESCRIPTION
… way of loading .env files. This means .env.<environment> for environment specific overrides (e.g. .env.prod) and .env.local and .env.<environment>.local to make local changes (keep your .local files out of version control)

See https://github.com/bolt/core/issues/1973