### PR TITLE
Allow '/' in setcontent where query

### DIFF
--- a/src/Storage/QueryParameterParser.php
+++ b/src/Storage/QueryParameterParser.php
@@ -43,7 +43,7 @@ class QueryParameterParser
 
     public function setupDefaults(): void
     {
-        $word = "[\p{L}\p{N}_]+";
+        $word = "[\p{L}\p{N}_\/]+";
 
         // @codingStandardsIgnoreStart
         $this->addValueMatcher("<\s?(${word})", [


### PR DESCRIPTION
So, for example `{% setcontent any = 'page' where { 'slug' : '/' } %}