### PR TITLE
Fix missing id's for integer/float field

### DIFF
--- a/assets/js/app/editor/Components/Number.vue
+++ b/assets/js/app/editor/Components/Number.vue
@@ -1,6 +1,7 @@
 <template>
     <div class="input-group">
         <input
+            :id="id"
             v-model="val"
             :name="name"
             class="form-control"
@@ -22,6 +23,7 @@ export default {
     name: 'EditorNumber',
     mixins: [val],
     props: {
+        id: String,
         value: String,
         name: String,
         step: Number,

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -23,6 +23,7 @@
   {% endif %}
 
   <editor-number
+    :id='{{ id|json_encode }}'
     name="{{ name }}"
     value="{{ value }}"
     :step="{{ step }}"


### PR DESCRIPTION
Id was missing for the integer and float field which broke both of the labels.