### PR TITLE
Performance boost: Keep in-memory copy of `currentLocale`

### DIFF
--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -36,6 +36,9 @@ class LocaleHelper
     /** @var string */
     private $defaultLocale;
 
+    /** @var Collection */
+    private $currentLocale;
+
     public function __construct(string $locales, ContentRepository $contentRepository, UrlGeneratorInterface $urlGenerator, Config $config, string $defaultLocale)
     {
         $this->localeCodes = new Collection(explode('|', $locales));
@@ -51,7 +54,13 @@ class LocaleHelper
 
     public function getCurrentLocale(Environment $twig): ?Collection
     {
-        return $this->getLocales($twig)->firstWhere('current', true);
+        // Getting the currentLocale is surprisingly inefficient, so we do it once per Request
+        // See https://github.com/bolt/core/pull/2597
+        if (! isset($this->currentLocale)) {
+            $this->currentLocale = $this->getLocales($twig)->firstWhere('current', true);
+        }
+
+        return $this->currentLocale;
     }
 
     public function getLocales(Environment $twig, ?Collection $localeCodes = null, bool $all = false): Collection


### PR DESCRIPTION
It turns out that `getCurrentLocale` can be pretty inefficient, especially when a page has a lot of fields and/or relations. Every time _any_ field is fetched, like `{% record.title %}`, the `currentLocale` is checked, triggering a database lookup. 

See these screenshots from a real-world site, where a page has 180 related records. Before: 

![Screenshot_2021-05-30_at_11_19_09](https://user-images.githubusercontent.com/1833361/120100677-3b30fa80-c142-11eb-9cd8-49611674e3d6.png)

After:

![Screenshot_2021-05-30_at_11_23_12](https://user-images.githubusercontent.com/1833361/120100684-42580880-c142-11eb-83d3-f75f11b149dd.png)

In this out-of-the-ordinary case, performance increases by a factor of 60. 

On 'regular' sites, performance gains are around 10 to 15% for detail pages.  
