### PR TITLE
Filter by any field

### DIFF
--- a/src/Controller/Backend/ListingController.php
+++ b/src/Controller/Backend/ListingController.php
@@ -56,6 +56,7 @@ class ListingController extends TwigAwareController implements BackendZoneInterf
             'records' => $records,
             'sortBy' => $this->getFromRequest('sortBy'),
             'filterValue' => $this->getFromRequest('filter'),
+            'filterKey' => $this->getFromRequest('filterKey'),
         ]);
     }
 }

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -202,7 +202,8 @@ class TwigAwareController extends AbstractController
         }
 
         if ($this->request->get('filter')) {
-            $params['anyField'] = '%' . $this->getFromRequest('filter') . '%';
+            $key = $this->request->get('filterKey', 'anyField');
+            $params[$key] = '%' . $this->getFromRequest('filter') . '%';
         }
 
         if ($this->request->get('taxonomy')) {

--- a/templates/content/listing.html.twig
+++ b/templates/content/listing.html.twig
@@ -104,6 +104,16 @@
                         <input class="form-control" type="text" name="filter" id="content-filter" value="{{ filterValue }}"
                                placeholder="{{ 'listing.placeholder_filter'|trans }}"/>
                     </p>
+
+                    <p>
+                        <label for="filterKey">{{ 'listing.title_filterby_field'|trans }}</label>:
+                        <select name="filterKey" class="form-control">
+                            <option value="anyField"></option>
+                            {% for name, field in contentType.fields %}
+                                <option value="{{ name }}" {% if name == filterKey|default %}selected {% endif %}>{{ field.label }}</option>
+                            {% endfor %}
+                        </select>
+                    </p>
                 </div>
 
                     {{ macro.button('listing.button_filter', 'filter', 'tertiary mb-0', {'type': 'submit'}) }}

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2373,5 +2373,11 @@
         <target>Select …</target>
       </segment>
     </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filter by field</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes #1965 

It also works for things which are not fields, e.g .status=published, but not through the UI.

It would be nice, in a future PR, to allow editors to filter by date, status, author... All things which are possible with this, _once the query params are set correctly_.