### PR TITLE
Allow search queries containing special characters (fix for #2427)

### DIFF
--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -98,11 +98,15 @@ class ContentRepository extends ServiceEntityRepository
         $connection = $qb->getEntityManager()->getConnection();
         [$where] = JsonHelper::wrapJsonFunction('t.value', $searchTerm, $connection);
 
+        // The search term must match the format of the content in the database
+        // Therefore, it is JSON encoded and escaped with backslashes
+        $encodedSearchTerm = addslashes(trim(json_encode($searchTerm), '"'));
+
         $qb->addSelect('f')
             ->innerJoin('content.fields', 'f')
             ->innerJoin('f.translations', 't')
             ->andWhere($qb->expr()->like($where, ':search'))
-            ->setParameter('search', '%' . $searchTerm . '%');
+            ->setParameter('search', '%' . $encodedSearchTerm . '%');
 
         // These are the ID's of content we need.
         $ids = array_column($qb->getQuery()->getArrayResult(), 'id');


### PR DESCRIPTION
Hey folks!

This is a fix for the issue I described in #2427.
I added search term encoding & escaping to match the format of the content in `bolt_field_translation`.

There doesn't seem to be any tests for this repository/method, but I tested the change on a Bolt project with: 
- the examples mentioned in the issue
- other strings with accented/special characters
- regular strings without special characters
- email adresses
- numbers

... and they all worked fine. 

If there are tests set up for this and I just missed them somehow, just let me know and I'll take the appropriate steps.

Cheers!