### PR TITLE
Use DatabasePlatform instead of Driver to check for MySQL/MariaDB

### DIFF
--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -20,7 +20,7 @@ class Cast extends FunctionNode
 
     public function getSql(SqlWalker $sqlWalker): string
     {
-        $backend_driver = $sqlWalker->getConnection()->getDriver()->getName();
+        $backend_driver = $sqlWalker->getConnection()->getDatabasePlatform()->getName();
 
         // test if we are using MySQL
         if (mb_strpos($backend_driver, 'mysql') !== false) {


### PR DESCRIPTION
Replace getDriver()->getName() call with getDatabasePlatform()->getName() to avoid [a deprecation in Doctrine](https://github.com/doctrine/dbal/pull/3558).

This returns `mysql` instead of `pdo_mysql` on MariaDB, at least, so the `mb_strpos` check should work just fine as-is.