### PR TITLE
Don't allow `symfony/security-http` 5.3.0 and 5.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,8 @@
     "conflict": {
         "doctrine/common": ">=3.0",
         "doctrine/persistence": "<1.3",
-        "friendsofphp/php-cs-fixer": ">=2.19.0"
+        "friendsofphp/php-cs-fixer": ">=2.19.0",
+        "symfony/security-http": "v5.3.0 v5.3.1"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
For context: 

https://symfony.com/blog/cve-2021-32693-authentication-granted-to-all-firewalls-instead-of-just-one
https://github.com/symfony/symfony/commit/3084764ad82f29dbb025df19978b9cbc3ab34728
