### PR TITLE
allow rel attribute by default

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -157,7 +157,7 @@ filepermissions:
 # will be allowed, regardless of it being in the `allowed_tags` setting.
 htmlcleaner:
     allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dt, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption, sub, super, figure, figcaption ]
-    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan ]
+    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, rel ]
     allowed_frame_targets: [ _blank, _self, _parent, _top ]
 
 # Define the file types (extensions to be exact) that are acceptable for upload

--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -157,7 +157,7 @@ filepermissions:
 # will be allowed, regardless of it being in the `allowed_tags` setting.
 htmlcleaner:
     allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dt, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption, sub, super, figure, figcaption ]
-    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, rel ]
+    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, rel, download, hreflang ]
     allowed_frame_targets: [ _blank, _self, _parent, _top ]
 
 # Define the file types (extensions to be exact) that are acceptable for upload


### PR DESCRIPTION
Allow rel attribute when sanitize HTML

Same proposition for Bolt 4 as made here --> https://github.com/bolt/bolt/pull/7885 for Bolt 3.7 

As the ckeditor link options have 'rel' tags in there 'advanced' tab it would be a good idea to allow rel tag by default/ Because it's a bit confusing for the user to be allowed to add the tag but to not store it in the database.

(see discussion here (talking about 3.7) --> https://boltcms.slack.com/archives/C094GL7ME/p1603187487310500)