### PR TITLE
Show number of records on listing

### DIFF
--- a/templates/content/listing.html.twig
+++ b/templates/content/listing.html.twig
@@ -135,7 +135,10 @@
             <p>{{ contentType.description }}</p>
         {% endif %}
 
+        {% set showingRecords = ((records.currentPage -1) * records.maxPerPage + 1 ) ~ '-'
+            ~ ((records.currentPage -1) * records.maxPerPage + records|length) %}
         <ul class="px-2">
+            <li>Showing records <strong>{{ showingRecords}}</strong> of <strong>{{ records.nbResults }}</strong></li>
             <li>Name: <code>{{ contentType.name }}</code> (singular: <code>{{ contentType.singular_name }}</code>)</li>
             <li>Slug: <code>{{ contentType.slug }}</code> (singular: <code>{{ contentType.singular_slug }}</code>)</li>
             <li>Record template: <code>{{ contentType.record_template }}</code></li>


### PR DESCRIPTION
@bobdenotter I noticed we sometimes calculate the number of records by multiplying the page * record listing thing 

![image](https://user-images.githubusercontent.com/7093518/103647675-f969a280-4f5b-11eb-9a74-a9f00fe768cd.png)
