### PR TITLE
Allow sensio/framework-extra-bundle version 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/event-dispatcher": "^1.0",
         "psr/simple-cache": "^1.0",
         "scienta/doctrine-json-functions": "^4.1",
-        "sensio/framework-extra-bundle": "^5.6",
+        "sensio/framework-extra-bundle": "^5.6 || ^6.0",
         "sensiolabs/security-checker": "^6.0",
         "siriusphp/upload": "^3.0.1",
         "squirrelphp/twig-php-syntax": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/event-dispatcher": "^1.0",
         "psr/simple-cache": "^1.0",
         "scienta/doctrine-json-functions": "^4.1",
-        "sensio/framework-extra-bundle": "^5.6 || ^6.0",
+        "sensio/framework-extra-bundle": "^6.1",
         "sensiolabs/security-checker": "^6.0",
         "siriusphp/upload": "^3.0.1",
         "squirrelphp/twig-php-syntax": "^1.5",


### PR DESCRIPTION
I'm not sure if PSR-7 is actually used by this bundle, but that is the only major change between v5 en v6 of `sensio/framework-extra-bundle` (see https://github.com/sensiolabs/SensioFrameworkExtraBundle/pull/710 / https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/CHANGELOG.md). 

It seems to work fine for me when forcing composer to install v6.1.2.