### PR TITLE
Do not cast the order by expression for MySQL drivers as casting a TE…

### DIFF
--- a/src/Storage/Directive/OrderDirective.php
+++ b/src/Storage/Directive/OrderDirective.php
@@ -115,10 +115,17 @@ class OrderDirective
             } else {
                 // Note the `lower()` in the `addOrderBy()`. It is essential to sorting the
                 // results correctly. See also https://github.com/bolt/core/issues/1190
-                // again: lower breaks postgresql jsonb compatibility, first cast as txt
+                // again: lower breaks postgresql jsonb compatibility, first cast as txt (but not for MySQL/MariaDB)
+                $backend_driver = $query->getQueryBuilder()->getEntityManager()->getConnection()->getDatabasePlatform()->getName();
+                $lowerExpression = $translationsAlias . '.value';
+
+                if (mb_strpos($backend_driver, 'mysql') === false) {
+                    $lowerExpression = 'CAST(' . $lowerExpression . ' as TEXT)';
+                }
+
                 $query
                     ->getQueryBuilder()
-                    ->addOrderBy('lower(CAST(' . $translationsAlias . '.value as TEXT))', $direction);
+                    ->addOrderBy('lower(' . $lowerExpression . ')', $direction);
             }
             $query->incrementIndex();
         } else {


### PR DESCRIPTION
Fixes #1971 - the CAST to TEXT causes an error on MySQL.

This follows similar logic implemented in src/Doctrine/Query/Cast.php.

Getting the backend driver name (e.g. mysql) is a long chain of method calls but I cannot see any other way.  It also uses `getDatabasePlatform()->getName()` instead of the `getDriver()->getName()` call in `Cast.php` as the docblock on that method suggests it is deprecated (but no alternative suggested.)