### PR TITLE
Don't break on unknown 'fit' parameter

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -196,9 +196,8 @@ class ImageController
                 return 'stretch';
             case 'c':
             case 'crop':
-                return 'crop';
             default:
-                return $fit;
+                return 'crop';
         }
     }
 }


### PR DESCRIPTION
If we have a seemingly reasonable URL like `thumbs/580×405×resize/foo/bar.jpg` Bolt shouldn't throw a `500`, but just show the image instead.