### PR TITLE
Changed name of generic taxonomy config file identifier

### DIFF
--- a/src/TemplateChooser.php
+++ b/src/TemplateChooser.php
@@ -125,7 +125,7 @@ class TemplateChooser
         $templates = new Collection();
 
         // First candidate: defined specifically in the taxonomy
-        $templates->push($this->config->get('taxonomy/' . $taxonomyslug . '/listing_template'));
+        $templates->push($this->config->get('taxonomies/' . $taxonomyslug . '/listing_template'));
 
         // Second candidate: Theme-specific config.yml file.
         $templates->push($this->config->get('theme/listing_template'));


### PR DESCRIPTION
I wasn't able to set the listing template for a taxonomy in taxonomy.yml. Did some snooping in the code and found that this line was referring to the taxonomy config by the wrong identifier. Just changed it to the new identifier and I could now set the listing template in my taxonomy.yml.

Hope I'm putting the pr in the right place, followed the instructions from the Contributing documentation online. There was no issue so I just named it after what I did.