### PR TITLE
Don't break with `TaxonomyRepository::factory() must be of the type string, int given`

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -485,7 +485,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
             ]);
 
             if ($taxonomy === null) {
-                $taxonomy = $this->taxonomyRepository->factory($key, $slug);
+                $taxonomy = $this->taxonomyRepository->factory($key, (string) $slug);
             }
 
             $content->addTaxonomy($taxonomy);

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -660,7 +660,7 @@ class ContentExtension extends AbstractExtension
 
         foreach ($taxonomy['options'] as $key => $value) {
             $options[] = [
-                'key' => $key,
+                'key' => (string) $key,
                 'value' => $value,
             ];
         }


### PR DESCRIPTION
Fixes #2201 

PHP Arrays are **_THE WORST_**

`A key may be either an integer or a string. If a key is the standard representation of an integer, it will be interpreted as such (i.e. "8" will be interpreted as 8, while "08" will be interpreted as "08").` 🤦‍♂️
