### PR TITLE
Project specific extension bug in ExtensionExtension.php

### DIFF
--- a/src/Twig/ExtensionExtension.php
+++ b/src/Twig/ExtensionExtension.php
@@ -48,8 +48,9 @@ class ExtensionExtension extends AbstractExtension
         $rows = [];
 
         foreach ($extensions as $extension) {
+            $packageName = $extension->getComposerPackage() ? $extension->getComposerPackage()->getName() : 'No Package';
             $rows[] = [
-                'package' => $extension->getComposerPackage()->getName(),
+                'package' => $packageName,
                 'class' => $extension->getClass(),
                 'name' => $extension->getName(),
             ];


### PR DESCRIPTION
When a project specific extension is created an exception is throwed in front end because there is no composer package name.