### PR TITLE
Run E2E tests on lowest supported PHP version only [bugfixes]

### DIFF
--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -8,9 +8,9 @@ jobs:
         name: API Tests
         runs-on: ubuntu-latest
         strategy:
-            fail-fast: false # do not cancel 7.2 if 7.3 fails	
+            fail-fast: false
             matrix:
-                php: ['7.2', '7.3', '7.4']
+                php: ['7.2']
                 node-version: ['12.5']
         steps:
             - uses: actions/checkout@v2
@@ -47,9 +47,9 @@ jobs:
         name: E2E Tests
         runs-on: ubuntu-latest
         strategy:
-            fail-fast: false # do not cancel 7.2 if 7.3 fails	
+            fail-fast: false
             matrix:
-                php: [ '7.2', '7.3', '7.4' ]
+                php: [ '7.2' ]
                 node-version: ['12.5']
         steps:
             -   uses: actions/checkout@v2


### PR DESCRIPTION
Same as #2227 but for the bugfix branch