### PR TITLE
Don't show old fields in a `set` if they're removed from the definition

### DIFF
--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -83,7 +83,10 @@ class SetField extends Field implements FieldInterface, FieldParentInterface, Li
     {
         $fieldsFromDefinition = $this->getFieldsFromDefinition();
 
-        return array_merge($fieldsFromDefinition, $this->getDefaultValue(), $this->getValue());
+        // Values from the database, but not of fields that are no longer in the definition.
+        $value = array_intersect_key($this->getValue(), $fieldsFromDefinition);
+
+        return array_merge($fieldsFromDefinition, $this->getDefaultValue(), $value);
     }
 
     private function getFieldsFromDefinition(): array


### PR DESCRIPTION
FIxes #2387 