### PR TITLE
Show `404` instead of Exception when missing secret

### DIFF
--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -56,7 +56,8 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
 
         $this->contentHelper->setCanonicalPath($record);
 
-        if ($this->validateSecret($this->request->get('secret', ''), (string) $record->getId())) {
+        // Check if we're attempting to preview an unpublished Record
+        if ($record && $this->validateSecret($this->request->get('secret', ''), (string) $record->getId())) {
             $requirePublished = false;
         }
 


### PR DESCRIPTION
Fixes this error / exception: 

![Schermafbeelding 2021-04-09 om 15 26 48](https://user-images.githubusercontent.com/1833361/114188170-29ed1e00-9949-11eb-838b-a46150e5f8e9.png)
