### PR TITLE
Fix a CSS quirk in listing overview pages

### DIFF
--- a/assets/js/app/listing/Components/Table/Row/_Meta.vue
+++ b/assets/js/app/listing/Components/Table/Row/_Meta.vue
@@ -11,7 +11,7 @@
                 <template v-if="type === 'dashboard'"
                     ><a :href="`/bolt/content/${record.contentType}`"> {{ record.extras.singular_name }}</a>
                 </template>
-                <template v-else>{{ record.extras.singular_name | trim(14) }}</template
+                <template v-else>{{ record.extras.singular_name }}</template
                 >&nbsp;№ {{ record.id }}
             </li>
         </ul>

--- a/assets/js/app/listing/Components/Table/Row/_Meta.vue
+++ b/assets/js/app/listing/Components/Table/Row/_Meta.vue
@@ -11,7 +11,7 @@
                 <template v-if="type === 'dashboard'"
                     ><a :href="`/bolt/content/${record.contentType}`"> {{ record.extras.singular_name }}</a>
                 </template>
-                <template v-else>{{ record.extras.singular_name }}</template
+                <template v-else>{{ record.extras.singular_name|trim(14) }}</template
                 >&nbsp;№ {{ record.id }}
             </li>
         </ul>

--- a/assets/js/app/listing/Components/Table/Row/_Meta.vue
+++ b/assets/js/app/listing/Components/Table/Row/_Meta.vue
@@ -11,7 +11,7 @@
                 <template v-if="type === 'dashboard'"
                     ><a :href="`/bolt/content/${record.contentType}`"> {{ record.extras.singular_name }}</a>
                 </template>
-                <template v-else>{{ record.extras.singular_name|trim(14) }}</template
+                <template v-else>{{ record.extras.singular_name | trim(14) }}</template
                 >&nbsp;№ {{ record.id }}
             </li>
         </ul>

--- a/assets/scss/modules/listing/row/row.scss
+++ b/assets/scss/modules/listing/row/row.scss
@@ -170,7 +170,7 @@ $checkbox-row-width: 32px;
     }
 
     &.is-meta {
-      flex: 1 0 65%;
+      flex: 1 0 68%;
       display: flex;
       flex-wrap: wrap;
       padding-top: 0;
@@ -185,8 +185,8 @@ $checkbox-row-width: 32px;
       }
 
       @include media-breakpoint-up(md) {
-        flex: 0 0 130px;
-        max-width: 130px;
+        flex: 0 0 140px;
+        max-width: 140px;
         order: 3;
         padding: $spacer*0.5;
       }
@@ -216,12 +216,9 @@ $checkbox-row-width: 32px;
   }
 
   &--list {
-    display: flex;
-    flex-wrap: wrap;
     padding: 0;
     list-style: none;
     font-size: 0.8rem;
-    line-height: 1.6;
     letter-spacing: $letter-spacing;
     margin-bottom: 0;
 

--- a/assets/scss/modules/listing/row/row.scss
+++ b/assets/scss/modules/listing/row/row.scss
@@ -171,7 +171,7 @@ $checkbox-row-width: 32px;
 
     &.is-meta {
       flex: 1 0 68%;
-      display: flex;
+      display: block;
       flex-wrap: wrap;
       padding-top: 0;
       margin-bottom: 0;
@@ -185,10 +185,11 @@ $checkbox-row-width: 32px;
       }
 
       @include media-breakpoint-up(md) {
-        flex: 0 0 140px;
-        max-width: 140px;
+        flex: 0 0 155px;
+        max-width: 155px;
         order: 3;
-        padding: $spacer*0.5;
+        padding: $spacer*0.5 0 $spacer*0.3 $spacer*0.5;
+        margin-right: -2rem;
       }
     }
 
@@ -228,12 +229,12 @@ $checkbox-row-width: 32px;
     }
 
     li {
-      //display: flex;
       padding-right: 1rem;
-      //align-items: center;
       margin-bottom: $spacer / 4;
       color: var(--shade);
       text-transform: capitalize;
+      text-overflow: ellipsis;
+      overflow: hidden;
 
       > :first-child,
       .status,


### PR DESCRIPTION
Before: 

![Screenshot 2021-04-28 at 17 18 20](https://user-images.githubusercontent.com/1833361/116432144-b0aa6200-a848-11eb-9b08-8000563be714.png)

After: 

![Screenshot 2021-04-28 at 17 37 27](https://user-images.githubusercontent.com/1833361/116432162-b43de900-a848-11eb-97cc-ec2180aa5d7f.png)

It would be better if it were dynamic, but that might have downsides as well (like, columns shifting). This fix makes it better, with low impact.