### PR TITLE
Canonical improvements

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -190,6 +190,7 @@ curl_options:
 # Various settings about Bolt's built-in localization features.
 localization:
     fallback_when_missing: true # When set to true, fields with empty values will fallback to the default locale's value.
+    remove_default_locale_on_canonical: true # When set to true removes locale prefix on default locale canonical URLs
 
 # Define the seed used to generated the test data
 # Used in <bolt-core>/src/DataFixtures/ContentFixtures.php

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -164,7 +164,10 @@ class Canonical
 
     public function generateLink(?string $route, ?array $params, $canonical = false): ?string
     {
-        if (isset($params['_locale']) && $params['_locale'] === $this->defaultLocale) {
+        $removeDefaultLocaleOnCanonical = $this->config->get('general/localization/remove_default_locale_on_canonical', true);
+        $hasDefaultLocale = isset($params['_locale']) && $params['_locale'] === $this->defaultLocale;
+
+        if ($removeDefaultLocaleOnCanonical && $hasDefaultLocale) {
             unset($params['_locale']);
             $routeWithoutLocale = str_replace('_locale', '', $route);
 

--- a/src/Configuration/Parser/GeneralParser.php
+++ b/src/Configuration/Parser/GeneralParser.php
@@ -100,6 +100,7 @@ class GeneralParser extends BaseParser
             'internal_server_error' => 'helpers/page_500.html.twig',
             'localization' => [
                 'fallback_when_missing' => true,
+                'remove_default_locale_on_canonical' => true,
             ],
             'omit_backgrounds' => false,
             'omit_powered_by_header' => false,

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -80,6 +80,16 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
 
         $records = $this->setRecords($content, $amountPerPage, $page);
 
+        // Set canonical URL
+        $this->canonical->setPath(
+            'listing_locale',
+            array_merge([
+                'contentTypeSlug' => $contentType->get('slug'),
+                '_locale' => $this->request->getLocale(),
+            ], $queryParams),
+        );
+
+        // Render
         $templates = $this->templateChooser->forListing($contentType);
         $this->twig->addGlobal('records', $records);
 

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -86,7 +86,7 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
             array_merge([
                 'contentTypeSlug' => $contentType->get('slug'),
                 '_locale' => $this->request->getLocale(),
-            ], $queryParams),
+            ], $queryParams)
         );
 
         // Render


### PR DESCRIPTION
This PR fixes the following issues:

## Fix listing page Canonical

> Listing pages have different canonical when using singular or plural form: https://github.com/bolt/core/issues/2218

Example:

- Using `localization.remove_default_locale_on_canonical = true`
- Note how the URL contains the singular form but **the canonical is normalized to the plural form**
- Also the default locale (`en`) is removed (old behaviour)

![image](https://user-images.githubusercontent.com/188612/101840337-32bd1700-3b44-11eb-95a1-68cb583b6ddb.png)

## Force default locale on canonical

> Add a new config option to tell Bolt if the canonical URL should force-prefix the default locale or not: https://github.com/bolt/core/issues/2219

Example:

- Using `localization.remove_default_locale_on_canonical = false`
- Note how the **default locale (`en`) is maintained on the canonical**

![image](https://user-images.githubusercontent.com/188612/101840657-cd1d5a80-3b44-11eb-9e42-05dd63c0a564.png)
