### PR TITLE
Unlimited select field options

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -7,7 +7,8 @@
             :limit="1000"
             :multiple="multiple"
             :options="options"
-            :searchable="taggable"
+            :optionsLimit="optionslimit"
+            :searchable="autocomplete || taggable"
             :show-labels="false"
             :taggable="taggable"
             :disabled="readonly"
@@ -70,11 +71,13 @@ export default {
         id: String,
         form: String,
         options: Array,
+        optionslimit: Number,
         multiple: Boolean,
         allowempty: Boolean,
         taggable: Boolean,
         readonly: Boolean,
         classname: String,
+        autocomplete: Boolean,
         errormessage: String | Boolean, //string if errormessage is set, and false otherwise
     },
     data: () => {

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -15,6 +15,15 @@
     {% set multiple = field.definition.get('multiple')|default ? 'true' : 'false' %}
 {% endif %}
 
+{% if autocomplete is not defined %}
+	{% set autocomplete = field.definition.get('autocomplete')|default ? 'true' : 'false' %}
+{% endif %}
+
+{% if limit is not defined %}
+	{% set limit = field.definition.get('limit')|default(99999) %}
+{% endif %}
+
+
 {% block field %}
     <editor-select
         :classname="{{ "wide-options"|json_encode }}"
@@ -22,8 +31,10 @@
         :name='{{ name|json_encode }}'
         :id='{{ id|json_encode }}'
         :options="{{ options|json_encode }}"
+        :optionslimit="{{ limit }}"
         :form='{{ form|json_encode }}'
         :multiple="{{ multiple }}"
+        :autocomplete="{{ autocomplete }}"
         :readonly="{{ readonly|json_encode }}"
         :errormessage='{{ errormessage|json_encode }}'
         :allowempty="{{ required ? 'false' : 'true' }}"


### PR DESCRIPTION
Allows the number of options displayed in select fields to be set by the limit value in the contenttypes.yaml