### PR TITLE
Deprecate `bolt/binary-chromedriver` for `lanfest/binary-chromedriver`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "behatch/contexts": "^3.3",
         "bobdenotter/configuration-notices": "^1.1",
         "bobdenotter/weatherwidget": "^1.1",
-        "bolt/binary-chromedriver": "^5.1.1",
+        "lanfest/binary-chromedriver": "^6.0",
         "bolt/newswidget": "^1.2",
         "coduo/php-matcher": "^4.0",
         "dama/doctrine-test-bundle": "^6.2.0",


### PR DESCRIPTION
Fixes #2221