### PR TITLE
Run E2E tests on lowest supported PHP version only [new features]

### DIFF
--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -49,7 +49,7 @@ jobs:
         strategy:
             fail-fast: false # do not cancel 7.2 if 7.3 fails	
             matrix:
-                php: [ '7.2', '7.3', '7.4' ]
+                php: [ '7.2' ]
                 node-version: ['12.5']
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -8,9 +8,9 @@ jobs:
         name: API Tests
         runs-on: ubuntu-latest
         strategy:
-            fail-fast: false # do not cancel 7.2 if 7.3 fails	
+            fail-fast: false
             matrix:
-                php: ['7.2', '7.3', '7.4']
+                php: ['7.2']
                 node-version: ['12.5']
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -47,7 +47,7 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         strategy:
-            fail-fast: false # do not cancel 7.2 if 7.3 fails	
+            fail-fast: false
             matrix:
                 php: [ '7.2' ]
                 node-version: ['12.5']


### PR DESCRIPTION
Same as #2228 but for the features (next minor version) branch