### PR TITLE
[WIP] Re-enable multiple db table prefixes

### DIFF
--- a/src/Doctrine/TablePrefixTrait.php
+++ b/src/Doctrine/TablePrefixTrait.php
@@ -23,6 +23,10 @@ trait TablePrefixTrait
 
     protected function setTablePrefix(ObjectManager $manager, string $prefix)
     {
+        // Force initializing the ObjectManager by calling a method in case it is a proxy for
+        // a lazily initialized service using symfony/proxy-manager-bridge.
+        // Doing this before calling spl_object_hash() makes sure we are getting the 'correct' hash
+        $manager->getMetadataFactory();
         $key = spl_object_hash($manager);
         $this->tablePrefixes[$key] = Str::ensureEndsWith($prefix, '_');
 


### PR DESCRIPTION
Force initialization of ObjectManager for correct spl_object_hash() behavior. 
Needed to get the correct spl_object_hash in case it is a proxy