### PR TITLE
Don't require user to re-authenticate after changing user locale

### DIFF
--- a/src/Event/Subscriber/LocaleSubscriber.php
+++ b/src/Event/Subscriber/LocaleSubscriber.php
@@ -36,7 +36,7 @@ class LocaleSubscriber implements EventSubscriberInterface
             $request->setLocale($locale);
         } elseif ($request->attributes->get('zone', false) === 'backend' && $request->getSession()->has('_backend_locale')) {
             $request->setLocale($request->getSession()->get('_backend_locale'));
-        } elseif ($request->getSession()->has('_locale')) {
+        } else {
             $request->setLocale($this->defaultLocale);
         }
     }

--- a/src/Event/Subscriber/UserLocaleSubscriber.php
+++ b/src/Event/Subscriber/UserLocaleSubscriber.php
@@ -49,6 +49,7 @@ class UserLocaleSubscriber implements EventSubscriberInterface
     {
         return [
             SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+            UserEvent::ON_POST_SAVE => 'onUserEdit',
         ];
     }
 }


### PR DESCRIPTION
Fixes a bug that requires the user to re-authenticate in order to apply the locale settings.