### PR TITLE
Fix issue with incorrectly named `autocomplete` option

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -7,7 +7,7 @@
             :limit="1000"
             :multiple="multiple"
             :options="options"
-            :searchable="searchable || taggable"
+            :searchable="autocomplete || taggable"
             :show-labels="false"
             :taggable="taggable"
             :disabled="readonly"
@@ -75,7 +75,7 @@ export default {
         taggable: Boolean,
         readonly: Boolean,
         classname: String,
-        searchable: Boolean,
+        autocomplete: Boolean,
         errormessage: String | Boolean, //string if errormessage is set, and false otherwise
     },
     data: () => {

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -53,7 +53,7 @@ class FieldType extends Collection
             'height' => '10',
             'icon' => '',
             'maxlength' => '',
-            'autocomplete' => true
+            'autocomplete' => true,
         ]);
     }
 

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -53,6 +53,7 @@ class FieldType extends Collection
             'height' => '10',
             'icon' => '',
             'maxlength' => '',
+            'autocomplete' => true
         ]);
     }
 

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -15,8 +15,8 @@
     {% set multiple = field.definition.get('multiple')|default ? 'true' : 'false' %}
 {% endif %}
 
-{% if searchable is not defined %}
-    {% set searchable = field.definition.get('searchable')|default ? 'true' : 'false' %}
+{% if autocomplete is not defined %}
+    {% set autocomplete = field.definition.get('autocomplete')|default ? 'true' : 'false' %}
 {% endif %}
 
 {% block field %}
@@ -28,7 +28,7 @@
         :options="{{ options|json_encode }}"
         :form='{{ form|json_encode }}'
         :multiple="{{ multiple }}"
-        :searchable="{{ searchable }}"
+        :autocomplete="{{ autocomplete }}"
         :readonly="{{ readonly|json_encode }}"
         :errormessage='{{ errormessage|json_encode }}'
         :allowempty="{{ required ? 'false' : 'true' }}"

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -17,7 +17,7 @@ class ContentTypesParserTest extends ParserTestBase
 
     public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 27;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 27;
+    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 28;
 
     public const ALLOWED_LOCALES = 'en|nl|es|fr|de|pl|it|hu|pt_BR|ja|nb|nn|nl_NL|nl_BE';
 


### PR DESCRIPTION
Fixes #2720 and makes `autocomplete: true` the default