### PR TITLE
Lookup slugs from record IDs in Twig templates

### DIFF
--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -137,6 +137,7 @@ class ContentExtension extends AbstractExtension
             new TwigFilter('status_options', [$this, 'statusOptions']),
             new TwigFilter('feature', [$this, 'getSpecialFeature']),
             new TwigFilter('sanitise', [$this, 'sanitise']),
+            new TwigFilter('record', [$this, 'record']),
         ];
     }
 
@@ -788,5 +789,10 @@ class ContentExtension extends AbstractExtension
     public function sanitise(string $html)
     {
         return $this->sanitiser->clean($html);
+    }
+
+    public function record(int $id)
+    {
+        return $this->contentRepository->findOneBy(['id' => $id]);
     }
 }


### PR DESCRIPTION
This extension makes it easy to create links in Twig templates that use slugs, but based on the record ID.

Slugs may change over time, so hard-coding them in templates is undesirable. Much better to use ID values which are a much more stable identifier.

`{{ path('record', { 'contentTypeSlug' : 'pages', 'slugOrId' : 'some-great-document' }) }}`

Can now be written as 

`{{ path('record', { 'contentTypeSlug' : 'pages', 'slugOrId' : idToSlug(6) }) }}`