### PR TITLE
Show actual error message from upload error response instead of [object Object]

### DIFF
--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -264,7 +264,14 @@ export default {
                     this.progress = 0;
                 })
                 .catch(err => {
-                    bootbox.alert(err.response.data + '<br>File did not upload.');
+                    const responseData = err.response.data;
+                    let errorMessage = 'unknown error';
+                    if (typeof responseData === 'string' || responseData instanceof String) {
+                        errorMessage = responseData;
+                    } else if (responseData.error && responseData.error.message) {
+                        errorMessage = responseData.error.message;
+                    }
+                    bootbox.alert(errorMessage + '<br>File did not upload.');
                     console.warn(err);
                     this.progress = 0;
                 });


### PR DESCRIPTION
When you upload a file that is too large you currently get an error showing [object Object], this change checks if there is a error message in that object, and displays that instead.

This fixes the [object Object] issue mentioned in https://github.com/bolt/core/issues/2000