### PR TITLE
Search now also finds words with special characters, like `büßen`

### DIFF
--- a/src/Repository/ContentRepository.php
+++ b/src/Repository/ContentRepository.php
@@ -105,7 +105,7 @@ class ContentRepository extends ServiceEntityRepository
 
         // The search term must match the format of the content in the database
         // Therefore, it is JSON encoded and escaped with backslashes
-        $encodedSearchTerm = addslashes(trim(json_encode($searchTerm), '"'));
+        $encodedSearchTerm = addslashes(trim(json_encode($searchTerm, JSON_UNESCAPED_UNICODE), '"'));
 
         $qb->addSelect('f')
             ->innerJoin('content.fields', 'f')


### PR DESCRIPTION
Fixes #2758

![afbeelding](https://user-images.githubusercontent.com/1833361/129206225-16d8db4d-9d93-483d-82b9-bdb3025249a9.png)
