### PR TITLE
Fallback to default locale when not explicitly given in URL

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -182,6 +182,10 @@ upload_location: "{contenttype}/{year}/{month}/"
 curl_options:
     verify_peer: false
 
+# Various settings about Bolt's built-in localization features.
+localization:
+    fallback_when_missing: true # When set to true, fields with empty values will fallback to the default locale's value.
+
 # Define the seed used to generated the test data
 # Used in <bolt-core>/src/DataFixtures/ContentFixtures.php
 fixtures_seed: 87654

--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -157,7 +157,7 @@ filepermissions:
 # will be allowed, regardless of it being in the `allowed_tags` setting.
 htmlcleaner:
     allowed_tags: [ div, span, p, br, hr, s, u, strong, em, i, b, li, ul, ol, mark, blockquote, pre, code, tt, h1, h2, h3, h4, h5, h6, dd, dl, dt, table, tbody, thead, tfoot, th, td, tr, a, img, address, abbr, iframe, caption, sub, super, figure, figcaption ]
-    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, rel ]
+    allowed_attributes: [ id, class, style, name, value, href, src, alt, title, width, height, frameborder, allowfullscreen, scrolling, target, colspan, rowspan, rel, download, hreflang ]
     allowed_frame_targets: [ _blank, _self, _parent, _top ]
 
 # Define the file types (extensions to be exact) that are acceptable for upload

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -68,7 +68,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
     private $dispatcher;
 
     /** @var string */
-    private $defaultLocale;
+    protected $defaultLocale;
 
     public function __construct(
         TaxonomyRepository $taxonomyRepository,

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -154,7 +154,7 @@ class ErrorController extends SymfonyErrorController
             // We wrap it in a try/catch, because we wouldn't want to
             // trigger a 404 within a 404 now, would we?
             try {
-                return $this->detailController->record($slug, null, $contentType, false);
+                return $this->detailController->record($slug, $contentType, false, null);
             } catch (NotFoundHttpException $e) {
                 // Just continue to the next one.
             }

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -154,7 +154,7 @@ class ErrorController extends SymfonyErrorController
             // We wrap it in a try/catch, because we wouldn't want to
             // trigger a 404 within a 404 now, would we?
             try {
-                return $this->detailController->record($slug, $contentType, false);
+                return $this->detailController->record($slug, null, $contentType, false);
             } catch (NotFoundHttpException $e) {
                 // Just continue to the next one.
             }

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -39,8 +39,12 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
      *
      * @param string|int $slugOrId
      */
-    public function record($slugOrId, ?string $contentTypeSlug = null, bool $requirePublished = true): Response
+    public function record($slugOrId, ?string $contentTypeSlug = null, bool $requirePublished = true, ?string $_locale = null): Response
     {
+        if ($_locale === null && ! $this->getFromRequest('_locale', null)) {
+            $this->request->setLocale($this->defaultLocale);
+        }
+
         // Check if there's a record with given `$slugOrId` as slug (might be a numeric slug)
         $contentType = ContentType::factory($contentTypeSlug, $this->config->get('contenttypes'));
         $record = $this->contentRepository->findOneBySlug($slugOrId, $contentType);

--- a/src/Controller/Frontend/DetailControllerInterface.php
+++ b/src/Controller/Frontend/DetailControllerInterface.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpFoundation\Response;
  */
 interface DetailControllerInterface
 {
-    public function record($slugOrId, ?string $contentTypeSlug, bool $requirePublished): Response;
+    public function record($slugOrId, ?string $contentTypeSlug, bool $requirePublished, ?string $_locale): Response;
 }

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -38,8 +38,12 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
      *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
      *     methods={"GET|POST"})
      */
-    public function listing(ContentRepository $contentRepository, string $contentTypeSlug): Response
+    public function listing(ContentRepository $contentRepository, string $contentTypeSlug, ?string $_locale = null): Response
     {
+        if ($_locale === null && ! $this->getFromRequest('_locale', null)) {
+            $this->request->setLocale($this->defaultLocale);
+        }
+
         $contentType = ContentType::factory($contentTypeSlug, $this->config->get('contenttypes'));
         $page = (int) $this->getFromRequest('page', '1');
         $amountPerPage = $contentType->get('listing_records');

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -47,10 +47,13 @@ class TwigAwareController extends AbstractController
     /** @var TemplateChooser */
     protected $templateChooser;
 
+    /** @var string */
+    protected $defaultLocale;
+
     /**
      * @required
      */
-    public function setAutowire(Config $config, Environment $twig, Packages $packages, Canonical $canonical, Sanitiser $sanitiser, RequestStack $requestStack, TemplateChooser $templateChooser): void
+    public function setAutowire(Config $config, Environment $twig, Packages $packages, Canonical $canonical, Sanitiser $sanitiser, RequestStack $requestStack, TemplateChooser $templateChooser, string $defaultLocale): void
     {
         $this->config = $config;
         $this->twig = $twig;
@@ -59,6 +62,7 @@ class TwigAwareController extends AbstractController
         $this->sanitiser = $sanitiser;
         $this->request = $requestStack->getCurrentRequest();
         $this->templateChooser = $templateChooser;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**


### PR DESCRIPTION
Hitting `/pages` for example will use the default locale, not the last used one.