### PR TITLE
Login: redirect to dashboard, if authenticated

### DIFF
--- a/src/Controller/Backend/AuthenticationController.php
+++ b/src/Controller/Backend/AuthenticationController.php
@@ -17,6 +17,11 @@ class AuthenticationController extends TwigAwareController implements BackendZon
      */
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
+        if ($this->getUser()) {
+            // Already authenticated
+            return $this->redirectToRoute('bolt_dashboard');
+        }
+
         $slugify = new Slugify();
 
         // last username entered by the user (if any)


### PR DESCRIPTION
When requesting the login page (e.g. via a bookmark), even an already authenticated user is presented the login dialog.
This commit improves that behavior by sending authenticated users to the dashboard.