### PR TITLE
Add restriction for (global) Composer 2 to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-pdo": "*",
+        "composer-runtime-api": "^2",
         "api-platform/core": "2.5.3.*",
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",


### PR DESCRIPTION
Fixes the issue where some people bumped into upgrade problems with vague descritpions, because they were still on composer 1. 

If this is you, please upgrade to composer 2, by running `composer selfupdate --2`. 

The main difference you'll notice is that Composer 2 is an order of magnitude faster than Composer 1 is. 