### PR TITLE
Pin API-platform to `2.5.*` for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
-        "api-platform/core": "^2.5",
+        "api-platform/core": "2.5.*",
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",
         "bolt/common": "^2.1.10",


### PR DESCRIPTION
Temporary workaround, until we fix #2335 properly.
