### PR TITLE
Fix the `allow_twig` option to work in the preview

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -258,6 +258,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $this->validateCsrf('editrecord');
 
         $content = $this->contentFromPost($content);
+        $this->denyAccessUnlessGranted(ContentVoter::CONTENT_VIEW, $content);
 
         $event = new ContentEvent($content);
         $this->dispatcher->dispatch($event, ContentEvent::ON_PREVIEW);

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -258,21 +258,11 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $this->validateCsrf('editrecord');
 
         $content = $this->contentFromPost($content);
-        $this->denyAccessUnlessGranted(ContentVoter::CONTENT_VIEW, $content);
-
-        $recordSlug = $content->getDefinition()->get('singular_slug');
 
         $event = new ContentEvent($content);
         $this->dispatcher->dispatch($event, ContentEvent::ON_PREVIEW);
 
-        $context = [
-            'record' => $content,
-            $recordSlug => $content,
-        ];
-
-        $templates = $this->templateChooser->forRecord($content);
-
-        return $this->render($templates, $context);
+        return $this->renderSingle($content, false);
     }
 
     /**

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -9,6 +9,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use Bolt\Common\Arr;
 use Bolt\Configuration\Content\FieldType;
+use Bolt\Event\Listener\FieldFillListener;
 use Doctrine\ORM\Mapping as ORM;
 use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
@@ -237,6 +238,10 @@ class Field implements FieldInterface, TranslatableInterface
         if (is_string($value) && $this->getContent() && $this->getDefinition()->get('sanitise')) {
             $value = $this->getContent()->sanitise($value);
         }
+
+        // Trim the zero spaces even before saving in FieldFillListener.
+        // Otherwise, the preview contains zero width whitespace.
+        $value = is_string($value) ? FieldFillListener::trimZeroWidthWhitespace($value) : $value;
 
         if ($this->shouldBeRenderedAsTwig($value)) {
             $twig = $this->getContent()->getTwig();

--- a/src/Event/Listener/FieldFillListener.php
+++ b/src/Event/Listener/FieldFillListener.php
@@ -67,11 +67,11 @@ class FieldFillListener
 
         foreach ($value as $key => $v) {
             if ($v instanceof Markup) {
-                $v = $this->trimZeroWidthWhitespace((string) $v);
+                $v = self::trimZeroWidthWhitespace((string) $v);
                 // todo: Figure out how to preserve original encoding
                 $v = new Markup($this->sanitiser->clean($v), 'UTF-8');
             } elseif (is_string($v)) {
-                $v = $this->trimZeroWidthWhitespace($v);
+                $v = self::trimZeroWidthWhitespace($v);
                 $v = $this->sanitiser->clean($v);
             }
 
@@ -84,7 +84,7 @@ class FieldFillListener
     /**
      * Remove the 'zero width space' from `{{` and `}}`, added in the editor.
      */
-    public function trimZeroWidthWhitespace(string $string): string
+    public static function trimZeroWidthWhitespace(string $string): string
     {
         return preg_replace('/([{}])[\x{200B}-\x{200D}\x{FEFF}]([{}])/u', '$1$2', $string);
     }


### PR DESCRIPTION
Fixes a few things related to the preview, among which:

- the `allow_twig`
- makes sure the `record` global variable is set in the preview
- makes sure there's _minimal_ differences between the preview and the actual record handling

LESS CODE IS MORE 🚀