### PR TITLE
Update _collection_buttons.html.twig

### DIFF
--- a/templates/_partials/fields/_collection_buttons.html.twig
+++ b/templates/_partials/fields/_collection_buttons.html.twig
@@ -1,5 +1,5 @@
 {% if in_compound is defined %}
-    <div class="btn-group ml-2" role="group" aria-label="Collection buttons">
+    <div class="btn-group ml-auto mr-2" role="group" aria-label="Collection buttons">
     <button class='action-move-up-collection-item btn btn-light btn-sm' style="white-space: nowrap" {% if is_first is defined and is_first %} disabled {% endif %}>
         <i class="fas fa-fw fa-chevron-up"></i>
         {{ 'collection.move_item_up'|trans }}


### PR DESCRIPTION
Aligns button group on the right side of its collection header.
See comment here: https://github.com/bolt/core/commit/492c45649f096d2a5318c1bcbbede6825304a88e#commitcomment-43284379

Fixes: https://github.com/bolt/core/issues/2014