### PR TITLE
Fix CSS for 'meta' block on overview pages

### DIFF
--- a/assets/js/app/listing/Components/Table/Row/_Meta.vue
+++ b/assets/js/app/listing/Components/Table/Row/_Meta.vue
@@ -8,13 +8,11 @@
             <li v-if="size === 'normal'"><i class="fas fa-user"></i> {{ record.authorName }}</li>
             <li v-if="size === 'normal'">
                 <i class="fas" :class="record.extras.icon"></i>
-                <div>
                     <template v-if="type === 'dashboard'">
                         <a :href="`/bolt/content/${record.contentType}`">{{ record.extras.singular_name }}</a>
                     </template>
                     <template v-else>{{ record.extras.singular_name }}</template
-                    >&nbsp;№ {{ record.id }}
-                </div>
+                    > № {{ record.id }}
             </li>
         </ul>
     </div>

--- a/assets/scss/modules/listing/row/row.scss
+++ b/assets/scss/modules/listing/row/row.scss
@@ -186,11 +186,11 @@ $checkbox-row-width: 32px;
       }
 
       @include media-breakpoint-up(md) {
-        flex: 0 0 155px;
-        max-width: 155px;
+        flex: 0 0 175px;
+        max-width: 175px;
         order: 3;
         padding: $spacer*0.5 0 $spacer*0.3 $spacer*0.5;
-        margin-right: -2rem;
+        margin: 0 -2rem 0 0;
       }
     }
 
@@ -230,7 +230,6 @@ $checkbox-row-width: 32px;
     }
 
     li {
-      padding-right: 1rem;
       margin-bottom: $spacer / 4;
       color: var(--shade);
       text-transform: capitalize;


### PR DESCRIPTION
Follow-up to #2554 

Before: 

![Screenshot 2021-05-30 at 13 50 17](https://user-images.githubusercontent.com/1833361/120103544-66bae180-c150-11eb-95a1-dfa721819577.png)


After: 

![Screenshot 2021-05-30 at 14 07 57](https://user-images.githubusercontent.com/1833361/120103557-75a19400-c150-11eb-850b-4a9a17de9ae4.png)
