### PR TITLE
Fix incorrect error when uploading an allowed filetype, that isn't an image

### DIFF
--- a/src/Controller/Backend/Async/UploadController.php
+++ b/src/Controller/Backend/Async/UploadController.php
@@ -116,8 +116,11 @@ class UploadController implements AsyncZoneInterface
         if ($result->isValid()) {
             try {
                 $media = $this->mediaFactory->createFromFilename($locationName, $path, $result->__get('name'));
-                $this->em->persist($media);
-                $this->em->flush();
+
+                if ($this->mediaFactory->isImage($media)) {
+                    $this->em->persist($media);
+                    $this->em->flush();
+                }
 
                 return new JsonResponse($media->getFilenamePath());
             } catch (\Throwable $e) {

--- a/src/Factory/MediaFactory.php
+++ b/src/Factory/MediaFactory.php
@@ -32,7 +32,7 @@ class MediaFactory
     private $exif;
 
     /** @var Collection */
-    private $mediaTypes;
+    private $allowedFileTypes;
 
     /** @var FileLocations */
     private $fileLocations;
@@ -44,7 +44,7 @@ class MediaFactory
         $this->tokenStorage = $tokenStorage;
 
         $this->exif = Reader::factory(Reader::TYPE_NATIVE);
-        $this->mediaTypes = $config->getMediaTypes();
+        $this->allowedFileTypes = $config->getMediaTypes()->merge($config->getFileTypes());
         $this->fileLocations = $fileLocations;
     }
 
@@ -65,7 +65,7 @@ class MediaFactory
                 ->setLocation($fileLocation);
         }
 
-        if ($this->mediaTypes->contains($file->getExtension()) === false) {
+        if ($this->allowedFileTypes->contains($file->getExtension()) === false) {
             throw new UnsupportedMediaTypeHttpException("{$file->getExtension()} files are not accepted");
         }
 
@@ -104,7 +104,7 @@ class MediaFactory
         }
     }
 
-    private function isImage(Media $media): bool
+    public function isImage(Media $media): bool
     {
         return in_array($media->getType(), ['gif', 'png', 'jpg', 'jpeg', 'svg', 'webp', 'avif'], true);
     }


### PR DESCRIPTION
For example, you have this: 

```yaml
accept_file_types: [ …, mp4, …]

accept_media_types: [ gif, jpg, jpeg, png, svg, pdf, mp3, tiff, avif, webp ]
```

Uploading an `mp4` into a `type: file` field _should_ work, but it doesn't, because it doesn't generate a Media Entity. This PR fixes that.

![Screenshot 2021-06-29 at 20 07 50](https://user-images.githubusercontent.com/1833361/123846492-b63e2a00-d915-11eb-81f8-ef169ada3d79.png)
