### PR TITLE
Remove extraneous whitespace in excerpts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "api-platform/core": "^2.5",
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",
-        "bolt/common": "^2.1.6",
+        "bolt/common": "^2.1.10",
         "cocur/slugify": "^4.0",
         "composer/composer": "^2.0",
         "composer/package-versions-deprecated": "^1.11",

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -33,7 +33,6 @@ use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tightenco\Collect\Support\Collection;
-use Tightenco\Collect\Support\Collection as LaravelCollection;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Markup;
@@ -267,7 +266,7 @@ class ContentExtension extends AbstractExtension
             $post = '';
         }
 
-        return $pre . Excerpt::getExcerpt(rtrim($excerpt, '. '), $length, $focus) . $post;
+        return $pre . Excerpt::getExcerpt($excerpt, $length, $focus) . $post;
     }
 
     private function getFieldBasedExcerpt(Content $content, int $length, bool $includeTitle = false): string
@@ -477,7 +476,7 @@ class ContentExtension extends AbstractExtension
         return new Collection($taxonomies);
     }
 
-    public function getListTemplates(TemplateselectField $field): LaravelCollection
+    public function getListTemplates(TemplateselectField $field): Collection
     {
         $definition = $field->getDefinition();
         $current = current($field->getValue());
@@ -517,7 +516,7 @@ class ContentExtension extends AbstractExtension
             ];
         }
 
-        return new LaravelCollection($options);
+        return new Collection($options);
     }
 
     public function pager(Environment $twig, ?Pagerfanta $records = null, string $template = '@bolt/helpers/_pager_basic.html.twig', string $class = 'pagination', int $surround = 3)
@@ -542,7 +541,7 @@ class ContentExtension extends AbstractExtension
         return $twig->render($template, $context);
     }
 
-    public function selectOptions(Field $field): LaravelCollection
+    public function selectOptions(Field $field): Collection
     {
         $values = $field->getDefinition()->get('values');
 
@@ -553,7 +552,7 @@ class ContentExtension extends AbstractExtension
         return $this->selectOptionsContentType($field);
     }
 
-    private function selectOptionsArray(Field $field): LaravelCollection
+    private function selectOptionsArray(Field $field): Collection
     {
         $values = $field->getDefinition()->get('values');
         $currentValues = $field->getValue();
@@ -572,7 +571,7 @@ class ContentExtension extends AbstractExtension
         }
 
         if (! is_iterable($values)) {
-            return new LaravelCollection($options);
+            return new Collection($options);
         }
 
         foreach ($values as $key => $value) {
@@ -583,10 +582,10 @@ class ContentExtension extends AbstractExtension
             ];
         }
 
-        return new LaravelCollection($options);
+        return new Collection($options);
     }
 
-    private function selectOptionsContentType(Field $field): LaravelCollection
+    private function selectOptionsContentType(Field $field): Collection
     {
         [ $contentTypeSlug, $format ] = explode('/', $field->getDefinition()->get('values'));
 
@@ -621,10 +620,10 @@ class ContentExtension extends AbstractExtension
             ];
         }
 
-        return new LaravelCollection($options);
+        return new Collection($options);
     }
 
-    public function taxonomyOptions(LaravelCollection $taxonomy): LaravelCollection
+    public function taxonomyOptions(Collection $taxonomy): Collection
     {
         $options = [];
 
@@ -652,10 +651,10 @@ class ContentExtension extends AbstractExtension
             ];
         }
 
-        return new LaravelCollection($options);
+        return new Collection($options);
     }
 
-    public function taxonomyValues(\Doctrine\Common\Collections\Collection $current, LaravelCollection $taxonomy): LaravelCollection
+    public function taxonomyValues(\Doctrine\Common\Collections\Collection $current, Collection $taxonomy): Collection
     {
         $values = [];
 
@@ -671,7 +670,7 @@ class ContentExtension extends AbstractExtension
             $values[] = key($taxonomy['options']);
         }
 
-        return new LaravelCollection($values);
+        return new Collection($values);
     }
 
     public function icon(?Content $record = null, string $icon = 'question-circle'): string

--- a/src/Utils/Excerpt.php
+++ b/src/Utils/Excerpt.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bolt\Utils;
 
+use Bolt\Common\Str;
+
 class Excerpt
 {
     public static function getExcerpt(string $text, int $length = 200, $focus = null): string
@@ -14,7 +16,7 @@ class Excerpt
             $text = Html::trimText($text, $length);
         }
 
-        return trim($text);
+        return Str::cleanWhitespace($text);
     }
 
     /**

--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -28,7 +28,7 @@ class Html
             $newLength = $desiredLength;
         }
 
-        $str = trim(strip_tags($str));
+        $str = Str::cleanWhitespace(strip_tags($str));
 
         $str = filter_var($str, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 
@@ -40,7 +40,7 @@ class Html
                 // Check for too long cutoff
                 if (mb_strlen($str) - $lastSpace >= $cutOffCap) {
                     // Trim the ellipse, as we do not want a space now
-                    return $str . trim($ellipseStr);
+                    return $str . Str::cleanWhitespace($ellipseStr);
                 }
                 $str = mb_substr($str, 0, $lastSpace);
             }


### PR DESCRIPTION
Before, excerpts could look like `This is an excerpt.            With two lines of text.                  Or even mo…`

In HTML this isn't a big deal, but it is when generating - say - SEO / OG tags. 


Edit: Github refuses to render the extra whitespace 🤦 