### PR TITLE
Fix excessive padding in dropdowns

### DIFF
--- a/assets/scss/init/_base.scss
+++ b/assets/scss/init/_base.scss
@@ -60,11 +60,6 @@ small {
   a:not(.btn):not(.dropdown-item) {
     text-decoration: underline;
   }
-
-  ul,
-  ol {
-    padding-left: 1rem;
-  }
 }
 
 .custom-select {

--- a/assets/scss/modules/admin/_widgets.scss
+++ b/assets/scss/modules/admin/_widgets.scss
@@ -1,3 +1,8 @@
 .widget {
   margin-bottom: $spacer*1.625;
+
+  ul,
+  ol {
+    padding-left: 1rem;
+  }
 }


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/7093518/98695425-e75fef00-2372-11eb-9b4c-20329fceb748.png)

But keeps the padding in the card (where it was originally intended to be fixed).