### PR TITLE
Copy packaged themes in `bolt:copy-themes` command

### DIFF
--- a/src/Extension/ExtensionRegistry.php
+++ b/src/Extension/ExtensionRegistry.php
@@ -16,6 +16,9 @@ class ExtensionRegistry
     /** @var array */
     protected $extensionClasses = [];
 
+    /** @var PackageInterface[] */
+    protected $themes = [];
+
     /**
      * @see ExtensionCompilerPass::process()
      */
@@ -59,6 +62,15 @@ class ExtensionRegistry
     public function getExtensions(): array
     {
         return $this->extensions;
+    }
+
+    public function getThemes()
+    {
+        if (! $this->themes) {
+            $this->themes = iterator_to_array(Types::get('bolt-theme'));
+        }
+
+        return $this->themes;
     }
 
     public function getExtensionNames(): array


### PR DESCRIPTION
When running `php bin/console bolt:copy-themes`, it will _also_ copy any themes that are installed as extensions.

@bobdenotter It _should_ work as-is, but I wasn't able to test it because of version constraints. Maybe you have an idea of how to verify that it works?