### PR TITLE
Fix homepage link generation, generate fallbacks as relative unless canonical

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -184,7 +184,7 @@ class Canonical
             );
         } catch (InvalidParameterException | MissingMandatoryParametersException | RouteNotFoundException | \TypeError $e) {
             // Just use the current URL /shrug
-            return$this->request->getUri();
+            return $canonical ? $this->request->getUri() : $this->request->getPathInfo();
         }
     }
 }

--- a/src/Utils/ContentHelper.php
+++ b/src/Utils/ContentHelper.php
@@ -63,6 +63,10 @@ class ContentHelper
 
     private function getCanonicalRouteAndParams(Content $record, ?string $locale = null): array
     {
+        if (! $locale) {
+            $locale = $this->request->getLocale();
+        }
+
         if ($this->isHomepage($record)) {
             return [
                 'route' => 'homepage_locale',
@@ -70,10 +74,6 @@ class ContentHelper
                     '_locale' => $locale,
                 ],
             ];
-        }
-
-        if (! $locale) {
-            $locale = $this->request->getLocale();
         }
 
         return [


### PR DESCRIPTION
This fixes an issue I had where the current locale was not picked up by homepage link generation.

Along the way I noticed that the fallback link generation ("Just use the current URL") always generated canonical links which sometimes led to links like "https://domain.tld/https://domain.tld" because it is used as a argument to setPath in getLink.