### PR TITLE
Pin Chromedriver to version 90.x 

### DIFF
--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -70,7 +70,7 @@ jobs:
             -   uses: nanasess/setup-chromedriver@master
                 with:
                     # Pin Chromedriver to 90.something, because 91 _appends_ text when using `.setValue()` instead of replacing it.
-                    chromedriver-version: ['90.0.4430.24']
+                    chromedriver-version: '90.0.4430.24'
             -   uses: actions/setup-node@v1
                 with:
                     node-version: ${{ matrix.node-version }}

--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -25,32 +25,32 @@ jobs:
             -   name: Install dependencies
                 run: |
                     sudo composer self-update -q
-                    sudo COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=60 composer update --prefer-dist --no-progress	
+                    sudo COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=60 composer update --prefer-dist --no-progress
                     ./bin/console bolt:info	--ansi
-                    npm set progress=false	
-                    npm ci	
-                    mkdir -p ./var/log/e2e-reports/report/features/	
-                    touch ./var/log/e2e-reports/report/features/.gitkeep	
-                    # Install latest stable Chrome for e2e tests	
-                    sudo apt-get install libxss1 libappindicator1 libindicator7	
-                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb	
+                    npm set progress=false
+                    npm ci
+                    mkdir -p ./var/log/e2e-reports/report/features/
+                    touch ./var/log/e2e-reports/report/features/.gitkeep
+                    # Install latest stable Chrome for e2e tests
+                    sudo apt-get install libxss1 libappindicator1 libindicator7
+                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
                     sudo apt install ./google-chrome*.deb
             -   name: Prepare environment
                 run: |
-                    # build assets	
+                    # build assets
                     npm run build
-                    sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/	
-                    # prepare web server for e2e tests	
-                    ./bin/console doctrine:database:create	
-                    ./bin/console doctrine:schema:create	
-                    ./bin/console doctrine:fixtures:load --group=without-images -n	
-                    ./bin/console server:start 127.0.0.1:8088	
-                    # test if web server works	
-                    sleep 3	
+                    sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
+                    # prepare web server for e2e tests
+                    ./bin/console doctrine:database:create
+                    ./bin/console doctrine:schema:create
+                    ./bin/console doctrine:fixtures:load --group=without-images -n
+                    ./bin/console server:start 127.0.0.1:8088
+                    # test if web server works
+                    sleep 3
                     wget "http://127.0.0.1:8088/bolt/login"
 
             - name: run API tests
-              run: make behat-api-quiet 
+              run: make behat-api-quiet
     e2e:
         name: E2E Tests
         runs-on: ubuntu-latest
@@ -68,6 +68,9 @@ jobs:
                     extensions: json, mbstring, pdo, curl, pdo_sqlite
                     coverage: none
             -   uses: nanasess/setup-chromedriver@master
+                with:
+                    # Pin Chromedriver to 90.something, because 91 _appends_ text when using `.setValue()` instead of replacing it.
+                    chromedriver-version: ['90.0.4430.24']
             -   uses: actions/setup-node@v1
                 with:
                     node-version: ${{ matrix.node-version }}
@@ -76,28 +79,28 @@ jobs:
             -   name: Install dependencies
                 run: |
                     sudo composer self-update -q
-                    sudo COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=60 composer update --prefer-dist --no-progress	
+                    sudo COMPOSER_MEMORY_LIMIT=-1 COMPOSER_PROCESS_TIMEOUT=60 composer update --prefer-dist --no-progress
                     ./bin/console bolt:info	--ansi
-                    npm set progress=false	
-                    npm ci	
-                    mkdir -p ./var/log/e2e-reports/report/features/	
-                    touch ./var/log/e2e-reports/report/features/.gitkeep	
-                    # Install latest stable Chrome for e2e tests	
-                    sudo apt-get install libxss1 libappindicator1 libindicator7	
-                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb	
+                    npm set progress=false
+                    npm ci
+                    mkdir -p ./var/log/e2e-reports/report/features/
+                    touch ./var/log/e2e-reports/report/features/.gitkeep
+                    # Install latest stable Chrome for e2e tests
+                    sudo apt-get install libxss1 libappindicator1 libindicator7
+                    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
                     sudo apt install ./google-chrome*.deb
             -   name: Prepare environment
                 run: |
-                    # build assets	
+                    # build assets
                     npm run build
-                    sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/	
-                    # prepare web server for e2e tests	
-                    ./bin/console doctrine:database:create	
-                    ./bin/console doctrine:schema:create	
-                    ./bin/console doctrine:fixtures:load --group=without-images -n	
-                    ./bin/console server:start 127.0.0.1:8088	
-                    # test if web server works	
-                    sleep 3	
+                    sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
+                    # prepare web server for e2e tests
+                    ./bin/console doctrine:database:create
+                    ./bin/console doctrine:schema:create
+                    ./bin/console doctrine:fixtures:load --group=without-images -n
+                    ./bin/console server:start 127.0.0.1:8088
+                    # test if web server works
+                    sleep 3
                     wget "http://127.0.0.1:8088/bolt/login"
             -   name: Install latest Google Chrome (for e2e tests)
                 run: wget -q https://script.install.devinsideyou.com/google-chrome && chmod +x google-chrome
@@ -106,5 +109,5 @@ jobs:
                 run: ./run_behat_tests.sh && make behat-js-quiet
 
             -   name: Upload Behat logs
-                run: ./vendor/bin/upload-textfiles "var/log/behat-reports/*.log"
+                run: ./bin/upload-textfiles "var/log/behat-reports/*.html"
                 if: always()

--- a/bin/upload-textfiles
+++ b/bin/upload-textfiles
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]
+then
+    echo "Usage: $0 <glob_path>"
+    exit 1
+fi
+
+echo "Uploading logs..."
+
+for file in $1
+do
+    if [ ! -e "$file" ]
+    then
+        break
+    fi
+
+    url=`cat "$file" | nc termbin.com 9999`
+    echo "$file - $url"
+done


### PR DESCRIPTION
We pin Chromedriver to `90.something`, because `91` _appends_ text when using `.setValue()` instead of replacing it.