### PR TITLE
Bugfix incorrect `|current` filter for localized menu items

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -251,15 +251,26 @@ class Content
             $slug = $this->getFieldValue('slug');
         } else {
             // get slug with the requested locale
-            $slug = $this->getField('slug')->setLocale($locale)->getParsedValue();
+            $field = $this->getField('slug');
+
+            // @todo: Refactor this. Field.php should be able to get locale
+            // without changing it for later use.
+            $currentLocale = $field->getLocale();
+            $field->setLocale($locale);
+            $slug = $field->getParsedValue();
+            $field->setLocale($currentLocale);
         }
 
         // if no slug exists for the current/requested locale, default fallback
         if (! $slug && $this->hasField('slug')) {
-            $slug = $this
-                ->getField('slug')
-                ->setLocale($this->getField('slug')->getDefaultLocale())
-                ->getParsedValue();
+            $field = $this->getField('slug');
+
+            // @todo: Refactor this. Field.php should be able to get locale
+            // without changing it for later use.
+            $currentLocale = $field->getLocale();
+            $field->setLocale($this->getField('slug')->getDefaultLocale());
+            $slug = $field->getParsedValue();
+            $field->setLocale($currentLocale);
         }
 
         return $slug;

--- a/src/Utils/ContentHelper.php
+++ b/src/Utils/ContentHelper.php
@@ -80,7 +80,7 @@ class ContentHelper
             'route' => $record->getDefinition()->get('record_route'),
             'params' => [
                 'contentTypeSlug' => $record->getContentTypeSingularSlug(),
-                'slugOrId' => $record->getSlug(),
+                'slugOrId' => $record->getSlug($locale),
                 '_locale' => $locale,
             ],
         ];


### PR DESCRIPTION
Fixes issue with localized menu URI's not recognised as current. Credits to @nestordedios for finding and debugging this!

Also fixes issue with using `record.slug`. It used to return the _wrong_ locale.