### PR TITLE
Temporary version lock for `api-platform` bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
-        "api-platform/core": "2.5.*",
+        "api-platform/core": "2.5.3",
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",
         "bolt/common": "^2.1.11",
@@ -103,6 +103,10 @@
         "symfony/browser-kit": "^5.1",
         "symfony/css-selector": "^5.1",
         "symplify/easy-coding-standard": "^8.2.3"
+    },
+    "conflict": {
+        "doctrine/common": ">=3.0",
+        "doctrine/persistence": "<1.3"
     },
     "config": {
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
-        "api-platform/core": "2.5.3",
+        "api-platform/core": "2.5.3.*",
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",
         "bolt/common": "^2.1.11",


### PR DESCRIPTION
The main issue, see discussion https://github.com/api-platform/core/issues/3349

![image](https://user-images.githubusercontent.com/7093518/110439132-606c1a80-80b7-11eb-92e5-099536570afd.png)

Fixed by locking `"api-platform/core": "2.5.3"`, which then causes:

![image](https://user-images.githubusercontent.com/7093518/110439300-94dfd680-80b7-11eb-9dc5-873fe0ff04c1.png)

See https://github.com/api-platform/core/issues/3683