### PR TITLE
`extensions:configure` accepts both `.yaml` and `.yml` for config, routes and services in extensions

### DIFF
--- a/src/Command/ExtensionsConfigureCommand.php
+++ b/src/Command/ExtensionsConfigureCommand.php
@@ -64,14 +64,9 @@ class ExtensionsConfigureCommand extends Command
         // @todo: Combine this with Bolt\Extension\ConfigTrait.php
         foreach ($packages as $package) {
             $path = $this->getPackagePath($package);
-            $origin = $this->getRelativePath($path) . '/config/config.yaml';
 
-            [$namespace, $name] = explode('\\', mb_strtolower($this->getNamespace($package) . '\\'));
-            $destination = $this->getExtensionConfigPath($namespace, $name);
-
-            if (file_exists($origin) && ! file_exists($destination)) {
-                file_put_contents($destination, file_get_contents($origin));
-            }
+            $this->copyConfig($this->getRelativePath($path) . '/config/config.yaml', $path);
+            $this->copyConfig($this->getRelativePath($path) . '/config/config.yml', $path);
         }
     }
 
@@ -100,19 +95,11 @@ class ExtensionsConfigureCommand extends Command
         foreach ($packages as $package) {
             $path = $this->getPackagePath($package);
 
-            $sourceRoutes = $this->getRelativePath($path) . '/config/routes.yaml';
-            if (file_exists($sourceRoutes)) {
-                $destination = $this->getExtensionRoutesPath($path);
-                $oldExtensionsRoutes = array_diff($oldExtensionsRoutes, [$destination]);
-                file_put_contents($destination, file_get_contents($sourceRoutes));
-            }
+            $this->copyRoute($this->getRelativePath($path) . '/config/routes.yaml', $path, $oldExtensionsRoutes);
+            $this->copyRoute($this->getRelativePath($path) . '/config/routes.yml', $path, $oldExtensionsRoutes);
 
-            $sourceServices = $this->getRelativePath($path) . '/config/services.yaml';
-            if (file_exists($sourceServices)) {
-                $destination = $this->getExtensionServicesPath($path);
-                $oldExtensionsServices = array_diff($oldExtensionsServices, [$destination]);
-                file_put_contents($destination, file_get_contents($sourceServices));
-            }
+            $this->copyService($this->getRelativePath($path) . '/config/services.yaml', $path, $oldExtensionsServices);
+            $this->copyService($this->getRelativePath($path) . '/config/services.yml', $path, $oldExtensionsServices);
         }
 
         // Remove routes.yaml files for old (uninstalled) extensions
@@ -120,6 +107,34 @@ class ExtensionsConfigureCommand extends Command
 
         // Remove services.yaml files for old (uninstalled) extensions
         array_map('unlink', $oldExtensionsServices);
+    }
+
+    private function copyConfig(string $source, string $package): void
+    {
+        [$namespace, $name] = explode('\\', mb_strtolower($this->getNamespace($package) . '\\'));
+        $destination = $this->getExtensionConfigPath($namespace, $name);
+
+        if (file_exists($source) && ! file_exists($destination)) {
+            file_put_contents($destination, file_get_contents($source));
+        }
+    }
+
+    private function copyRoute(string $source, string $packagePath, array &$oldExtensionsRoutes): void
+    {
+        if (file_exists($source)) {
+            $destination = $this->getExtensionRoutesPath($packagePath);
+            $oldExtensionsRoutes = array_diff($oldExtensionsRoutes, [$destination]);
+            file_put_contents($destination, file_get_contents($source));
+        }
+    }
+
+    private function copyService(string $source, string $packagePath, array &$oldExtensionsServices): void
+    {
+        if (file_exists($source)) {
+            $destination = $this->getExtensionServicesPath($packagePath);
+            $oldExtensionsServices = array_diff($oldExtensionsServices, [$destination]);
+            file_put_contents($destination, file_get_contents($source));
+        }
     }
 
     private function runExtensionInstall(array $packages): void


### PR DESCRIPTION
Fixes #2615 

@LordSimal I'd also advise renaming it to `services.yaml` (note the A), that way it will work for people with `4.1.21` as well :-) 