### PR TITLE
Make the migrations conditional

### DIFF
--- a/migrations/Version20201210105836.php
+++ b/migrations/Version20201210105836.php
@@ -34,14 +34,19 @@ final class Version20201210105836 extends AbstractMigration
     public function up(Schema $schema) : void
     {
         // Create the user avatar. See https://github.com/bolt/core/pull/2114
-        $schema->getTable($this->tablePrefix . '_user')
-            ->addColumn('avatar', 'string', ['notnull' => false, 'length' => 250]);
+        $userTable = $schema->getTable($this->tablePrefix . '_user');
+
+        if (! $userTable->hasColumn('avatar')) {
+            $userTable->addColumn('avatar', 'string', ['notnull' => false, 'length' => 250]);
+        }
 
         // Create the reset password table. See https://github.com/bolt/core/pull/2131
-        $resetPaswordTable = $schema->createTable($this->tablePrefix . '_password_request');
-        $resetPaswordTable->addColumn('id', 'integer', ['autoincrement' => true]);
-        $resetPaswordTable->addColumn('user_id', 'integer', ['notnull' => true, '', 'default' => 0]);
-        $resetPaswordTable->addForeignKeyConstraint($this->tablePrefix . '_user', ['user_id'], ['id'], ['onUpdate' => 'CASCADE']);
+        if (!$schema->hasTable($this->tablePrefix . '_password_request')) {
+            $resetPaswordTable = $schema->createTable($this->tablePrefix . '_password_request');
+            $resetPaswordTable->addColumn('id', 'integer', ['autoincrement' => true]);
+            $resetPaswordTable->addColumn('user_id', 'integer', ['notnull' => true, '', 'default' => 0]);
+            $resetPaswordTable->addForeignKeyConstraint($this->tablePrefix . '_user', ['user_id'], ['id'], ['onUpdate' => 'CASCADE']);
+        }
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
On an installation where I already ran `bin/console doctrine:schema:update` a while ago, the migration broke and was stuck from then on. 

by checking if the table and column don't exist yet, it'll continue and prevent breakage. 