### PR TITLE
Fix From URL label in an Imagelist's Image Field upload button

### DIFF
--- a/templates/_partials/fields/imagelist.html.twig
+++ b/templates/_partials/fields/imagelist.html.twig
@@ -21,6 +21,7 @@
         'placeholder_title': 'image.placeholder_title'|trans,
         'button_remove': 'image.button_remove'|trans,
         'button_edit_attributes': 'image.button_edit_attributes'|trans,
+        'button_from_url': 'image.button_from_url'|trans,
         'button_move_up': 'image.button_up'|trans,
         'button_move_down': 'image.button_down'|trans,
         'add_new_image': 'image.add_new_image'|trans,


### PR DESCRIPTION
The label was missing in `imagelist.html.twig` file. 

Fixes #2721 
