### PR TITLE
Show `memory_limit` and attempt to set in on CLI

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,6 +8,7 @@ use Symfony\Component\Debug\Debug;
 use Symfony\Component\Dotenv\Dotenv;
 
 set_time_limit(0);
+@ini_set('memory_limit', '1024M');
 
 require __DIR__.'/../vendor/autoload.php';
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,11 +31,6 @@ parameters:
             message: "#Offset 'location' does not exist on array#"
             path: %currentWorkingDirectory%/src/Log/LogHandler.php
 
-        # false positive: Parameter #1 $description of method Bolt\Entity\Media::setDescription() expects string|null, array given.
-        -
-            message: '#of method Bolt\\Entity\\Media::setDescription#'
-            path: %currentWorkingDirectory%/src/DataFixtures/ImagesFixtures.php
-
 includes:
 	- vendor/phpstan/phpstan-symfony/extension.neon
 	- vendor/phpstan/phpstan-doctrine/extension.neon

--- a/src/Command/ImageTrait.php
+++ b/src/Command/ImageTrait.php
@@ -26,7 +26,7 @@ trait ImageTrait
         $filename = dirname(dirname(__DIR__)) . '/assets/static/images/bolt_logo_cli.png';
         $imageFile = base64_encode(file_get_contents($filename));
 
-        return $this->unicodeString('\u001B]1337;File=inline=1;width=40;height=auto;preserveAspectRatio=1:' . $imageFile . '\u0007');
+        return $this->unicodeString('\u001B]1337;File=inline=1;width=auto;height=3;preserveAspectRatio=1:' . $imageFile . '\u0007');
     }
 
     private function unicodeString(string $str, ?string $encoding = null): string

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -88,6 +88,7 @@ HELP
             sprintf('PHP version: <info>%s</info>', PHP_VERSION),
             sprintf('Symfony version: <info>%s</info>', Version::getSymfonyVersion()),
             sprintf('Operating System: <info>%s</info> - <comment>%s</comment>', php_uname('s'), php_uname('r')),
+            sprintf('Memory limit: <info>%s</info>', ini_get('memory_limit')),
         ]);
 
         $this->warnOutdatedComposerJson();

--- a/src/Controller/Backend/GeneralController.php
+++ b/src/Controller/Backend/GeneralController.php
@@ -38,6 +38,7 @@ class GeneralController extends TwigAwareController implements BackendZoneInterf
             'symfony' => Version::getSymfonyVersion(),
             'os_name' => php_uname('s'),
             'os_version' => php_uname('r'),
+            'memory_limit' => ini_get('memory_limit'),
         ];
 
         return $this->render('@bolt/pages/about.html.twig', $twigVars);

--- a/templates/pages/about.html.twig
+++ b/templates/pages/about.html.twig
@@ -24,8 +24,9 @@
         <li>Database: <code>{{ platform.driver_name }} {{ platform.server_version }} <small> - {{ platform.connection_status }}</small> </code></li>
         <li>PHP version: <code>{{ php }}</code></li>
         <li>Symfony version: <code>{{ symfony }}</code></li>
-        <li>Operating System: <code>{{ os_name }} - <small>{{ os_version }}</small></code></li>
+        <li>Operating system: <code>{{ os_name }} - <small>{{ os_version }}</small></code></li>
         <li>Assets version: <code id="assetsVersion">-</code></li>
+        <li>Memory limit: <code>{{ memory_limit }}</code></li>
     </ul>
     <hr>
 


### PR DESCRIPTION
Try to set `memory_limit` on the CLI to help out with memory limits, to turn this: 

![Schermafbeelding 2021-09-07 om 09 38 25](https://user-images.githubusercontent.com/1833361/132304346-f388b6f6-816d-415d-a6e9-69d87647d140.png)

into: 

![Schermafbeelding 2021-09-07 om 09 38 54](https://user-images.githubusercontent.com/1833361/132304370-b70ac122-f564-4dec-a3a2-e4c3235a02ef.png)

Also show the memory limit on `/about` and `bin/console b:i`:

![afbeelding](https://user-images.githubusercontent.com/1833361/132304525-6f8c6762-c4c8-42d8-a24f-76b8674bf468.png)

![afbeelding](https://user-images.githubusercontent.com/1833361/132304550-9ea91a7d-1d64-4c50-868f-a17e850691e9.png)
