### PR TITLE
Improve backend search box accessibility

### DIFF
--- a/assets/js/app/toolbar/Components/Toolbar.vue
+++ b/assets/js/app/toolbar/Components/Toolbar.vue
@@ -16,6 +16,7 @@
         </div>
 
         <form :action="backendPrefix" class="toolbar-item toolbar-item__filter input-group">
+            <label for="global-search" class="sr-only">{{ labels['general.label.search'] }}</label>
             <input
                 id="global-search"
                 type="text"

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -40,6 +40,7 @@
             'about.visit_bolt': 'about.visit_bolt'|trans,
             'listing.button_search': 'general.phrase.search'|trans,
             'listing.placeholder_search': 'listing.placeholder_search'|trans,
+            'general.label.search': 'general.label.search'|trans,
         }|json_encode %}
 
         <admin-toolbar


### PR DESCRIPTION
This PR is part of #2429 .

It adds a label to the search input field visible only to screen readers .