### PR TITLE
Use `CompletePackageInterface` in BaseExtension

### DIFF
--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -7,7 +7,7 @@ namespace Bolt\Extension;
 use Bolt\Widget\WidgetInterface;
 use Bolt\Widgets;
 use Cocur\Slugify\Slugify;
-use Composer\Package\CompletePackage;
+use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use ComposerPackages\Packages;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -153,7 +153,7 @@ abstract class BaseExtension implements ExtensionInterface
      * Get the ComposerPackage, that contains information about the package,
      * version, etc.
      */
-    public function getComposerPackage(): ?CompletePackage
+    public function getComposerPackage(): ?CompletePackageInterface
     {
         $className = $this->getClass();
 

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Extension;
 
-use Composer\Package\CompletePackage;
+use Composer\Package\CompletePackageInterface;
 
 interface ExtensionInterface
 {
@@ -18,5 +18,5 @@ interface ExtensionInterface
 
     public function initialize(): void;
 
-    public function getComposerPackage(): ?CompletePackage;
+    public function getComposerPackage(): ?CompletePackageInterface;
 }


### PR DESCRIPTION
Prevents: 

```
Return value of Bolt\Extension\BaseExtension::getComposerPackage() must be an instance of Composer\Package\CompletePackage or null, instance of Composer\Package\AliasPackage returned
```

![Schermafbeelding 2021-04-02 om 12 25 23](https://user-images.githubusercontent.com/1833361/113408121-1113c400-93af-11eb-8eb3-6c2a71ad512e.png)
