### PR TITLE
[WIP] Always return field objects (not Markup)

### DIFF
--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -8,6 +8,7 @@ use Bolt\Canonical;
 use Bolt\Configuration\Config;
 use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Content;
+use Bolt\Entity\Field\HtmlRenderable;
 use Bolt\Entity\Field\TemplateselectField;
 use Bolt\Enum\Statuses;
 use Bolt\Storage\Query;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tightenco\Collect\Support\Collection;
 use Twig\Environment;
+use Twig\Extension\EscaperExtension;
 use Twig\Loader\FilesystemLoader;
 
 class TwigAwareController extends AbstractController
@@ -69,6 +71,11 @@ class TwigAwareController extends AbstractController
         $this->templateChooser = $templateChooser;
         $this->defaultLocale = $defaultLocale;
         $this->commonExtension = $commonExtension;
+
+        // Set safe html classes. See https://twig.symfony.com/doc/3.x/api.html
+        /** @var EscaperExtension $escaper */
+        $escaper = $twig->getExtension(EscaperExtension::class);
+        $escaper->addSafeClass(HtmlRenderable::class, ['html']);
     }
 
     /**

--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -9,8 +9,6 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiSubresource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use Bolt\Configuration\Content\ContentType;
-use Bolt\Entity\Field\Excerptable;
-use Bolt\Entity\Field\ScalarCastable;
 use Bolt\Enum\Statuses;
 use Bolt\Repository\FieldRepository;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -675,10 +673,6 @@ class Content
 
             // Invoked from code, throw Exception
             throw new \RuntimeException(sprintf('Invalid field name or method call on %s: %s', $this->__toString(), $name));
-        }
-
-        if ($field instanceof Excerptable || $field instanceof ScalarCastable) {
-            return $field->getTwigValue();
         }
 
         return $field;

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -98,9 +98,7 @@ class Field implements FieldInterface, TranslatableInterface
         if (is_array($value) && array_key_exists($key, $value)) {
             // If value is field, return getTwigValue so that {{ value }}
             // is parsed as html, rather than __toString() which is escaped
-            $value = $value[$key];
-
-            return $value instanceof self ? $value->getTwigValue() : $value;
+            return $value[$key];
         }
 
         return null;

--- a/src/Entity/Field/CheckboxField.php
+++ b/src/Entity/Field/CheckboxField.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class CheckboxField extends Field implements FieldInterface, ScalarCastable, RawPersistable
+class CheckboxField extends Field implements FieldInterface, RawPersistable
 {
     public const TYPE = 'checkbox';
 
@@ -30,10 +30,5 @@ class CheckboxField extends Field implements FieldInterface, ScalarCastable, Raw
         }
 
         return parent::setValue($value);
-    }
-
-    public function getTwigValue()
-    {
-        return current($this->getValue());
     }
 }

--- a/src/Entity/Field/DateField.php
+++ b/src/Entity/Field/DateField.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class DateField extends Field implements FieldInterface, ScalarCastable
+class DateField extends Field implements FieldInterface
 {
     public const TYPE = 'date';
 

--- a/src/Entity/Field/EmailField.php
+++ b/src/Entity/Field/EmailField.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class EmailField extends Field implements FieldInterface, ScalarCastable
+class EmailField extends Field implements FieldInterface
 {
     public const TYPE = 'email';
 }

--- a/src/Entity/Field/HiddenField.php
+++ b/src/Entity/Field/HiddenField.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class HiddenField extends Field implements FieldInterface, ScalarCastable, RawPersistable
+class HiddenField extends Field implements FieldInterface, HtmlRenderable, RawPersistable
 {
     public const TYPE = 'hidden';
 

--- a/src/Entity/Field/HtmlRenderable.php
+++ b/src/Entity/Field/HtmlRenderable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Entity\Field;
+
+/**
+ * Field that should be rendered as safe html in Twig.
+ */
+interface HtmlRenderable
+{
+    public function __toString(): string;
+}

--- a/src/Entity/Field/NumberField.php
+++ b/src/Entity/Field/NumberField.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class NumberField extends Field implements FieldInterface, ScalarCastable
+class NumberField extends Field implements FieldInterface
 {
     public const TYPE = 'number';
 

--- a/src/Entity/Field/ScalarCastable.php
+++ b/src/Entity/Field/ScalarCastable.php
@@ -6,6 +6,8 @@ namespace Bolt\Entity\Field;
 
 /**
  * Field that can be cast to a plain scalar value (string, int, boolean, float) in excerpt must implement this interface
+ *
+ * @deprecated in favour of HtmlRenderable.
  */
 interface ScalarCastable
 {

--- a/src/Entity/Field/SlugField.php
+++ b/src/Entity/Field/SlugField.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class SlugField extends Field implements FieldInterface, ScalarCastable
+class SlugField extends Field implements FieldInterface
 {
     public const TYPE = 'slug';
 


### PR DESCRIPTION
Prior to this, some fields were passed to twig as object, some as Markup.

Apart from the ugly inconsistency, the issue is that the Markup ones don't then work with twig functions/filters that expect fields. This is specifically an issue with set, where `set.field` is different than `set.value.field`.

This PR fixes it, however it introduces a breaking change by deprecating the `ScalarCastable` interface in favour of `HtmlRenderable`.

Things that need to be updated:
https://github.com/bolt/article/blob/master/src/Entity/ArticleField.php
https://github.com/bolt/redactor/blob/master/src/Entity/RedactorField.php
https://github.com/LordSimal/bolt-geolocation-field/blob/master/src/Entity/GeolocationField.php