### PR TITLE
[WIP] Same canonical for listing pages using singular or plural slug

### DIFF
--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -79,7 +79,6 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
             'contenttype' => $contentType,
         ];
 
-
         $this->canonical->setPath($this->request->get('_route'), ['contentTypeSlug' => $contentType->getSlug()]);
 
         return $this->render($templates, $twigVars);

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -79,6 +79,9 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
             'contenttype' => $contentType,
         ];
 
+
+        $this->canonical->setPath($this->request->get('_route'), ['contentTypeSlug' => $contentType->getSlug()]);
+
         return $this->render($templates, $twigVars);
     }
 


### PR DESCRIPTION
Fixes #2218 

For the default locale: `/pages`
For another locale: `/nl/pages`