### PR TITLE
`imagelist` and `filelist` fields can be emptied

### DIFF
--- a/assets/js/app/editor/Components/Filelist.vue
+++ b/assets/js/app/editor/Components/Filelist.vue
@@ -22,6 +22,9 @@
                 @moveFileDown="onMoveFileDown"
             ></editor-file>
         </div>
+        <div v-if="containerFiles.length === 0">
+            <input :name="name" value="" type="hidden" />
+        </div>
 
         <button class="btn btn-tertiary" type="button" :disabled="!allowMore" @click="addFile">
             <i class="fas fa-fw fa-plus"></i>
@@ -104,9 +107,6 @@ export default {
         onRemoveFile(elem) {
             let fieldNumber = this.getFieldNumberFromElement(elem);
             this.containerFiles.splice(fieldNumber, 1);
-            if (this.containerFiles.length === 0) {
-                this.addFile();
-            }
         },
         fieldName(index) {
             return this.name + '[' + index + ']';

--- a/assets/js/app/editor/Components/Imagelist.vue
+++ b/assets/js/app/editor/Components/Imagelist.vue
@@ -25,6 +25,9 @@
                 @moveImageDown="onMoveImageDown"
             ></editor-image>
         </div>
+        <div v-if="getActiveImageFields().length === 0">
+            <input :name="name" value="" type="hidden" />
+        </div>
 
         <button class="btn btn-tertiary" type="button" :disabled="!allowMore" @click="addImage">
             <i class="fas fa-fw fa-plus"></i>
@@ -114,10 +117,6 @@ export default {
             let updatedImage = this.containerImages[fieldNumber];
             updatedImage.hidden = true;
             this.$set(this.containerImages, fieldNumber, updatedImage);
-
-            if (this.getActiveImageFields().length === 0) {
-                this.addImage();
-            }
         },
         fieldName(index) {
             return this.name + '[' + index + ']';

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -26,7 +26,9 @@ class FilelistField extends Field implements FieldInterface, ListFieldInterface,
      */
     public function getRawValue(): array
     {
-        return (array) parent::getValue() ?: [];
+        $value = parent::getValue();
+
+        return empty(current($value)) ? [] : (array) $value;
     }
 
     /**

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -26,7 +26,9 @@ class ImagelistField extends Field implements FieldInterface, ListFieldInterface
      */
     public function getRawValue(): array
     {
-        return (array) parent::getValue() ?: [];
+        $value = parent::getValue();
+
+        return empty(current($value)) ? [] : (array) $value;
     }
 
     /**


### PR DESCRIPTION
Fixes #2736 and #2606