### PR TITLE
Add `copy to clipboard` for suggested password. Fix view password glitch

### DIFF
--- a/assets/js/app/editor/Components/Password.vue
+++ b/assets/js/app/editor/Components/Password.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="input-group-prepend">
+        <div class="input-group">
             <input
                 :id="id"
                 ref="inputField"
@@ -17,7 +17,13 @@
                 @input="measureStrength"
             />
 
-            <i ref="visibilityToggle" class="input-group-text toggle-password fas fa-eye" @click="togglePassword"></i>
+            <div class="input-group-append">
+                <i
+                    ref="visibilityToggle"
+                    class="input-group-text toggle-password fas fa-eye"
+                    @click="togglePassword"
+                ></i>
+            </div>
         </div>
         <progress-bar v-if="strength" ref="progressBar" :max="4" height="4px"></progress-bar>
     </div>
@@ -59,7 +65,7 @@ export default {
     methods: {
         togglePassword(event) {
             const iconElement = event.target;
-            const inputElement = event.target.previousElementSibling;
+            const inputElement = this.$el.querySelector('#' + this.id);
             const inputType = inputElement.attributes.getNamedItem('type').value;
 
             if (inputType === 'password') {

--- a/assets/scss/modules/user/user.scss
+++ b/assets/scss/modules/user/user.scss
@@ -4,4 +4,15 @@
 
 .toggle-password {
   cursor: pointer;
+  margin-right: 0;
+  width: 3em;
+  padding: 0;
+  position: relative;
+
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }

--- a/templates/users/_form.html.twig
+++ b/templates/users/_form.html.twig
@@ -39,6 +39,13 @@
     {% set use_suggested_pw = userForm.plainPassword.vars.required %}
     {% set suggested_pw = userForm.plainPassword.vars.attr.suggested_password %}
 
+    {% set suggested_pw_postfix %}{% apply spaceless %}
+        <div>
+            {{ 'password.suggested'|trans({'%password%': suggested_pw })|raw }}
+            <i style="cursor: pointer;" class="fas fa-clipboard-check ml-2" data-copy-to-clipboard="{{ suggested_pw }}"></i>
+        </div>
+    {% endapply %}{% endset %}
+
     {% include '@bolt/_partials/fields/password.html.twig' with {
         'id' : userForm.plainPassword.vars.id,
         'label': 'label.password'|trans,
@@ -46,7 +53,7 @@
         'value': use_suggested_pw ? suggested_pw : '',
         'hidden': 'true',
         'strength': true,
-        'postfix': __('password.suggested', {'%password%': suggested_pw }),
+        'postfix': ''~suggested_pw_postfix,
         'required': userForm.plainPassword.vars.required,
     } %}
     {% if form_errors(userForm.plainPassword) is not empty %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7093518/112500058-566d3b80-8d88-11eb-8f54-a5adc7cdb3f7.png)

And fixes a glitch where clicking the eye icon moved it a couple of pixels.