### PR TITLE
Use default locale when not explicitly stated

### DIFF
--- a/src/Event/Subscriber/LocaleSubscriber.php
+++ b/src/Event/Subscriber/LocaleSubscriber.php
@@ -10,6 +10,14 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class LocaleSubscriber implements EventSubscriberInterface
 {
+    /** @var string */
+    private $defaultLocale;
+
+    public function __construct(string $defaultLocale)
+    {
+        $this->defaultLocale = $defaultLocale;
+    }
+
     public function onKernelRequest(RequestEvent $event): void
     {
         $request = $event->getRequest();
@@ -29,9 +37,7 @@ class LocaleSubscriber implements EventSubscriberInterface
         } elseif ($request->attributes->get('zone', false) === 'backend' && $request->getSession()->has('_backend_locale')) {
             $request->setLocale($request->getSession()->get('_backend_locale'));
         } elseif ($request->getSession()->has('_locale')) {
-            // @todo: This is probably never reached. Remove if you're brave enough ;-)
-            // if no explicit locale has been set on this request, use one from the session
-            $request->setLocale($request->getSession()->get('_locale'));
+            $request->setLocale($this->defaultLocale);
         }
     }
 


### PR DESCRIPTION
I'm not even sure why this is broken in the first place 🤔 