### PR TITLE
[4.x] Simplify, don't mangle username on incorrect input for Login

### DIFF
--- a/src/Controller/Backend/AuthenticationController.php
+++ b/src/Controller/Backend/AuthenticationController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Bolt\Controller\Backend;
 
 use Bolt\Controller\TwigAwareController;
-use Cocur\Slugify\Slugify;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
@@ -17,17 +16,9 @@ class AuthenticationController extends TwigAwareController implements BackendZon
      */
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
-        $slugify = new Slugify();
-
-        // last username entered by the user (if any)
-        $last_username = $slugify->slugify($authenticationUtils->getLastUsername());
-
-        // last authentication error (if any)
-        $error = $authenticationUtils->getLastAuthenticationError();
-
         return $this->render('@bolt/security/login.html.twig', [
-            'last_username' => $last_username,
-            'error' => $error,
+            'last_username' => $authenticationUtils->getLastUsername(),
+            'error' => $authenticationUtils->getLastAuthenticationError(),
         ]);
     }
 


### PR DESCRIPTION
input `admin@example.org` becomes: 
![Screenshot 2021-07-19 at 20 15 35](https://user-images.githubusercontent.com/1833361/126207503-f8f779d8-dffa-45be-8141-339ab6d949c2.png)
