### PR TITLE
Localize menu with `{locale}: {label}` configuration

### DIFF
--- a/config/bolt/menu.yaml
+++ b/config/bolt/menu.yaml
@@ -6,7 +6,9 @@ main:
     title: This is the <b>first<b> menu item.
     link: homepage
     class: homepage
-  - label: About
+  - label: 
+        en: About
+        nl: Over
     link: page/2
     submenu:
         - label: Sub 1

--- a/src/Menu/CachedFrontendMenuBuilder.php
+++ b/src/Menu/CachedFrontendMenuBuilder.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Twig\Environment;
 
 final class CachedFrontendMenuBuilder implements FrontendMenuBuilderInterface
 {
@@ -27,14 +28,14 @@ final class CachedFrontendMenuBuilder implements FrontendMenuBuilderInterface
         $this->request = $requestStack->getCurrentRequest();
     }
 
-    public function buildMenu(?string $name = null): array
+    public function buildMenu(Environment $twig, ?string $name = null): array
     {
         $key = 'frontendmenu_' . ($name ?: 'main') . '_' . $this->request->getLocale();
 
-        return $this->cache->get($key, function (ItemInterface $item) use ($name) {
+        return $this->cache->get($key, function (ItemInterface $item) use ($name, $twig) {
             $item->tag('frontendmenu');
 
-            return $this->menuBuilder->buildMenu($name);
+            return $this->menuBuilder->buildMenu($twig, $name);
         });
     }
 }

--- a/src/Menu/FrontendMenuBuilder.php
+++ b/src/Menu/FrontendMenuBuilder.php
@@ -9,8 +9,10 @@ use Bolt\Configuration\Config;
 use Bolt\Entity\Content;
 use Bolt\Repository\ContentRepository;
 use Bolt\Twig\ContentExtension;
+use Bolt\Twig\LocaleExtension;
 use Bolt\Utils\Html;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
 
 final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
 {
@@ -26,19 +28,29 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
     /** @var ContentExtension */
     private $contentExtension;
 
+    /** @var LocaleExtension */
+    private $localeExtension;
+
+    /** @var string */
+    private $defaultLocale;
+
     public function __construct(
         Config $config,
         UrlGeneratorInterface $urlGenerator,
         ContentRepository $contentRepository,
-        ContentExtension $contentExtension
+        ContentExtension $contentExtension,
+        LocaleExtension $localeExtension,
+        string $defaultLocale
     ) {
         $this->config = $config;
         $this->urlGenerator = $urlGenerator;
         $this->contentRepository = $contentRepository;
         $this->contentExtension = $contentExtension;
+        $this->localeExtension = $localeExtension;
+        $this->defaultLocale = $defaultLocale;
     }
 
-    public function buildMenu(?string $name = null): array
+    public function buildMenu(Environment $twig, ?string $name = null): array
     {
         /** @var DeepCollection $menuConfig */
         $menuConfig = $this->config->get('menu');
@@ -51,12 +63,12 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
             throw new \RuntimeException("Tried to build non-existing menu: {$name}");
         }
 
-        return array_map(function ($item): array {
-            return $this->setUris($item);
+        return array_map(function ($item) use ($twig): array {
+            return $this->setUris($twig, $item);
         }, $menu);
     }
 
-    private function setUris(array $item): array
+    private function setUris(Environment $twig, array $item): array
     {
         [$title, $item['uri']] = $this->generateUri($item['link']);
 
@@ -64,9 +76,22 @@ final class FrontendMenuBuilder implements FrontendMenuBuilderInterface
             $item['title'] = $title;
         }
 
+        $currentLocale = $this->localeExtension->getHtmlLang($twig);
+        if (is_iterable($item['label'])) {
+            if (array_key_exists($currentLocale, $item['label'])) {
+                $label = $item['label'][$currentLocale];
+            } elseif (array_key_exists($this->defaultLocale, $item['label'])) {
+                $label = $item['label'][$this->defaultLocale];
+            } else {
+                $label = $item['title'] ?? '';
+            }
+
+            $item['label'] = $label;
+        }
+
         if (is_iterable($item['submenu'])) {
-            $item['submenu'] = array_map(function ($sub): array {
-                return $this->setUris($sub);
+            $item['submenu'] = array_map(function ($sub) use ($twig): array {
+                return $this->setUris($twig, $sub);
             }, $item['submenu']);
         }
 

--- a/src/Menu/FrontendMenuBuilderInterface.php
+++ b/src/Menu/FrontendMenuBuilderInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Bolt\Menu;
 
+use Twig\Environment;
+
 interface FrontendMenuBuilderInterface
 {
-    public function buildMenu(?string $name): array;
+    public function buildMenu(Environment $twig, ?string $name): array;
 }

--- a/src/Menu/StopwatchFrontendMenuBuilder.php
+++ b/src/Menu/StopwatchFrontendMenuBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Menu;
 
 use Symfony\Component\Stopwatch\Stopwatch;
+use Twig\Environment;
 
 final class StopwatchFrontendMenuBuilder implements FrontendMenuBuilderInterface
 {
@@ -20,10 +21,10 @@ final class StopwatchFrontendMenuBuilder implements FrontendMenuBuilderInterface
         $this->stopwatch = $stopwatch;
     }
 
-    public function buildMenu(?string $name = null): array
+    public function buildMenu(Environment $twig, ?string $name = null): array
     {
         $this->stopwatch->start('bolt.frontendMenu');
-        $menu = $this->menuBuilder->buildMenu($name);
+        $menu = $this->menuBuilder->buildMenu($twig, $name);
         $this->stopwatch->stop('bolt.frontendMenu');
 
         return $menu;

--- a/src/Twig/FrontendMenuExtension.php
+++ b/src/Twig/FrontendMenuExtension.php
@@ -37,19 +37,19 @@ class FrontendMenuExtension extends AbstractExtension
 
         return [
             new TwigFunction('menu', [$this, 'renderMenu'], $env + $safe),
-            new TwigFunction('menu_array', [$this, 'getMenu'], $safe),
+            new TwigFunction('menu_array', [$this, 'getMenu'], $env + $safe),
         ];
     }
 
-    public function getMenu(?string $name = null): array
+    public function getMenu(Environment $twig, ?string $name = null): array
     {
-        return $this->menuBuilder->buildMenu($name);
+        return $this->menuBuilder->buildMenu($twig, $name);
     }
 
     public function renderMenu(Environment $twig, ?string $name = null, string $template = 'helpers/_menu.html.twig', string $class = '', bool $withsubmenus = true): string
     {
         $context = [
-            'menu' => $this->menuBuilder->buildMenu($name),
+            'menu' => $this->menuBuilder->buildMenu($twig, $name),
             'class' => $class,
             'withsubmenus' => $withsubmenus,
         ];

--- a/tests/php/Menu/FrontendMenuBuilderTest.php
+++ b/tests/php/Menu/FrontendMenuBuilderTest.php
@@ -7,36 +7,66 @@ namespace Bolt\Tests\Menu;
 use Bolt\Collection\DeepCollection;
 use Bolt\Menu\FrontendMenuBuilder;
 use Bolt\Tests\DbAwareTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Environment;
 
 class FrontendMenuBuilderTest extends DbAwareTestCase
 {
     /** @var FrontendMenuBuilder */
     private $menuBuilder;
 
+    /** @var MockObject */
+    private $twig;
+
+    /** @var MockObject */
+    private $request;
+
+    /** @var MockObject */
+    private $app;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->menuBuilder = self::$container->get(FrontendMenuBuilder::class);
+
+        // Setup mocks for testing the localized menu
+        $this->twig = $this->createMock(Environment::class);
+        $this->request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->request->method('getLocale')->wilLReturn('en');
+
+        $this->request->attributes = $this->createMock(ParameterBag::class);
+        $this->request->attributes
+            ->method('get')
+            ->withConsecutive(['_route'], ['_route_params'])
+            ->willReturn('homepage_locale', []);
+        $this->app = $this->createMock(AppVariable::class);
+        $this->app->method('getRequest')->willReturn($this->request);
+        $this->twig->method('getGlobals')->willReturn(['app' => $this->app]);
     }
 
     public function testNonExistingMenu(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->menuBuilder->buildMenu('foo');
+        $this->menuBuilder->buildMenu($this->twig, 'foo');
     }
 
     public function testDefaultMenuIsFirst(): void
     {
-        $menu1 = $this->menuBuilder->buildMenu();
-        $menu2 = $this->menuBuilder->buildMenu('main');
+        $menu1 = $this->menuBuilder->buildMenu($this->twig);
+        $menu2 = $this->menuBuilder->buildMenu($this->twig, 'main');
 
         $this->assertSame($menu1, $menu2);
     }
 
     public function testFirstItem(): void
     {
-        $menu = $this->menuBuilder->buildMenu('main');
+        $menu = $this->menuBuilder->buildMenu($this->twig, 'main');
 
         $firstItem = DeepCollection::deepMake($menu)->first();
 
@@ -51,7 +81,7 @@ class FrontendMenuBuilderTest extends DbAwareTestCase
 
     public function testLastItem(): void
     {
-        $menu = $this->menuBuilder->buildMenu('main');
+        $menu = $this->menuBuilder->buildMenu($this->twig, 'main');
 
         $lastItem = DeepCollection::deepMake($menu)->last();
 
@@ -66,7 +96,7 @@ class FrontendMenuBuilderTest extends DbAwareTestCase
 
     public function testHasSubMenu(): void
     {
-        $menu = $this->menuBuilder->buildMenu('main');
+        $menu = $this->menuBuilder->buildMenu($this->twig, 'main');
 
         $submenu = $menu[1]['submenu'];
 


### PR DESCRIPTION
Fixes #2222 

For example:

```yaml
main:
  - label: Home
    title: This is the <b>first<b> menu item.
    link: homepage
    class: homepage
  - label: 
        en: About
        nl: Over
    link: page/2
```