### PR TITLE
allow tightenco/collect 8.0 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/yaml": "^5.1",
         "symfonycasts/reset-password-bundle": "^1.1",
-        "tightenco/collect": "^7.25",
+        "tightenco/collect": "^7.25 || ^v8.0.0",
         "twig/twig": "^3.0",
         "ua-parser/uap-php": "^3.9",
         "webimpress/safe-writer": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "symfony/yaml": "^5.1",
         "symfonycasts/reset-password-bundle": "^1.1",
-        "tightenco/collect": "^7.25 || ^v8.0.0",
+        "tightenco/collect": "^v8.0",
         "twig/twig": "^3.0",
         "ua-parser/uap-php": "^3.9",
         "webimpress/safe-writer": "^2.1",


### PR DESCRIPTION
Related to #2087 

I have no idea if 8.0 is downwards compatible with 7.0 nor do I have an idea how and where collections are used here.
It is just one step closer to allowing bolt to be installed with a PHP 8.0 CLI