### PR TITLE
add default value for $extensionMenus so bolt won't break when configuration hasn't been updated yet.

### DIFF
--- a/src/Menu/BackendMenuBuilder.php
+++ b/src/Menu/BackendMenuBuilder.php
@@ -42,7 +42,7 @@ final class BackendMenuBuilder implements BackendMenuBuilderInterface
 
     public function __construct(
         FactoryInterface $menuFactory,
-        iterable $extensionMenus,
+        iterable $extensionMenus = [],
         Config $config,
         ContentRepository $contentRepository,
         UrlGeneratorInterface $urlGenerator,


### PR DESCRIPTION
The new support for extensions to insert menu items requires a change to the services.yaml - with a default set for the injected $extensionMenus the menu items will not appear when the configuration change hasn't been made, but it will allow the the site to keep working instead of throwing a big error.