### PR TITLE
Migrate `JSON_GET_TEXT` and `CAST` in `doctrine.yaml` since 4.1.11

### DIFF
--- a/yaml-migrations/m_2021_01_15-doctrine.yaml
+++ b/yaml-migrations/m_2021_01_15-doctrine.yaml
@@ -1,0 +1,11 @@
+# Adding the new services for Bolt 4.2.0
+file: packages/doctrine.yaml
+since: 4.2.0
+
+add:
+    doctrine:
+        orm:
+            dql:
+                string_functions:
+                    JSON_GET_TEXT: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql\JsonGetText
+                    CAST: Bolt\Doctrine\Query\Cast


### PR DESCRIPTION
Adds the migrations for the recent fix for #2241 and an order change to `JSON_GET_TEXT`