### PR TITLE
Fix ecs breakage with `friendsofphp/php-cs-fixer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,8 @@
     },
     "conflict": {
         "doctrine/common": ">=3.0",
-        "doctrine/persistence": "<1.3"
+        "doctrine/persistence": "<1.3",
+        "friendsofphp/php-cs-fixer": ">=2.19.0"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
Fixes `Warning: count(): Parameter must be an array or an object that implements Countable in /[...]/bolt/core/vendor/friendsofphp/php-cs-fixer/src/AbstractProxyFixer.php on line 73`