### PR TITLE
Fix: Set a default status for the `default_status`

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -186,7 +186,7 @@ class Content
         }
 
         // Set default status and default values
-        $this->setStatus($this->contentTypeDefinition->get('default_status'), 'published');
+        $this->setStatus($this->contentTypeDefinition->get('default_status', 'published'));
         $this->contentTypeDefinition->get('fields')->each(function (LaravelCollection $item, string $name): void {
             if ($item->get('default')) {
                 $field = FieldRepository::factory($item, $name);

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -186,7 +186,7 @@ class Content
         }
 
         // Set default status and default values
-        $this->setStatus($this->contentTypeDefinition->get('default_status'));
+        $this->setStatus($this->contentTypeDefinition->get('default_status'), 'published');
         $this->contentTypeDefinition->get('fields')->each(function (LaravelCollection $item, string $name): void {
             if ($item->get('default')) {
                 $field = FieldRepository::factory($item, $name);


### PR DESCRIPTION
This is a fix for 'creating content from a 404 page', and the contenttype has no default_status set.