### PR TITLE
fix issue with migration that wouldn't run on MariaDB 10

### DIFF
--- a/migrations/Version20201210105836.php
+++ b/migrations/Version20201210105836.php
@@ -45,6 +45,7 @@ final class Version20201210105836 extends AbstractMigration
         if (!$schema->hasTable($this->tablePrefix . '_password_request')) {
             $resetPaswordTable = $schema->createTable($this->tablePrefix . '_password_request');
             $resetPaswordTable->addColumn('id', 'integer', ['autoincrement' => true]);
+            $resetPaswordTable->setPrimaryKey(["id"]); // MySQL / MariaDB needs autoincrement column to be the primary key
             $resetPaswordTable->addColumn('user_id', 'integer', ['notnull' => true, '', 'default' => 0]);
             $resetPaswordTable->addForeignKeyConstraint($this->tablePrefix . '_user', ['user_id'], ['id'], ['onUpdate' => 'CASCADE']);
         }


### PR DESCRIPTION
by specifying a primary key

This should fix https://github.com/bolt/core/issues/2569

This has not been tested on sqlite!