### PR TITLE
Taxonomy singular slug fix part 2

### DIFF
--- a/src/Entity/Taxonomy.php
+++ b/src/Entity/Taxonomy.php
@@ -107,7 +107,7 @@ class Taxonomy
     public function getTaxonomyTypeSlug(): string
     {
         if ($this->getDefinition() === null) {
-            throw new \RuntimeException('Taxonomy not fully initialized');
+            return $this->getType();
         }
 
         return $this->getDefinition()->get('slug');
@@ -116,7 +116,7 @@ class Taxonomy
     public function getTaxonomyTypeSingularSlug(): string
     {
         if ($this->getDefinition() === null) {
-            throw new \RuntimeException('Taxonomy not fully initialized');
+            return $this->getType();
         }
 
         return $this->getDefinition()->get('singular_slug');


### PR DESCRIPTION
Following on from #2044, this prevents an exception being thrown when the `TaxonomyFillListener` has not been added to `services.yml`.  Any existing links will still generate as '/categories/something', for example, until the new listener is added.

@bobdenotter please review this before the next 4.1 release or it will break existing sites if `services.yml` is not updated.