### PR TITLE
Allow HTML for `type: text` and `type: textarea` fields by default

### DIFF
--- a/src/Configuration/Parser/ContentTypesParser.php
+++ b/src/Configuration/Parser/ContentTypesParser.php
@@ -328,7 +328,7 @@ class ContentTypesParser extends BaseParser
         }
 
         if (isset($field['allow_html']) === false) {
-            $field['allow_html'] = in_array($field['type'], ['text', 'html', 'markdown'], true);
+            $field['allow_html'] = in_array($field['type'], ['text', 'textarea', 'html', 'markdown'], true);
         }
 
         if (isset($field['sanitise']) === false) {


### PR DESCRIPTION
Fixes #2783 