### PR TITLE
Improve contrast ratio in filemanager

### DIFF
--- a/templates/finder/_files_list.html.twig
+++ b/templates/finder/_files_list.html.twig
@@ -45,7 +45,7 @@
                         {{ file.getRelativePathname|shy }}
                     </a>
                 </b>
-                {% if title %}<br><small style="color: #888;">{{ title }}</small>{% endif %}
+                {% if title %}<br><small>{{ title }}</small>{% endif %}
             </td>
             <td class="listing-thumb">
                 {%- if thumbnail -%}
@@ -58,12 +58,12 @@
                 {%- endif -%}
             </td>
             <td>
-                <small style="color: #888; white-space:nowrap;">{{ file.getSize()|format_bytes(1) }}
+                <small style="white-space:nowrap;">{{ file.getSize()|format_bytes(1) }}
                 {% if dimensions %}<br>{{ dimensions }}{% endif %}
                 </small>
             </td>
             <td>
-                <small style="color: #888;">{{ file.getCTime()|date('Y-m-d H:i:s') }}</small>
+                <small>{{ file.getCTime()|date('Y-m-d H:i:s') }}</small>
             </td>
             <td>
                 {% include '@bolt/finder/_files_actions.html.twig' %}


### PR DESCRIPTION
Fixes #1997.

The button contrast seems to be already fixed. This PR only fixes the contrast of the text. See screenshot.

Before:
![before](https://user-images.githubusercontent.com/6607455/114706837-cd637780-9d29-11eb-8a62-042a92de6cf8.JPG)

After:
![after](https://user-images.githubusercontent.com/6607455/114706860-d2c0c200-9d29-11eb-9971-0e806194abb3.JPG)



