### PR TITLE
Use form and shape in addition to colour for content statuses

### DIFF
--- a/assets/scss/modules/base/_status.scss
+++ b/assets/scss/modules/base/_status.scss
@@ -1,26 +1,67 @@
 //** Base | Status
 
+.apply-fa {
+  font-family: 'Font Awesome 5 Free', serif;
+  font-weight: 900;
+}
+
+.apply-fas {
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-feature-settings: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+}
+
 .status {
   width: 12px;
   height: 12px;
   border-radius: 100%;
-  background: var(--shade);
   display: inline-flex;
 
+  @extend .apply-fa;
+  @extend .apply-fas;
+
   &.is-published {
-    background: var(--status-published);
+    color: var(--status-published);
+
+    &::before {
+      content: "\f058"; // check mark
+    }
   }
 
   &.is-held {
-    background: var(--status-held);
+    color: var(--status-held);
+
+    &::before {
+      content: "\f057"; // times circle
+    }
   }
 
   &.is-draft {
-    background: var(--status-draft);
+    color: var(--status-draft);
+    border-radius: 50%;
+
+    &::before {
+      content: "\f14b"; // pen-square
+    }
   }
 
   &.is-timed {
     background: var(--status-timed);
+    color: $white;
+    position: relative;
+
+    &::before {
+      content: "\f017"; // clock
+      font-size: 0.6em;
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transform: translate(-45%, -50%);
+    }
   }
 }
 


### PR DESCRIPTION
**Before:**
![Screenshot 2021-03-25 at 11 57 08](https://user-images.githubusercontent.com/7093518/112463209-43e00b80-8d62-11eb-8004-1cc6c4553781.png)
![Screenshot 2021-03-25 at 11 56 47](https://user-images.githubusercontent.com/7093518/112463217-45a9cf00-8d62-11eb-92c8-3087fbb2b016.png)

**After:**
![Screenshot 2021-03-25 at 11 54 46](https://user-images.githubusercontent.com/7093518/112463225-47739280-8d62-11eb-81ea-e8957241339f.png)
![Screenshot 2021-03-25 at 11 59 12](https://user-images.githubusercontent.com/7093518/112463203-42164800-8d62-11eb-92b9-a38842598c82.png)

Bit of an ugly SCSS implementation, but it makes sure it's done across the board and keeps simple `status is-published`, `status is-held`, etc. classes.