### PR TITLE
Allow `SelectField` options from callables and services

### DIFF
--- a/src/Entity/Field/SelectField.php
+++ b/src/Entity/Field/SelectField.php
@@ -73,7 +73,7 @@ class SelectField extends Field implements FieldInterface, RawPersistable, \Iter
         $values = $this->getDefinition()->get('values');
 
         // Check if it is a service
-        if (self::$container && self::$container->has($values)) {
+        if (self::$container && is_string($values) && self::$container->has($values)) {
             $class = self::$container->get($values);
             // the name of the function
             $func = 'getOptions';

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -6,6 +6,7 @@ namespace Bolt;
 
 use Bolt\Configuration\Parser\ContentTypesParser;
 use Bolt\Configuration\Parser\TaxonomyParser;
+use Bolt\Entity\Field\SelectField;
 use Bolt\Extension\ExtensionCompilerPass;
 use Bolt\Extension\ExtensionInterface;
 use Bolt\Repository\FieldRepository;
@@ -42,6 +43,7 @@ class Kernel extends BaseKernel
         // Add the entity manager as a static class property used in FieldRepository::factory()
         $manager = $this->getContainer()->get('doctrine')->getManager();
         FieldRepository::setEntityManager($manager);
+        SelectField::setContainer(self::getContainer());
     }
 
     public function build(ContainerBuilder $container): void

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -13,6 +13,7 @@ use Bolt\Entity\Field;
 use Bolt\Entity\Field\Excerptable;
 use Bolt\Entity\Field\ImageField;
 use Bolt\Entity\Field\ImagelistField;
+use Bolt\Entity\Field\SelectField;
 use Bolt\Entity\Field\TemplateselectField;
 use Bolt\Entity\Taxonomy;
 use Bolt\Enum\Statuses;
@@ -561,7 +562,11 @@ class ContentExtension extends AbstractExtension
 
     public function selectOptions(Field $field): Collection
     {
-        $values = $field->getDefinition()->get('values');
+        if (! $field instanceof SelectField) {
+            return collect([]);
+        }
+
+        $values = $field->getOptions();
 
         if (is_iterable($values)) {
             return $this->selectOptionsArray($field);
@@ -572,7 +577,11 @@ class ContentExtension extends AbstractExtension
 
     private function selectOptionsArray(Field $field): Collection
     {
-        $values = $field->getDefinition()->get('values');
+        if (! $field instanceof SelectField) {
+            return collect([]);
+        }
+
+        $values = $field->getOptions();
         $currentValues = $field->getValue();
 
         $options = [];


### PR DESCRIPTION
Two new options:

**Option 1: Static callable**

Example `contenttypes.yaml` configuration:


```yaml
        books:
            type: select
            values: App\Books::getOptions
```


Allows you to implement an `App\Books` class like so (where the `$field` argument is optional):

```
<?php

declare(strict_types=1);

namespace App;

use Bolt\Entity\Field\SelectField;

class Books
{
    public static function getOptions(SelectField $field): iterable
    {
        return [
            'Animal Farm',
            '1984',
        ];
    }
}
```

**Option 2: Callable as a Symfony service (with autowiring and autoloading)**


Example `contenttypes.yaml` configuration:

```yaml
        books:
            type: select
            values: App\Books
```

Allows you to implement an `App\Books` class like so (where the `$field` argument is optional):
**Important**: the `App\Books` service **must** explicitly be [public](https://symfony.com/doc/current/service_container/alias_private.html#marking-services-as-public-private), so that it does not get automatically removed from the container if unused 

```php
<?php

declare(strict_types=1);

namespace App;

class Books
{
    public function __construct(SomeNiceService $service)
    {
        $this->service = $service;
    }

    public function getOptions(SelectField $field): iterable
    {
        // $this->service is available here
        return $this->service->getBooks();
    }
}
```
_Note:_ the method name `getOptions` is significant in this case.

