### PR TITLE
Allow `id` in sanitiser (purifier). Don't sanitise fields with `sanitise: false`

### DIFF
--- a/src/Event/Listener/FieldFillListener.php
+++ b/src/Event/Listener/FieldFillListener.php
@@ -41,7 +41,7 @@ class FieldFillListener
             /** @var Field $field */
             $field = $entity->getTranslatable();
 
-            if (! $field instanceof RawPersistable) {
+            if (! $field instanceof RawPersistable && $field->getDefinition()->get('sanitise', true)) {
                 $value = $this->clean($field->getParsedValue());
                 $field->setValue($value);
             }

--- a/src/Utils/Sanitiser.php
+++ b/src/Utils/Sanitiser.php
@@ -40,6 +40,10 @@ class Sanitiser
         $purifierConfig->set('HTML.AllowedAttributes', $allowedAttributes);
         $purifierConfig->set('Attr.AllowedFrameTargets', $allowedFrameTargets);
 
+        if (in_array('id', $this->config->get('general/htmlcleaner/allowed_attributes')->all(), true)) {
+            $purifierConfig->set('Attr.EnableID', true);
+        }
+
         $definition = $purifierConfig->maybeGetRawHTMLDefinition();
         $definition->addElement('super', 'Inline', 'Flow', 'Common', []);
         $definition->addElement('sub', 'Inline', 'Flow', 'Common', []);


### PR DESCRIPTION
Identical to #2198, but for the 4.1.x branch.

Fixes #2248 