### PR TITLE
Support multiple targets for widget, keeping `$target` too

### DIFF
--- a/src/Widget/BaseWidget.php
+++ b/src/Widget/BaseWidget.php
@@ -25,6 +25,9 @@ abstract class BaseWidget implements WidgetInterface
     /** @var string from Target enum */
     protected $target;
 
+    /** @var string[] */
+    protected $targets = [];
+
     /** @var string from RequestZone */
     protected $zone;
 
@@ -46,7 +49,7 @@ abstract class BaseWidget implements WidgetInterface
     /** @var int duration (in seconds) to cache output */
     protected $cacheDuration = 600;
 
-    public function setName(string $name): self
+    public function setName(string $name): WidgetInterface
     {
         $this->name = $name;
         $this->slug = null;
@@ -63,20 +66,51 @@ abstract class BaseWidget implements WidgetInterface
         return $this->name;
     }
 
-    public function setTarget(string $target): self
+    public function getTargets(): array
     {
-        $this->target = $target;
+        // backwards compatibility for $target
+        if ($this->target && ! $this->hasTarget($this->target)) {
+            $this->targets[] = $this->target;
+        }
+
+        if ($this->targets === null) {
+            throw new WidgetException("Widget {$this->getName()} does not have Targets set");
+        }
+
+        return $this->targets;
+    }
+
+    /**
+     * @var string[]
+     */
+    public function setTargets(array $targets): WidgetInterface
+    {
+        $this->targets = $targets;
 
         return $this;
     }
 
-    public function getTarget(): string
+    public function addTarget(string $target): WidgetInterface
     {
-        if ($this->target === null) {
-            throw new WidgetException("Widget {$this->getName()} does not have Target set");
+        if (! $this->hasTarget($target)) {
+            $this->targets[] = $target;
         }
 
-        return $this->target;
+        return $this;
+    }
+
+    public function removeTarget(string $target): WidgetInterface
+    {
+        if ($this->hasTarget($target)) {
+            unset($this->targets[$target]);
+        }
+
+        return $this;
+    }
+
+    public function hasTarget(string $target): bool
+    {
+        return is_array($this->targets) && in_array($target, $this->targets, true);
     }
 
     public function setPriority(int $priority): self

--- a/src/Widget/BoltHeaderWidget.php
+++ b/src/Widget/BoltHeaderWidget.php
@@ -27,9 +27,9 @@ class BoltHeaderWidget extends BaseWidget implements WidgetInterface, ResponseAw
         return 'Bolt Header Widget';
     }
 
-    public function getTarget(): string
+    public function getTargets(): array
     {
-        return Target::NOWHERE;
+        return [Target::NOWHERE];
     }
 
     public function getPriority(): int

--- a/src/Widget/BoltHeaderWidget.php
+++ b/src/Widget/BoltHeaderWidget.php
@@ -8,7 +8,7 @@ use Bolt\Extension\ExtensionInterface;
 use Bolt\Widget\Injector\RequestZone;
 use Bolt\Widget\Injector\Target;
 
-class BoltHeaderWidget implements WidgetInterface, ResponseAwareInterface
+class BoltHeaderWidget extends BaseWidget implements WidgetInterface, ResponseAwareInterface
 {
     use ResponseTrait;
 

--- a/src/Widget/ResponseTrait.php
+++ b/src/Widget/ResponseTrait.php
@@ -12,7 +12,7 @@ trait ResponseTrait
     /** @var Response */
     private $response;
 
-    public function setResponse(Response $response): self
+    public function setResponse(Response $response): WidgetInterface
     {
         $this->response = $response;
 

--- a/src/Widget/SnippetWidget.php
+++ b/src/Widget/SnippetWidget.php
@@ -11,19 +11,19 @@ class SnippetWidget extends BaseWidget
 {
     protected $name;
     protected $type;
-    protected $target;
+    protected $targets;
     protected $zone;
     protected $priority;
 
     public function __construct(
         string $snippet = '<!-- snippet -->',
         string $name = 'Nameless Snippet',
-        string $target = Target::NOWHERE,
+        array $targets = [Target::NOWHERE],
         string $zone = RequestZone::NOWHERE
     ) {
         $this->setTemplate($snippet);
         $this->setName($name);
-        $this->setTargets([$target]);
+        $this->setTargets($targets);
         $this->setZone($zone);
     }
 

--- a/src/Widget/SnippetWidget.php
+++ b/src/Widget/SnippetWidget.php
@@ -18,11 +18,14 @@ class SnippetWidget extends BaseWidget
     public function __construct(
         string $snippet = '<!-- snippet -->',
         string $name = 'Nameless Snippet',
-        array $targets = [Target::NOWHERE],
+        $targets = [Target::NOWHERE],
         string $zone = RequestZone::NOWHERE
     ) {
         $this->setTemplate($snippet);
         $this->setName($name);
+
+        $targets = is_array($targets) ? $targets : [$targets];
+
         $this->setTargets($targets);
         $this->setZone($zone);
     }

--- a/src/Widget/SnippetWidget.php
+++ b/src/Widget/SnippetWidget.php
@@ -21,10 +21,10 @@ class SnippetWidget extends BaseWidget
         string $target = Target::NOWHERE,
         string $zone = RequestZone::NOWHERE
     ) {
-        $this->template = $snippet;
-        $this->name = $name;
-        $this->target = $target;
-        $this->zone = $zone;
+        $this->setTemplate($snippet);
+        $this->setName($name);
+        $this->setTargets([$target]);
+        $this->setZone($zone);
     }
 
     protected function run(array $params = []): ?string

--- a/src/Widget/WidgetInterface.php
+++ b/src/Widget/WidgetInterface.php
@@ -14,9 +14,29 @@ interface WidgetInterface
     public function getName(): string;
 
     /**
-     * @return string from Bolt\Widget\Injector\Target constants enum
+     * @return string[] from Bolt\Widget\Injector\Target constants enum
      */
-    public function getTarget(): string;
+    public function getTargets(): array;
+
+    /**
+     * @param string[] $targets from Bolt\Widget\Injector\Target constants enum
+     */
+    public function setTargets(array $targets): self;
+
+    /**
+     * @param string $target from Bolt\Widget\Injector\Target constants enum
+     */
+    public function addTarget(string $target): self;
+
+    /**
+     * @param string $target from Bolt\Widget\Injector\Target constants enum
+     */
+    public function removeTarget(string $target): self;
+
+    /**
+     * @param string $target from Bolt\Widget\Injector\Target constants enum
+     */
+    public function hasTarget(string $target): bool;
 
     public function getPriority(): int;
 

--- a/src/Widgets.php
+++ b/src/Widgets.php
@@ -103,7 +103,7 @@ class Widgets
     private function filteredWidgets(string $target): Collection
     {
         return $this->queue->filter(function (WidgetInterface $widget) use ($target) {
-            return $widget->getTarget() === $target;
+            return in_array($target, $widget->getTargets(), true);
         })->sortBy(function (WidgetInterface $widget) {
             return $widget->getPriority();
         });

--- a/tests/php/Widget/WidgetsTest.php
+++ b/tests/php/Widget/WidgetsTest.php
@@ -51,7 +51,7 @@ class WidgetsTest extends StringTestCase
         $snippet = (new SnippetWidget())
             ->setTemplate('*foo*')
             ->setZone(RequestZone::EVERYWHERE)
-            ->setTarget(Target::END_OF_BODY);
+            ->addTarget(Target::END_OF_BODY);
 
         $widgets->registerWidget($snippet);
         $widgets->processQueue($response);
@@ -112,7 +112,7 @@ class WidgetsTest extends StringTestCase
         $referenceWidget = new ReferenceWidget();
 
         // overwrite things just to simplify test
-        $referenceWidget->setTarget(Target::END_OF_BODY);
+        $referenceWidget->addTarget(Target::END_OF_BODY);
         $referenceWidget->setTemplate('reference.twig');
 
         $widgets->registerWidget($referenceWidget);
@@ -133,7 +133,7 @@ class WidgetsTest extends StringTestCase
         $reference = new ReferenceWidget();
 
         // overwrite things just to simplify test
-        $reference->setTarget(Target::START_OF_BODY);
+        $reference->addTarget(Target::START_OF_BODY);
         $reference->setTemplate('reference.twig');
 
         $widgets->registerWidget($reference);


### PR DESCRIPTION
Fixes #1585

It also keeps a single `$target` class variable, for ease of use and backwards compatibility. Apart from that, all other handling should be handled as an array of targets.