### PR TITLE
Fix incorrect error when uploading an allowed filetype, that isn't an image

### DIFF
--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -109,5 +109,5 @@ jobs:
                 run: ./run_behat_tests.sh && make behat-js-quiet
 
             -   name: Upload Behat logs
-                run: ./bin/upload-textfiles "var/log/behat-reports/*.html"
+                run: ./bin/upload-textfiles "var/log/behat-reports/*"
                 if: always()

--- a/.github/workflows/behavioural_tests.yaml
+++ b/.github/workflows/behavioural_tests.yaml
@@ -109,5 +109,5 @@ jobs:
                 run: ./run_behat_tests.sh && make behat-js-quiet
 
             -   name: Upload Behat logs
-                run: ./bin/upload-textfiles "var/log/behat-reports/*"
+                run: ./bin/upload-textfiles "var/log/behat-reports/*.html"
                 if: always()

--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -8,6 +8,7 @@ use Bolt\Common\Arr;
 use Bolt\Common\Str;
 use Bolt\Configuration\Content\ContentType;
 use Bolt\Configuration\Content\FieldType;
+use Bolt\Enum\ImageTypes;
 use Bolt\Enum\Statuses;
 use Bolt\Exception\ConfigurationException;
 use Tightenco\Collect\Support\Collection;
@@ -294,7 +295,7 @@ class ContentTypesParser extends BaseParser
         // If field is an "image" type, make sure the 'extensions' are set.
         if ($field['type'] === 'image' || $field['type'] === 'imagelist') {
             if (empty($field['extensions'])) {
-                $extensions = new Collection(['gif', 'jpg', 'jpeg', 'png', 'svg', 'avif', 'webp']);
+                $extensions = new Collection(ImageTypes::all());
                 $field['extensions'] = $extensions->intersect($acceptFileTypes)->toArray();
             }
         }

--- a/src/Configuration/Parser/GeneralParser.php
+++ b/src/Configuration/Parser/GeneralParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Configuration\Parser;
 
 use Bolt\Common\Arr;
+use Bolt\Enum\ImageTypes;
 use Tightenco\Collect\Support\Collection;
 
 class GeneralParser extends BaseParser
@@ -82,7 +83,7 @@ class GeneralParser extends BaseParser
                 'only_aliases' => false,
             ],
             'accept_file_types' => explode(',', 'twig,html,js,css,scss,gif,jpg,jpeg,png,ico,zip,tgz,txt,md,doc,docx,pdf,epub,xls,xlsx,csv,ppt,pptx,mp3,ogg,wav,m4a,mp4,m4v,ogv,wmv,avi,webm,svg,avif,webp'),
-            'accept_media_types' => explode(',', 'gif,jpg,jpeg,png,svg,pdf,mp3,tiff,avif,webp'),
+            'accept_media_types' => ImageTypes::all(),
             'accept_upload_size' => '8M',
             'upload_location' => '{contenttype}/{year}/{month}/',
             'maintenance_mode' => false,

--- a/src/Controller/Backend/Async/UploadController.php
+++ b/src/Controller/Backend/Async/UploadController.php
@@ -116,8 +116,11 @@ class UploadController implements AsyncZoneInterface
         if ($result->isValid()) {
             try {
                 $media = $this->mediaFactory->createFromFilename($locationName, $path, $result->__get('name'));
-                $this->em->persist($media);
-                $this->em->flush();
+
+                if ($this->mediaFactory->isImage($media)) {
+                    $this->em->persist($media);
+                    $this->em->flush();
+                }
 
                 return new JsonResponse($media->getFilenamePath());
             } catch (\Throwable $e) {

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Controller;
 
 use Bolt\Configuration\Config;
+use Bolt\Enum\ImageTypes;
 use League\Glide\Responses\SymfonyResponseFactory;
 use League\Glide\Server;
 use League\Glide\ServerFactory;
@@ -168,7 +169,7 @@ class ImageController
     {
         $pathinfo = pathinfo($filename);
 
-        $imageExtensions = ['gif', 'png', 'jpg', 'jpeg', 'svg', 'avif', 'webp'];
+        $imageExtensions = ImageTypes::all();
 
         return array_key_exists('extension', $pathinfo) && in_array($pathinfo['extension'], $imageExtensions, true);
     }

--- a/src/DataFixtures/BaseFixture.php
+++ b/src/DataFixtures/BaseFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\DataFixtures;
 
+use Bolt\Enum\ImageTypes;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Symfony\Component\Finder\Finder;
 use Tightenco\Collect\Support\Collection;
@@ -83,7 +84,7 @@ abstract class BaseFixture extends Fixture
     {
         $fullpath = Path::canonicalize($base);
 
-        $glob = '*.{jpg,png,gif,jpeg,webp,avif}';
+        $glob = sprintf('*.{%s}', implode(',', ImageTypes::all()));
 
         $finder = new Finder();
         $finder->in($fullpath)->depth('< 2')->sortByName()->name($glob)->files();

--- a/src/Enum/BaseEnum.php
+++ b/src/Enum/BaseEnum.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Enum;
+
+use Tightenco\Collect\Support\Collection;
+
+class BaseEnum implements EnumInterface
+{
+    /**
+     * @return string[]
+     */
+    public static function all(): array
+    {
+        $self = new \ReflectionClass(self::class);
+
+        return $self->getConstants();
+    }
+
+    public static function isValid(?string $status): bool
+    {
+        if ($status === null) {
+            return false;
+        }
+
+        return (new Collection(static::all()))->containsStrict($status);
+    }
+}

--- a/src/Enum/EnumInterface.php
+++ b/src/Enum/EnumInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Enum;
+
+interface EnumInterface
+{
+    public static function all(): array;
+
+    public static function isValid(?string $status): bool;
+}

--- a/src/Enum/ImageTypes.php
+++ b/src/Enum/ImageTypes.php
@@ -4,39 +4,18 @@ declare(strict_types=1);
 
 namespace Bolt\Enum;
 
-use Tightenco\Collect\Support\Collection;
-
 /**
  * Class ImageTypes, see https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
  */
-class ImageTypes
+class ImageTypes extends BaseEnum
 {
     public const APNG = 'apng';
     public const AVIF = 'avif';
     public const GIF = 'gif';
     public const JPEG = 'jpeg';
     public const JPG = 'jpg';
-    public const PNG = 'png';
+    public const png = 'png';
     public const SVG = 'svg';
     public const TIFF = 'tiff';
     public const WEBP = 'webp';
-
-    /**
-     * @return string[]
-     */
-    public static function all(): array
-    {
-        $self = new \ReflectionClass(self::class);
-
-        return array_values($self->getConstants());
-    }
-
-    public static function isValid(?string $status): bool
-    {
-        if ($status === null) {
-            return false;
-        }
-
-        return (new Collection(static::all()))->containsStrict($status);
-    }
 }

--- a/src/Enum/ImageTypes.php
+++ b/src/Enum/ImageTypes.php
@@ -28,7 +28,7 @@ class ImageTypes
     {
         $self = new \ReflectionClass(self::class);
 
-        return $self->getConstants();
+        return array_values($self->getConstants());
     }
 
     public static function isValid(?string $status): bool

--- a/src/Enum/ImageTypes.php
+++ b/src/Enum/ImageTypes.php
@@ -6,12 +6,20 @@ namespace Bolt\Enum;
 
 use Tightenco\Collect\Support\Collection;
 
-class Statuses
+/**
+ * Class ImageTypes, see https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
+ */
+class ImageTypes
 {
-    public const PUBLISHED = 'published';
-    public const HELD = 'held';
-    public const TIMED = 'timed';
-    public const DRAFT = 'draft';
+    public const APNG = 'apng';
+    public const AVIF = 'avif';
+    public const GIF = 'gif';
+    public const JPEG = 'jpeg';
+    public const JPG = 'jpg';
+    public const PNG = 'png';
+    public const SVG = 'svg';
+    public const TIFF = 'tiff';
+    public const WEBP = 'webp';
 
     /**
      * @return string[]

--- a/src/Enum/Statuses.php
+++ b/src/Enum/Statuses.php
@@ -4,31 +4,10 @@ declare(strict_types=1);
 
 namespace Bolt\Enum;
 
-use Tightenco\Collect\Support\Collection;
-
-class Statuses
+class Statuses extends BaseEnum
 {
     public const PUBLISHED = 'published';
     public const HELD = 'held';
     public const TIMED = 'timed';
     public const DRAFT = 'draft';
-
-    /**
-     * @return string[]
-     */
-    public static function all(): array
-    {
-        $self = new \ReflectionClass(self::class);
-
-        return array_values($self->getConstants());
-    }
-
-    public static function isValid(?string $status): bool
-    {
-        if ($status === null) {
-            return false;
-        }
-
-        return (new Collection(static::all()))->containsStrict($status);
-    }
 }

--- a/src/Enum/Statuses.php
+++ b/src/Enum/Statuses.php
@@ -20,7 +20,7 @@ class Statuses
     {
         $self = new \ReflectionClass(self::class);
 
-        return $self->getConstants();
+        return array_values($self->getConstants());
     }
 
     public static function isValid(?string $status): bool

--- a/src/Enum/UserStatus.php
+++ b/src/Enum/UserStatus.php
@@ -4,29 +4,8 @@ declare(strict_types=1);
 
 namespace Bolt\Enum;
 
-use Tightenco\Collect\Support\Collection;
-
-class UserStatus
+class UserStatus extends BaseEnum
 {
     public const ENABLED = 'enabled';
     public const DISABLED = 'disabled';
-
-    /**
-     * @return string[]
-     */
-    public static function all(): array
-    {
-        $self = new \ReflectionClass(self::class);
-
-        return array_values($self->getConstants());
-    }
-
-    public static function isValid(?string $status): bool
-    {
-        if ($status === null) {
-            return false;
-        }
-
-        return (new Collection(static::all()))->containsStrict($status);
-    }
 }

--- a/src/Enum/UserStatus.php
+++ b/src/Enum/UserStatus.php
@@ -18,7 +18,7 @@ class UserStatus
     {
         $self = new \ReflectionClass(self::class);
 
-        return $self->getConstants();
+        return array_values($self->getConstants());
     }
 
     public static function isValid(?string $status): bool

--- a/src/Enum/UserStatus.php
+++ b/src/Enum/UserStatus.php
@@ -16,10 +16,9 @@ class UserStatus
      */
     public static function all(): array
     {
-        return [
-            static::ENABLED,
-            static::DISABLED,
-        ];
+        $self = new \ReflectionClass(self::class);
+
+        return $self->getConstants();
     }
 
     public static function isValid(?string $status): bool

--- a/src/Factory/MediaFactory.php
+++ b/src/Factory/MediaFactory.php
@@ -32,7 +32,7 @@ class MediaFactory
     private $exif;
 
     /** @var Collection */
-    private $mediaTypes;
+    private $allowedFileTypes;
 
     /** @var FileLocations */
     private $fileLocations;
@@ -44,7 +44,7 @@ class MediaFactory
         $this->tokenStorage = $tokenStorage;
 
         $this->exif = Reader::factory(Reader::TYPE_NATIVE);
-        $this->mediaTypes = $config->getMediaTypes();
+        $this->allowedFileTypes = $config->getMediaTypes()->merge($config->getFileTypes());
         $this->fileLocations = $fileLocations;
     }
 
@@ -65,7 +65,7 @@ class MediaFactory
                 ->setLocation($fileLocation);
         }
 
-        if ($this->mediaTypes->contains($file->getExtension()) === false) {
+        if ($this->allowedFileTypes->contains($file->getExtension()) === false) {
             throw new UnsupportedMediaTypeHttpException("{$file->getExtension()} files are not accepted");
         }
 
@@ -104,7 +104,7 @@ class MediaFactory
         }
     }
 
-    private function isImage(Media $media): bool
+    public function isImage(Media $media): bool
     {
         return in_array($media->getType(), ['gif', 'png', 'jpg', 'jpeg', 'svg', 'webp', 'avif'], true);
     }

--- a/src/Factory/MediaFactory.php
+++ b/src/Factory/MediaFactory.php
@@ -8,6 +8,7 @@ use Bolt\Configuration\Config;
 use Bolt\Configuration\FileLocations;
 use Bolt\Controller\UserTrait;
 use Bolt\Entity\Media;
+use Bolt\Enum\ImageTypes;
 use Bolt\Repository\MediaRepository;
 use Carbon\Carbon;
 use PHPExif\Exif;
@@ -106,7 +107,7 @@ class MediaFactory
 
     public function isImage(Media $media): bool
     {
-        return in_array($media->getType(), ['gif', 'png', 'jpg', 'jpeg', 'svg', 'webp', 'avif'], true);
+        return in_array($media->getType(), ImageTypes::all(), true);
     }
 
     public function createFromFilename(string $locationName, string $path, string $filename): Media


### PR DESCRIPTION
For example, you have this: 

```yaml
accept_file_types: [ …, mp4, …]

accept_media_types: [ gif, jpg, jpeg, png, svg, pdf, mp3, tiff, avif, webp ]
```

Uploading an `mp4` into a `type: file` field _should_ work, but it doesn't, because it doesn't generate a Media Entity. This PR fixes that.

![Screenshot 2021-06-29 at 20 07 50](https://user-images.githubusercontent.com/1833361/123846492-b63e2a00-d915-11eb-81f8-ef169ada3d79.png)
