### PR TITLE
Support Twig chain loaders if available

### DIFF
--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tightenco\Collect\Support\Collection;
 use Twig\Environment;
+use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 
 class TwigAwareController extends AbstractController
@@ -185,8 +186,12 @@ class TwigAwareController extends AbstractController
 
     private function setTwigLoader(): void
     {
-        /** @var FilesystemLoader $twigLoaders */
+        /** @var FilesystemLoader|ChainLoader $twigLoaders */
         $twigLoaders = $this->twig->getLoader();
+
+        $twigLoaders = $twigLoaders instanceof ChainLoader ?
+            $twigLoaders->getLoaders() :
+            [$twigLoaders];
 
         $path = $this->config->getPath('theme');
 
@@ -194,8 +199,10 @@ class TwigAwareController extends AbstractController
             $path .= DIRECTORY_SEPARATOR . $this->config->get('theme/template_directory');
         }
 
-        if ($twigLoaders instanceof FilesystemLoader) {
-            $twigLoaders->prependPath($path, '__main__');
+        foreach ($twigLoaders as $twigLoader) {
+            if ($twigLoader instanceof FilesystemLoader) {
+                $twigLoader->prependPath($path, '__main__');
+            }
         }
     }
 

--- a/src/Extension/BaseExtension.php
+++ b/src/Extension/BaseExtension.php
@@ -13,6 +13,7 @@ use ComposerPackages\Packages;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Twig\Environment;
 use Twig\Extension\ExtensionInterface as TwigExtensionInterface;
+use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -111,11 +112,17 @@ abstract class BaseExtension implements ExtensionInterface
             return;
         }
 
-        /** @var FilesystemLoader $twigLoaders */
+        /** @var FilesystemLoader|ChainLoader $twigLoaders */
         $twigLoaders = $this->getTwig()->getLoader();
 
-        if ($twigLoaders instanceof FilesystemLoader) {
-            $twigLoaders->prependPath($foldername, $namespace);
+        $twigLoaders = $twigLoaders instanceof ChainLoader ?
+            $twigLoaders->getLoaders() :
+            [$twigLoaders];
+
+        foreach ($twigLoaders as $twigLoader) {
+            if ($twigLoader instanceof FilesystemLoader) {
+                $twigLoader->prependPath($foldername, $namespace);
+            }
         }
     }
 

--- a/src/Widget/BaseWidget.php
+++ b/src/Widget/BaseWidget.php
@@ -8,6 +8,7 @@ use Bolt\Extension\ExtensionInterface;
 use Bolt\Widget\Exception\WidgetException;
 use Cocur\Slugify\Slugify;
 use Twig\Error\LoaderError;
+use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -189,11 +190,17 @@ abstract class BaseWidget implements WidgetInterface
 
     private function addTwigLoader(): void
     {
-        /** @var FilesystemLoader $twigLoaders */
+        /** @var FilesystemLoader|ChainLoader $twigLoaders */
         $twigLoaders = $this->getTwig()->getLoader();
 
-        if ($twigLoaders instanceof FilesystemLoader) {
-            $twigLoaders->addPath($this->getTemplateFolder(), $this->getSlug());
+        $twigLoaders = $twigLoaders instanceof ChainLoader ?
+            $twigLoaders->getLoaders() :
+            [$twigLoaders];
+
+        foreach ($twigLoaders as $twigLoader) {
+            if ($twigLoader instanceof FilesystemLoader) {
+                $twigLoader->addPath($this->getTemplateFolder(), $this->getSlug());
+            }
         }
     }
 


### PR DESCRIPTION
One of our Symfony bundles that we're testing on Bolt uses a custom Twig loader.

This results in `$this->getTwig()->getLoader()` code used in Bolt in several places to return an instance of `Twig\Loader\ChainLoader` instead of `Twig\Loader\FilesystemLoader` making the code in question fail in Bolt, which results in Bolt not being able to find any of its templates.

This fix adds support for `ChainLoader`, which basically iterates over any Twig loader in the chain loader, and if it is an instance of `FilesystemLoader`, does what Bolt did previously (adds or prepends a new path, based on context).

Thanks to @ilukac for discovering the cause of the issue.