### PR TITLE
Add Nelmio Security Bundle, for sane default secure headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "league/glide-symfony": "^1.0",
         "miljar/php-exif": "^0.6.4",
         "nelmio/cors-bundle": "^2.1",
+        "nelmio/security-bundle": "^2.10",
         "nesbot/carbon": "^2.39",
         "peterkahl/country-code-to-emoji-flag": "^1.2",
         "php-translation/symfony-bundle": "^0.12",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -25,4 +25,5 @@ return [
     Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
     Translation\Bundle\TranslationBundle::class => ['all' => true],
     Translation\PlatformAdapter\Loco\Bridge\Symfony\TranslationAdapterLocoBundle::class => ['dev' => true, 'local' => true],
+    Nelmio\SecurityBundle\NelmioSecurityBundle::class => ['all' => true],
 ];

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -33,10 +33,10 @@ nelmio_security:
 
     # Forces HTTPS handling, DO NOT combine with flexible mode and
     # make sure you have SSL working on your site before enabling this
-    forced_ssl:
-        hsts_max_age: 2592000 # 30 days
-        hsts_subdomains: true
-        redirect_status_code: 302 # default, switch to 301 for permanent redirects
+    # forced_ssl:
+    #    hsts_max_age: 2592000 # 30 days
+    #    hsts_subdomains: true
+    #    redirect_status_code: 302 # default, switch to 301 for permanent redirects
 
     # Flexible HTTPS handling, read the detailed config info and make sure you
     # have SSL working on your site before enabling this

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -1,0 +1,50 @@
+nelmio_security:
+
+    # Signs/verifies all cookies
+    signed_cookie:
+        names: ['*']
+
+    # Prevents framing of the entire site
+    clickjacking:
+        paths:
+            '^/.*': DENY
+
+    # Disables content type sniffing for script resources
+    content_type:
+        nosniff: true
+
+    # Forces Microsoft's XSS-Protection with its block mode
+    xss_protection:
+        enabled: true
+        mode_block: true
+
+    # Send a full URL in the `Referer` header when performing a same-origin
+    # request, only send the origin of the document to secure destination
+    # (HTTPS->HTTPS), and send no header to a less secure destination
+    # (HTTPS->HTTP). If `strict-origin-when-cross-origin` is not supported, use
+    # `no-referrer` policy, no referrer information is sent along with
+    # requests.
+
+    referrer_policy:
+        enabled: true
+        policies:
+            - 'no-referrer'
+            - 'strict-origin-when-cross-origin'
+
+    # Forces HTTPS handling, DO NOT combine with flexible mode and
+    # make sure you have SSL working on your site before enabling this
+    forced_ssl:
+        hsts_max_age: 2592000 # 30 days
+        hsts_subdomains: true
+        redirect_status_code: 302 # default, switch to 301 for permanent redirects
+
+    # Flexible HTTPS handling, read the detailed config info and make sure you
+    # have SSL working on your site before enabling this
+    # flexible_ssl:
+    #     cookie_name: auth
+    #     unsecured_logout: false
+
+    # Prevents redirections outside the website's domain
+    # external_redirects:
+    #     abort: true
+    #     log: true

--- a/symfony.lock
+++ b/symfony.lock
@@ -356,6 +356,18 @@
             "config/packages/nelmio_cors.yaml"
         ]
     },
+    "nelmio/security-bundle": {
+        "version": "2.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "2.4",
+            "ref": "65726efb67ff51d89de38195bc0d230fa811f64d"
+        },
+        "files": [
+            "config/packages/nelmio_security.yaml"
+        ]
+    },
     "nesbot/carbon": {
         "version": "2.30.0"
     },


### PR DESCRIPTION
For 4.2!

This packages adds sane default security headers to your pages. See screenshot before: 

![Screenshot 2020-10-18 at 14 53 12](https://user-images.githubusercontent.com/1833361/96368035-b9abcf80-1151-11eb-9d6d-70f918dccb4c.png)


And after: 

![Screenshot 2020-10-18 at 14 52 03](https://user-images.githubusercontent.com/1833361/96368032-b6184880-1151-11eb-85ca-774b0962008c.png)
