### PR TITLE
Preview is frontend zone, fix for viewing content in another locale

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -41,7 +41,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Tightenco\Collect\Support\Collection;
 
 /**
- * CRUD + status, duplicate, preview, for content - note that listing is handled by ListingController.php
+ * CRUD + status, duplicate, for content - note that listing is handled by ListingController.php
  */
 class ContentEditController extends TwigAwareController implements BackendZoneInterface
 {
@@ -251,22 +251,6 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
     }
 
     /**
-     * @Route("/preview/{id}", name="bolt_content_edit_preview", methods={"POST"}, requirements={"id": "\d+"})
-     */
-    public function preview(?Content $content = null): Response
-    {
-        $this->validateCsrf('editrecord');
-
-        $content = $this->contentFromPost($content);
-        $this->denyAccessUnlessGranted(ContentVoter::CONTENT_VIEW, $content);
-
-        $event = new ContentEvent($content);
-        $this->dispatcher->dispatch($event, ContentEvent::ON_PREVIEW);
-
-        return $this->renderSingle($content, false);
-    }
-
-    /**
      * @Route("/duplicate/{id}", name="bolt_content_duplicate", methods={"GET"}, requirements={"id": "\d+"})
      */
     public function duplicate(Content $content): Response
@@ -360,7 +344,9 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         return new RedirectResponse($url);
     }
 
-    private function contentFromPost(?Content $content): Content
+    // todo: This function should not be public.
+    // It needs to be abstracted into its own class, alongside the other functions it uses.
+    public function contentFromPost(?Content $content): Content
     {
         $formData = $this->request->request->all();
         $locale = $this->getPostedLocale($formData) ?: $content->getDefaultLocale();

--- a/src/Controller/Frontend/PreviewController.php
+++ b/src/Controller/Frontend/PreviewController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Controller\Frontend;
+
+use Bolt\Controller\Backend\ContentEditController;
+use Bolt\Controller\CsrfTrait;
+use Bolt\Controller\TwigAwareController;
+use Bolt\Entity\Content;
+use Bolt\Event\ContentEvent;
+use Bolt\Security\ContentVoter;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class PreviewController extends TwigAwareController implements FrontendZoneInterface
+{
+    use CsrfTrait;
+
+    /** @var ContentEditController */
+    private $contentEditController;
+
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(
+        ContentEditController $contentEditController,
+        EventDispatcherInterface $dispatcher,
+        CsrfTokenManagerInterface $csrfTokenManager)
+    {
+        $this->contentEditController = $contentEditController;
+        $this->dispatcher = $dispatcher;
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    /**
+     * @Route("/preview/{id}", name="bolt_content_edit_preview", methods={"POST"}, requirements={"id": "\d+"})
+     */
+    public function preview(?Content $content = null): Response
+    {
+        $this->validateCsrf('editrecord');
+
+        $content = $this->contentEditController->contentFromPost($content);
+        $this->denyAccessUnlessGranted(ContentVoter::CONTENT_VIEW, $content);
+
+        $event = new ContentEvent($content);
+        $this->dispatcher->dispatch($event, ContentEvent::ON_PREVIEW);
+
+        return $this->renderSingle($content, false);
+    }
+}

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -137,7 +137,7 @@ class TwigAwareController extends AbstractController
         }
 
         // If the locale is the wrong locale
-        if (! $this->validLocaleForContentType($record->getDefinition()) && $this->request->getMethod() === 'GET') {
+        if (! $this->validLocaleForContentType($record->getDefinition())) {
             return $this->redirectToDefaultLocale();
         }
 


### PR DESCRIPTION
Fixes an issue causing the backend locale to be interpreted as the frontend locale during preview, rolls back #2772.

Good example of how refactoring the `ContentEditController` will be good! 