### PR TITLE
Workaround for constructor signature change in Symfony/Process

### DIFF
--- a/bin/composer-script/CreateProjectScript.php
+++ b/bin/composer-script/CreateProjectScript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bolt\ComposerScripts;
 
 use Composer\Script\Event;

--- a/bin/composer-script/PostInstallScript.php
+++ b/bin/composer-script/PostInstallScript.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bolt\ComposerScripts;
 
 class PostInstallScript extends Script
 {
-    public static function execute()
+    public static function execute(): void
     {
         parent::init('Running composer "post-install-cmd" scripts');
 

--- a/bin/composer-script/PostUpdateScript.php
+++ b/bin/composer-script/PostUpdateScript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bolt\ComposerScripts;
 
 class PostUpdateScript extends Script

--- a/bin/composer-script/PrePackageUninstallScript.php
+++ b/bin/composer-script/PrePackageUninstallScript.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bolt\ComposerScripts;
 
 class PrePackageUninstallScript extends Script

--- a/bin/composer-script/ProjectEventHandler.php
+++ b/bin/composer-script/ProjectEventHandler.php
@@ -20,7 +20,9 @@ class ProjectEventHandler
         CreateProjectScript::execute($event);
     }
 
-    /** @placeholder */
+    /**
+     * @placeholder
+     */
     public static function preInstall(Event $event): void
     {
     }
@@ -30,7 +32,9 @@ class ProjectEventHandler
         PostInstallScript::execute();
     }
 
-    /** @placeholder */
+    /**
+     * @placeholder
+     */
     public static function preUpdate(Event $event): void
     {
     }
@@ -44,5 +48,4 @@ class ProjectEventHandler
     {
         PrePackageUninstallScript::execute();
     }
-
 }

--- a/bin/composer-script/Script.php
+++ b/bin/composer-script/Script.php
@@ -1,8 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Bolt\ComposerScripts;
 
 use Composer\Script\Event;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
@@ -12,7 +17,7 @@ class Script
     /** @var SymfonyStyle */
     protected static $console;
 
-    protected static function init(string $message = '')
+    protected static function init(string $message = ''): void
     {
         $consoleFactory = new SymfonyStyleFactory();
         self::$console = $consoleFactory->create();
@@ -30,9 +35,42 @@ class Script
     /**
      * Execute a command in the CLI, as a separate process.
      */
-    protected static function run(string $command): void
+    protected static function run(string $command): int
     {
-        $process = new Process($command);
-        $process->run();
+        // Depending on the context, we're using either Symfony/Process 2.8.52 (bundled with composer 2.1.x)
+        // or Symfony/Process 5.3.x (if we're using our own). The signature of the Constructor changed
+        // from: `public function __construct(string $commandline, …)`
+        // to:   `public function __construct(array $command, …)`
+        // We'll have to attempt one, and otherwise fall back to the other.
+
+        try {
+            $process = new Process([$command]);
+        } catch (\TypeError $e) {
+            $process = new Process($command);
+        }
+
+        return $process->run();
+    }
+
+    /**
+     * Create SymfonyStyle object. Taken from Symplify (which we might not
+     * have at our disposal inside a 'project' installation)
+     */
+    public static function createSymfonyStyle(): SymfonyStyle
+    {
+        // to prevent missing argv indexes
+        if (! isset($_SERVER['argv'])) {
+            $_SERVER['argv'] = [];
+        }
+
+        $argvInput = new ArgvInput();
+        $consoleOutput = new ConsoleOutput();
+
+        // --debug is called
+        if ($argvInput->hasParameterOption('--debug')) {
+            $consoleOutput->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
+        }
+
+        return new SymfonyStyle($argvInput, $consoleOutput);
     }
 }

--- a/bin/composer-script/Script.php
+++ b/bin/composer-script/Script.php
@@ -44,9 +44,9 @@ class Script
         // We'll have to attempt one, and otherwise fall back to the other.
 
         try {
-            $process = new Process([$command]);
-        } catch (\TypeError $e) {
             $process = new Process($command);
+        } catch (\TypeError $e) {
+            $process = new Process([$command]);
         }
 
         return $process->run();


### PR DESCRIPTION
The important part of this PR is: 

```php

        // Depending on the context, we're using either Symfony/Process 2.8.52 (bundled with composer 2.1.x)
        // or Symfony/Process 5.3.x (if we're using our own). The signature of the Constructor changed
        // from: `public function __construct(string $commandline, …)`
        // to:   `public function __construct(array $command, …)`
        // We'll have to attempt one, and otherwise fall back to the other.

        try {
            $process = new Process($command);
        } catch (\TypeError $e) {
            $process = new Process([$command]);
        }
```

This was fun to figure out! (not)