### PR TITLE
Fixed that onUserEdit changes backend locale. Related issue #2811

### DIFF
--- a/src/Event/Subscriber/UserLocaleSubscriber.php
+++ b/src/Event/Subscriber/UserLocaleSubscriber.php
@@ -38,7 +38,7 @@ class UserLocaleSubscriber implements EventSubscriberInterface
 
     public function onUserEdit(UserEvent $event): void
     {
-        $this->updateBackendLocale($event->getUser());
+        
     }
 
     private function updateBackendLocale(User $user): void


### PR DESCRIPTION
On userEdit the backend locale got changed because of the function. 
Removed contents of the function and all is still functional.