### PR TITLE
feat: separate the persist logic from the back-office controller

### DIFF
--- a/src/Doctrine/Persister/ContentDataManager.php
+++ b/src/Doctrine/Persister/ContentDataManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Bolt\Doctrine\Persister;
+
+use Bolt\Entity\Content;
+use Bolt\Event\ContentEvent;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class ContentDataManager
+{
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    /** @var EntityManagerInterface */
+    private $em;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, EntityManagerInterface $em)
+    {
+        $this->dispatcher = $eventDispatcher;
+        $this->em = $em;
+    }
+
+    public function save(Content $object): void
+    {
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::PRE_SAVE);
+
+        $this->persist($object);
+        $this->flush();
+
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::POST_SAVE);
+    }
+
+    public function delete(Content $object): void
+    {
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::PRE_DELETE);
+
+        $this->remove($object);
+        $this->flush();
+
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::POST_DELETE);
+
+    }
+
+    public function persist(Content $object): void
+    {
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::PRE_PERSIST);
+
+        /* Note: Doctrine also calls preUpdate() -> Event/Listener/FieldFillListener.php */
+        $this->em->persist($object);
+
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::POST_PERSIST);
+    }
+
+    public function remove(Content $object): void
+    {
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::POST_REMOVE);
+
+        $this->em->remove($object);
+
+        $event = new ContentEvent($object);
+        $this->dispatcher->dispatch($event, ContentEvent::POST_REMOVE);
+    }
+
+    public function flush(?Content $entity = null): void
+    {
+        $event = new ContentEvent($entity);
+        $this->dispatcher->dispatch($event, ContentEvent::PRE_FLUSH);
+
+        $this->em->flush($event->getContent());
+
+        $this->dispatcher->dispatch($event, ContentEvent::POST_FLUSH);
+    }
+}

--- a/src/Doctrine/Persister/UserDataManager.php
+++ b/src/Doctrine/Persister/UserDataManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Bolt\Doctrine\Persister;
+
+use Bolt\Event\UserEvent;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class UserDataManager
+{
+    /** @var EntityManagerInterface */
+    private $em;
+
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(EntityManagerInterface $em, EventDispatcherInterface $dispatcher)
+    {
+        $this->em = $em;
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function persist($object): void
+    {
+        $event = new UserEvent($object);
+        $this->dispatcher->dispatch($event, UserEvent::ON_PRE_SAVE);
+
+        $this->em->persist($object);
+
+        $event = new UserEvent($object);
+        $this->dispatcher->dispatch($event, UserEvent::ON_POST_SAVE);
+    }
+
+    public function delete($object): void
+    {
+        $event = new UserEvent($object);
+        $this->dispatcher->dispatch($event, UserEvent::ON_PRE_DELETE);
+
+        $this->em->remove($object);
+
+        $event = new UserEvent($object);
+        $this->dispatcher->dispatch($event, UserEvent::ON_POST_DELETE);
+    }
+
+    public function flush(): void
+    {
+        $this->em->flush();
+    }
+}

--- a/src/Event/ContentEvent.php
+++ b/src/Event/ContentEvent.php
@@ -11,6 +11,10 @@ class ContentEvent extends Event
 {
     public const PRE_SAVE = 'bolt.pre_save';
     public const POST_SAVE = 'bolt.post_save';
+    public const PRE_PERSIST = 'bolt.pre_persist';
+    public const POST_PERSIST = 'bolt.post_persist';
+    public const PRE_FLUSH = 'bolt.pre_flush';
+    public const POST_FLUSH = 'bolt.post_flush';
     public const ON_EDIT = 'bolt.pre_edit';
     public const ON_PREVIEW = 'bolt.pre_edit';
     public const ON_DUPLICATE = 'bolt.on_duplicate';
@@ -18,6 +22,8 @@ class ContentEvent extends Event
     public const POST_STATUS_CHANGE = 'bolt.post_status_change';
     public const PRE_DELETE = 'bolt.pre_delete';
     public const POST_DELETE = 'bolt.post_delete';
+    public const PRE_REMOVE = 'bolt.pre_remove';
+    public const POST_REMOVE = 'bolt.post_remove';
 
     /** @var Content */
     private $content;

--- a/src/Event/UserEvent.php
+++ b/src/Event/UserEvent.php
@@ -13,6 +13,8 @@ class UserEvent
     public const ON_EDIT = 'bolt.users_pre_edit';
     public const ON_PRE_SAVE = 'bolt.users_post_save';
     public const ON_POST_SAVE = 'bolt.users_post_save';
+    public const ON_PRE_DELETE = 'bolt.users_pre_delete';
+    public const ON_POST_DELETE = 'bolt.users_post_delete';
 
     /** @var User */
     private $user;


### PR DESCRIPTION
(Work in progress)

Bolt has an event mechanism that allows developers to get notified and execute code when content or users are getting changes. But these events are currently dispatched by the `Bolt\Controller\Backend\ContentEditController` controller. As a consequence, developers cannot take advantage of these events in their own code.

In this PR, I propose to create two new _data manager_ classes (one per data type: user and content) that would take care of the task to persist the entities, and dispatch the relevant events.
This PR introduces four new events too, `{PRE,POST}_PERSIST` and `{PRE,POST}_FLUSH`, so the developers can subscribe to new intermediate states without breaking the backward compatibility.