### PR TITLE
Run bolt in a11y tests

### DIFF
--- a/.github/workflows/a11y_tests.yaml
+++ b/.github/workflows/a11y_tests.yaml
@@ -27,6 +27,7 @@ jobs:
                 uses: actions/setup-node@v1
                 with:
                     node-version: ${{ matrix.node-version }}
+                    coverage: none
             - uses: shivammathur/setup-php@v1
               with:
                   # test the lowest version, to make sure checks pass on it

--- a/.github/workflows/a11y_tests.yaml
+++ b/.github/workflows/a11y_tests.yaml
@@ -26,7 +26,31 @@ jobs:
                 with:
                     node-version: 12.5
 
-            # same as "npm install", just uses package-lock.json", see https://stackoverflow.com/a/53325242/1348344
-            -   run: npm ci
+            -   name: Install dependencies
+                run: |
+                    sudo composer self-update -q
+                    sudo COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=60 composer update --prefer-dist --no-progress	
+                    ./bin/console bolt:info	--ansi
+                    npm set progress=false	
+                    npm ci	
+                    mkdir -p ./var/log/e2e-reports/report/features/	
+                    touch ./var/log/e2e-reports/report/features/.gitkeep	
+                    # Install latest stable Chrome for e2e tests	
+                    sudo apt-get install libxss1 libappindicator1 libindicator7	
+                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb	
+                    sudo apt install ./google-chrome*.deb
+            -   name: Prepare environment
+                run: |
+                    # build assets	
+                    npm run build
+                    sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/	
+                    # prepare web server for e2e tests	
+                    ./bin/console doctrine:database:create	
+                    ./bin/console doctrine:schema:create	
+                    ./bin/console doctrine:fixtures:load --group=without-images -n	
+                    ./bin/console server:start 127.0.0.1:8088	
+                    # test if web server works	
+                    sleep 3	
+                    wget "http://127.0.0.1:8088/bolt/login"
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/a11y_tests.yaml
+++ b/.github/workflows/a11y_tests.yaml
@@ -39,12 +39,6 @@ jobs:
                     ./bin/console bolt:info	--ansi
                     npm set progress=false	
                     npm ci	
-                    mkdir -p ./var/log/e2e-reports/report/features/	
-                    touch ./var/log/e2e-reports/report/features/.gitkeep	
-                    # Install latest stable Chrome for e2e tests	
-                    sudo apt-get install libxss1 libappindicator1 libindicator7	
-                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb	
-                    sudo apt install ./google-chrome*.deb
             -   name: Prepare environment
                 run: |
                     # build assets	

--- a/.github/workflows/a11y_tests.yaml
+++ b/.github/workflows/a11y_tests.yaml
@@ -8,6 +8,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
+                php-version: ['7.2']
+                node-version: ['12.5']
                 actions:
                     -
                         name: Run pa11yci
@@ -24,7 +26,11 @@ jobs:
                 name: Use Node.js 12.5
                 uses: actions/setup-node@v1
                 with:
-                    node-version: 12.5
+                    node-version: ${{ matrix.node-version }}
+            - uses: shivammathur/setup-php@v1
+              with:
+                  # test the lowest version, to make sure checks pass on it
+                  php-version: ${{ matrix.php-version }}
 
             -   name: Install dependencies
                 run: |

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "stylelint": "stylelint 'assets/scss'",
         "stylelint-fix": "stylelint 'assets/scss' --fix",
         "csfix": "eslint --ext .js,.vue, assets --fix; stylelint 'assets/scss' --fix",
-        "a11y:ci": "pa11y-ci --threshold=82 --config=tests/a11y/pa11yci.json",
+        "a11y:ci": "pa11y-ci --threshold=83 --config=tests/a11y/pa11yci.json",
         "a11y:test:all": "pa11y-ci --threshold=0 --config=tests/a11y/pa11yci.json",
         "a11y:test": "pa11y-ci",
         "test": "jest",

--- a/tests/a11y/README.md
+++ b/tests/a11y/README.md
@@ -20,3 +20,9 @@ Run a test for a specific page with:
 ```
 npm run a11y:test localhost:8088/bolt/
 ```
+
+| :warning: Note - by default, tests will not fail on errors |
+|:----------------------------------------|
+| By default, the tests will pass even if there are accessibility errors and warnings, due to CI and limitations with pa11y. | 
+| If you want to see what is failing, edit `pa11yci.json`, by emoving the `"threshold": {number}` line. |                             
+

--- a/tests/a11y/pa11yci.json
+++ b/tests/a11y/pa11yci.json
@@ -1,5 +1,6 @@
 {
     "defaults": {
+        "threshold": 83,
         "concurrency": 1
     },
     "urls": [


### PR DESCRIPTION
Fixes #2084 

Roughly speaking, this will make sure that the tests aren't failing for outstanding issues. But if we introduce new problems, they will most likely be flagged by pa11y and tests will fail. Seems like a good compromise as we undertake the big work of making the whole of Bolt accessible. 