### PR TITLE
Warn of outstanding migrations

### DIFF
--- a/bin/composer-script/post-update-cmd.php
+++ b/bin/composer-script/post-update-cmd.php
@@ -26,4 +26,8 @@ run('php bin/console extensions:configure --with-config --ansi', $symfonyStyle);
 run('php bin/console cache:clear --no-warmup', $symfonyStyle);
 run('php bin/console assets:install --symlink --relative public', $symfonyStyle);
 
+$migrate = "Database is out-of-date. To update the database, run `php bin/console doctrine:migrations:migrate`.";
+$migrate .= " You are strongly advised to backup your database before migrating.";
+run('php bin/console doctrine:migrations:up-to-date', $symfonyStyle, false, $migrate);
+
 run('php bin/console bolt:info --ansi', $symfonyStyle, true);

--- a/bin/composer-script/run.php
+++ b/bin/composer-script/run.php
@@ -2,12 +2,16 @@
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-function run(string $command, SymfonyStyle $symfonyStyle, bool $withOutput = false): void {
+function run(string $command, SymfonyStyle $symfonyStyle, bool $withOutput = false, string $onerror = ''): void {
     exec($command, $output, $return);
     if ($return) {
-        // Some error occurred.
-        $message = sprintf("Command '%s' failed. %s", $command, implode("\n", $output));
-        $symfonyStyle->error($message);
+        if (empty($onerror)) {
+            // Some error occurred.
+            $message = sprintf("Command '%s' failed. %s", $command, implode("\n", $output));
+            $symfonyStyle->error($message);
+        } else {
+            $symfonyStyle->error($onerror);
+        }
     } else {
         if ($withOutput) {
             $symfonyStyle->text($output);


### PR DESCRIPTION
This is for `bolt/core`, but we can/should also do it in project. To do that, though, we'd need to revise `bolt/project` and move the post-update things in here, so we can version them.

![image](https://user-images.githubusercontent.com/7093518/101787737-b1dc2c00-3aff-11eb-88bf-dc83869c6bd6.png)
