### PR TITLE
Only show generic `Invalid credentials` error if error is credentials related

### DIFF
--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -154,7 +155,11 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): RedirectResponse
     {
-        parent::onAuthenticationFailure($request, $exception);
+        // Don't reveal the specifics of the $exception (e.g. username not found),
+        // instead only show a bad credentials exception.
+        $authenticationException = new BadCredentialsException();
+
+        parent::onAuthenticationFailure($request, $authenticationException);
 
         // Redirect back to where we came from
         return new RedirectResponse($request->headers->get('referer'));

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -157,7 +157,7 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): RedirectResponse
     {
         // Don't reveal a UsernameNotFound exception.
-        if ($exception instanceof BadCredentialsException || $exception instanceof UsernameNotFoundException) {
+        if ($exception instanceof UsernameNotFoundException) {
             $exception = new BadCredentialsException();
         }
 

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
@@ -155,11 +156,12 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): RedirectResponse
     {
-        // Don't reveal the specifics of the $exception (e.g. username not found),
-        // instead only show a bad credentials exception.
-        $authenticationException = new BadCredentialsException();
+        // Don't reveal a UsernameNotFound exception.
+        if ($exception instanceof BadCredentialsException || $exception instanceof UsernameNotFoundException) {
+            $exception = new BadCredentialsException();
+        }
 
-        parent::onAuthenticationFailure($request, $authenticationException);
+        parent::onAuthenticationFailure($request, $exception);
 
         // Redirect back to where we came from
         return new RedirectResponse($request->headers->get('referer'));


### PR DESCRIPTION
Don't show that a username is "guesstimated" by switching between `Username not found` and `Invalid credentials` exception. Instead, only ever show `Invalid credentials` for credentials issues.