### PR TITLE
Fix querying selects and multiselects

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -33,6 +33,7 @@ doctrine:
             string_functions:
                 JSON_EXTRACT: Bolt\Doctrine\Functions\JsonExtract
                 JSON_GET_TEXT: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Postgresql\JsonGetText
+                JSON_SEARCH: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonSearch
                 CAST: Bolt\Doctrine\Query\Cast
             numeric_functions:
                 RAND: Bolt\Doctrine\Functions\Rand

--- a/src/Doctrine/Version.php
+++ b/src/Doctrine/Version.php
@@ -97,6 +97,20 @@ class Version
         return true;
     }
 
+    public function hasJsonSearch(): bool
+    {
+        try {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('JSON_SEARCH("{}", "one", "")');
+            $query->execute();
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * If we're using SQLite, this method tests for JSON support
      *

--- a/src/Storage/FieldQueryUtils.php
+++ b/src/Storage/FieldQueryUtils.php
@@ -37,6 +37,13 @@ class FieldQueryUtils
         return $doctrineVersion->hasCast();
     }
 
+    public function hasJsonSearch(): bool
+    {
+        $doctrineVersion = new Version($this->em->getConnection());
+
+        return $doctrineVersion->hasJsonSearch();
+    }
+
     public function isLocalizedField(QueryInterface $query, $fieldname): bool
     {
         $contentType = $query->getConfig()->get('contenttypes/' . $query->getContentType());

--- a/yaml-migrations/m_2021-09-16-doctrine.yaml
+++ b/yaml-migrations/m_2021-09-16-doctrine.yaml
@@ -1,0 +1,10 @@
+# Adding the JSON_SEARCH for Bolt 5
+file: packages/doctrine.yaml
+since: 4.2.0
+
+add:
+    doctrine:
+        orm:
+            dql:
+                string_functions:
+                    JSON_SEARCH: Scienta\DoctrineJsonFunctions\Query\AST\Functions\Mysql\JsonSearch

--- a/yaml-migrations/m_2021-09-16-doctrine.yaml
+++ b/yaml-migrations/m_2021-09-16-doctrine.yaml
@@ -1,6 +1,6 @@
 # Adding the JSON_SEARCH for Bolt 5
 file: packages/doctrine.yaml
-since: 4.2.0
+since: 5.0.2
 
 add:
     doctrine:


### PR DESCRIPTION
Fixes #2806 select for MySQL where we can use `JSON_SEARCH`.

Doesn't yet fix the multiselect, but there's the groundwork. Not yet sure how to best parse the multiple expression...