### PR TITLE
Bolt generates pretty URLs without `contentTypeSlug` in path or query params

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -208,7 +208,7 @@ class Canonical
     {
         $routes = $this->router->getRouteCollection();
 
-        /** @var Route $routeDefinition */
+        /** @var Route|null $routeDefinition */
         $routeDefinition = $routes->get($route);
 
         if (! $routeDefinition) {

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -211,6 +211,10 @@ class Canonical
         /** @var Route $routeDefinition */
         $routeDefinition = $routes->get($route);
 
+        if (! $routeDefinition) {
+            return false;
+        }
+
         /** @var CompiledRoute $compiledRoute */
         $compiledRoute = $routeDefinition->compile();
 


### PR DESCRIPTION
Fixes #2261

Examples that work with this PR:

```
/page/hello-world -> /hello-world
/nl/page/hallo-wereld -> /nl/hallo-wereld
```

To configure this, put 2 routes in `routes.yaml`:

```yaml
content_seo_locale:
  path: /{_locale}/{slugOrId}
  methods: [GET|POST]
  defaults:
      _controller: Bolt\Controller\Frontend\DetailController::record

content_seo:
    path: /{slugOrId}
    methods: [GET|POST]
    defaults:
        _controller: Bolt\Controller\Frontend\DetailController::record

```

**Note: Naming is important here.** The localised route should be `{{ routeName }}_locale`, whereas the non-localised (generic) route should be `{{ routeName }}`. 

Then, for each Content Type that should have pretty URLs, set `record_locale` to `{{ routeName }}_locale`. This way, Bolt's existing URL shortcut for the default locale will be used. Otherwise, you'd generate links like `/en/hello-world` even for the default locale.

Exceptions can still be handled if you want to use `contentTypeSlug` by using Twig's `path` or the UrlGenerator in code.