### PR TITLE
Update the warning color to a11y compatible

### DIFF
--- a/assets/scss/init/_variables.scss
+++ b/assets/scss/init/_variables.scss
@@ -77,7 +77,7 @@ $secondary: #1f8389;
 $tertiary: #667a81;
 $success: #4f8419;
 $info: #17a2b8;
-$warning: #ffc107;
+$warning: #BF1722;
 $danger: #db2427;
 $light: #e0e0e0;
 $dark: #333;

--- a/assets/scss/init/_variables.scss
+++ b/assets/scss/init/_variables.scss
@@ -77,7 +77,7 @@ $secondary: #1f8389;
 $tertiary: #667a81;
 $success: #4f8419;
 $info: #17a2b8;
-$warning: #BF1722;
+$warning: #bf1722;
 $danger: #db2427;
 $light: #e0e0e0;
 $dark: #333;


### PR DESCRIPTION
Changing orange to red, because it was the only accessibility-compliant color that I could find 🤷‍♂️