### PR TITLE
Fix for Argument 1 passed to Bolt\Repository\FieldRepository::findAllBySlug() must be of the type string, null given

### DIFF
--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -185,6 +185,9 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
 
         $field = FieldRepository::factory($fieldType, $name);
 
+        // Make sure to create the fixture in the correct default locale.
+        $field->setLocale($this->defaultLocale);
+
         if (isset($preset[$name])) {
             $field->setValue($preset[$name]);
         } else {

--- a/src/Event/Listener/ContentFillListener.php
+++ b/src/Event/Listener/ContentFillListener.php
@@ -92,7 +92,7 @@ class ContentFillListener
             $slugField = null;
         }
 
-        $fields = $this->fieldRepository->findAllBySlug($slug);
+        $fields = $slug ? $this->fieldRepository->findAllBySlug($slug) : null;
 
         if (! $fields) {
             // No slug field with that slug exists. We're done here.


### PR DESCRIPTION
Fixes #2188 