### PR TITLE
Minor mobile improvements to content editing

### DIFF
--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -6,7 +6,18 @@
             </div>
         </transition>
         <div class="row">
-            <div class="col-9">
+            <div class="col-12 col-md-3 order-md-2">
+                <div class="editor__image--preview">
+                    <a
+                        v-if="thumbnailImage !== null && thumbnailImage !== ''"
+                        class="editor__image--preview-image"
+                        :href="previewImage"
+                        :style="`background-image: url('${thumbnailImage}')`"
+                    >
+                    </a>
+                </div>
+            </div>
+            <div class="col order-md-1">
                 <div class="input-group mb-3">
                     <input :name="name + '[media]'" type="hidden" :value="media" />
                     <input
@@ -129,17 +140,6 @@
                         aria-valuemax="100"
                         :style="`width: ${progress}%`"
                     ></div>
-                </div>
-            </div>
-            <div class="col-3">
-                <div class="editor__image--preview">
-                    <a
-                        v-if="thumbnailImage !== null && thumbnailImage !== ''"
-                        class="editor__image--preview-image"
-                        :href="previewImage"
-                        :style="`background-image: url('${thumbnailImage}')`"
-                    >
-                    </a>
                 </div>
             </div>
         </div>

--- a/assets/scss/modules/admin/_menupage.scss
+++ b/assets/scss/modules/admin/_menupage.scss
@@ -1,22 +1,22 @@
 
 .admin__body {
-    .menupage {
-        ul {
-            list-style: none;
-            padding-left: 0;
-            width: fit-content;
-            margin: 0 auto;
+  .menupage {
+    ul {
+      list-style: none;
+      padding-left: 0;
+      width: fit-content;
+      margin: 0 auto;
 
-            @include media-breakpoint-up(sm) {
-                margin-left: unset;
-            }
+      @include media-breakpoint-up(sm) {
+        margin-left: unset;
+      }
 
-            li {
-                a {
-                    min-width: 20em;
-                    text-align: left;
-                }
-            }
+      li {
+        a {
+          min-width: 20em;
+          text-align: left;
         }
+      }
     }
+  }
 }

--- a/assets/scss/modules/admin/_menupage.scss
+++ b/assets/scss/modules/admin/_menupage.scss
@@ -1,0 +1,22 @@
+
+.admin__body {
+    .menupage {
+        ul {
+            list-style: none;
+            padding-left: 0;
+            width: fit-content;
+            margin: 0 auto;
+
+            @include media-breakpoint-up(sm) {
+                margin-left: unset;
+            }
+
+            li {
+                a {
+                    min-width: 20em;
+                    text-align: left;
+                }
+            }
+        }
+    }
+}

--- a/assets/scss/modules/admin/admin.scss
+++ b/assets/scss/modules/admin/admin.scss
@@ -3,4 +3,5 @@
 @import '_sidebar';
 @import '_header';
 @import '_toolbar';
+@import '_menupage.scss';
 @import '_widgets';

--- a/templates/content/_buttons.html.twig
+++ b/templates/content/_buttons.html.twig
@@ -1,6 +1,6 @@
 {% import '@bolt/_macro/_macro.html.twig' as macro %}
 
-<div class="record-actions {% if hide_on_mobile|default(false) %}d-lg-none d-xl-block{% endif %}">
+<div class="record-actions {% if hide_on_mobile|default(false) %}d-none d-xl-block{% endif %}">
     {% if is_granted('edit', record) %}
         {{ macro.button('action.save', 'fa-save', 'success mb-0', {'type': 'submit', 'form': 'editcontent', 'data-patience': 'virtue', 'name': 'save'}) }}
     {% endif %}

--- a/templates/pages/menupage.html.twig
+++ b/templates/pages/menupage.html.twig
@@ -20,11 +20,15 @@
 
 {% block main %}
 
-    <p>
-    {% for sub in menu.submenu %}
-        {{ macro.buttonlink(sub.name, sub.editLink, sub.icon, 'light', {'style': 'width: 20em; text-align: left;'}, false) }} <br>
-    {% endfor %}
-    </p>
+    <div class="menupage">
+        <ul>
+        {% for sub in menu.submenu %}
+            <li>
+                {{ macro.buttonlink(sub.name, sub.editLink, sub.icon, 'light menupage__button', [],false) }}
+            </li>
+        {% endfor %}
+        </ul>
+    </div>
 
 {% endblock main %}
 

--- a/tests/e2e/users.feature
+++ b/tests/e2e/users.feature
@@ -4,7 +4,7 @@ Feature: Users & Permissions
     Given I am logged in as "admin"
     When I follow "Configuration"
     #Users & Permissions
-    When I click "body > div.admin > div.admin__body > div.admin__body--container.admin__body--container--has-sidebar > main > .menupage > a:nth-child(1)"
+    When I click "body > div.admin > div.admin__body > div.admin__body--container.admin__body--container--has-sidebar > main > .menupage a:nth-child(1)"
     Then I should be on "/bolt/users"
     #users table
     And the columns schema of the "body > div.admin > div.admin__body > div.admin__body--container > main > table:nth-child(1)" table should match:

--- a/tests/e2e/users.feature
+++ b/tests/e2e/users.feature
@@ -4,7 +4,7 @@ Feature: Users & Permissions
     Given I am logged in as "admin"
     When I follow "Configuration"
     #Users & Permissions
-    When I click "body > div.admin > div.admin__body > div.admin__body--container.admin__body--container--has-sidebar > main > p > a:nth-child(1)"
+    When I click "body > div.admin > div.admin__body > div.admin__body--container.admin__body--container--has-sidebar > main > .menupage > a:nth-child(1)"
     Then I should be on "/bolt/users"
     #users table
     And the columns schema of the "body > div.admin > div.admin__body > div.admin__body--container > main > table:nth-child(1)" table should match:


### PR DESCRIPTION
- Image field preview is full-width on mobile, as a two-column layout with the input.
- Don't repeat the "Save/Preview" buttons twice on mobile
- Center and clean up the menupage buttons on mobile