### PR TITLE
Several fixes for handling Relations

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -97,6 +97,12 @@ pages:
         template:
             type: templateselect
             filter: '/^[^_].*\.twig$/'
+    relations:
+        entries:
+            multiple: false
+            order: title
+            label: Select an Entry
+            required: false
     taxonomy: [ groups ]
     listing_records: 6
     order: id
@@ -139,7 +145,7 @@ entries:
             type: embed
     relations:
         pages:
-            multiple: false
+            multiple: true
             order: heading
             label: Select a page
     taxonomy: [ categories, tags, groups ]

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -199,9 +199,13 @@ class ContentTypesParser extends BaseParser
             $contentType['taxonomy'] = [];
         }
 
-        // when adding relations, make sure they're added by their slug. Not their 'name' or 'singular name'.
         if (! empty($contentType['relations']) && is_array($contentType['relations'])) {
             foreach (array_keys($contentType['relations']) as $relkey) {
+
+                // Default `required` to `false` for Relations
+                $contentType['relations'][$relkey]['required'] = $contentType['relations'][$relkey]['required'] ?? false;
+
+                // Make sure Relations are added by their slug. Not their 'name' or 'singular name'.
                 if ($relkey !== Str::slug($relkey)) {
                     $contentType['relations'][Str::slug($relkey)] = $contentType['relations'][$relkey];
                     unset($contentType['relations'][$relkey]);

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -201,7 +201,6 @@ class ContentTypesParser extends BaseParser
 
         if (! empty($contentType['relations']) && is_array($contentType['relations'])) {
             foreach (array_keys($contentType['relations']) as $relkey) {
-
                 // Default `required` to `false` for Relations
                 $contentType['relations'][$relkey]['required'] = $contentType['relations'][$relkey]['required'] ?? false;
 

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -484,7 +484,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
     private function updateRelation(Content $content, $newRelations): void
     {
         $newRelations = (new Collection(Json::findArray($newRelations)))->filter();
-        $currentRelations = $this->relationRepository->findRelations($content, null, false, null, false);
+        $currentRelations = $this->relationRepository->findRelations($content, null, true, null, false);
 
         // Remove old ones
         foreach ($currentRelations as $currentRelation) {

--- a/src/Factory/RelationFactory.php
+++ b/src/Factory/RelationFactory.php
@@ -47,8 +47,8 @@ class RelationFactory
     private function getFromMemory(Content $from, Content $to): ?Relation
     {
         return $this->relations->filter(function (Relation $relation) use ($from, $to) {
-            return $relation->getFromContent() === $from || $relation->getFromContent() === $to
-                || $relation->getToContent() === $to || $relation->getToContent() === $from;
+            return ($relation->getFromContent() === $from && $relation->getToContent() === $to)
+                || ($relation->getToContent() === $to && $relation->getToContent() === $from);
         })->last(null, null);
     }
 }


### PR DESCRIPTION
This PR fixes three issues related to Relations:

 - Default to `required: false`, since it makes most sense if you can _clear_ a Relation.
 - Allow deletion of a Relation from either side in the Backend
 - Fix logic error in `getFromMemory` in `RelationFactory`