### PR TITLE
Don't break `printquery` on array values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "babdev/pagerfanta-bundle": "^2.5",
         "beberlei/doctrineextensions": "^1.2",
         "bobdenotter/yaml-migrations": "^1.0",
-        "bolt/common": "^2.1.12",
+        "bolt/common": "^2.1.13",
         "cocur/slugify": "^4.0",
         "composer/composer": "^2.0",
         "composer/package-versions-deprecated": "^1.11",

--- a/src/Storage/Directive/PrintQueryDirective.php
+++ b/src/Storage/Directive/PrintQueryDirective.php
@@ -51,5 +51,4 @@ class PrintQueryDirective
 
         echo $output;
     }
-
 }

--- a/src/Storage/Directive/PrintQueryDirective.php
+++ b/src/Storage/Directive/PrintQueryDirective.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Storage\Directive;
 
+use Bolt\Common\Str;
 use Bolt\Storage\QueryInterface;
 use Doctrine\ORM\Query\Parameter;
 
@@ -29,7 +30,7 @@ class PrintQueryDirective
         foreach ($parameters as $parameter) {
             $dql = str_replace(
                 ':' . $parameter->getName() . '',
-                '<b title="' . self::stringifyValue($parameter->getValue()) . '">:' . $parameter->getName() . '</b>',
+                '<b title="' . Str::stringifyValue($parameter->getValue()) . '">:' . $parameter->getName() . '</b>',
                 $dql
             );
         }
@@ -42,7 +43,7 @@ class PrintQueryDirective
             $output .= sprintf(
                 '<li><code>%s</code>: <code>%s</code></li>',
                 $parameter->getName(),
-                self::stringifyValue($parameter->getValue())
+                Str::stringifyValue($parameter->getValue())
             );
         }
 
@@ -51,8 +52,4 @@ class PrintQueryDirective
         echo $output;
     }
 
-    private static function stringifyValue($value): string
-    {
-        return is_iterable($value) ? sprintf('[%s]', implode(',', $value)) : $value;
-    }
 }

--- a/src/Storage/Directive/PrintQueryDirective.php
+++ b/src/Storage/Directive/PrintQueryDirective.php
@@ -29,7 +29,7 @@ class PrintQueryDirective
         foreach ($parameters as $parameter) {
             $dql = str_replace(
                 ':' . $parameter->getName() . '',
-                '<b title="' . $parameter->getValue() . '">:' . $parameter->getName() . '</b>',
+                '<b title="' . self::stringifyValue($parameter->getValue()) . '">:' . $parameter->getName() . '</b>',
                 $dql
             );
         }
@@ -42,12 +42,17 @@ class PrintQueryDirective
             $output .= sprintf(
                 '<li><code>%s</code>: <code>%s</code></li>',
                 $parameter->getName(),
-                $parameter->getValue()
+                self::stringifyValue($parameter->getValue())
             );
         }
 
         $output .= '</ul>';
 
         echo $output;
+    }
+
+    private static function stringifyValue($value): string
+    {
+        return is_iterable($value) ? sprintf('[%s]', implode(',', $value)) : $value;
     }
 }


### PR DESCRIPTION
Fixes #2807 

For example: `{% setcontent pages = 'pages' where { 'test': '[123,456]'} printquery %}`