### PR TITLE
Fix new checkbox value on existing records

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -189,7 +189,7 @@ class Content
         // Set default status and default values
         $this->setStatus($this->contentTypeDefinition->get('default_status', 'published'));
         $this->contentTypeDefinition->get('fields')->each(function (LaravelCollection $item, string $name): void {
-            if ($item->get('default')) {
+            if ($item->has('default') && $item->get('default') !== null) {
                 $field = FieldRepository::factory($item, $name);
                 $field->setValue($field->getDefaultValue());
 


### PR DESCRIPTION
Fixes an issue where a new checkbox added to an existing record is always (wrongly) set to true.
Fixes the `default` value option for a checkbox to work.