### PR TITLE
Allow parsing of `localdate`s like `now` or `today + 1 week, 21:00`

### DIFF
--- a/src/Twig/LocaleExtension.php
+++ b/src/Twig/LocaleExtension.php
@@ -169,7 +169,7 @@ class LocaleExtension extends AbstractExtension
         } elseif (empty($dateTime)) {
             $dateTime = Carbon::now();
         } else {
-            $dateTime = Carbon::createFromTimeString($dateTime);
+            $dateTime = Carbon::parse($dateTime);
         }
 
         if ($format === null) {


### PR DESCRIPTION
Fixes #2516 