### PR TITLE
Ensure admin/developer option is respected

### DIFF
--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -240,7 +240,11 @@ class AddUserCommand extends Command
         $plainPassword = $input->getArgument('password');
         $email = $input->getArgument('email');
         $displayName = $input->getArgument('display-name');
-        $roles = $input->getOption('roles');
+        
+        // Always merge the admin/developer role when the parameter has been given
+        $isAdmin = $input->getOption('admin') ? ['ROLE_ADMIN'] : [];
+        $isDeveloper = $input->getOption('developer') ? ['ROLE_DEVELOPER'] : [];
+        $roles = array_unique(array_merge($input->getOption('roles'), $isAdmin, $isDeveloper));
 
         // create the user and encode its password
         $user = UserRepository::factory($displayName, $username, $email);

--- a/src/Command/AddUserCommand.php
+++ b/src/Command/AddUserCommand.php
@@ -240,7 +240,7 @@ class AddUserCommand extends Command
         $plainPassword = $input->getArgument('password');
         $email = $input->getArgument('email');
         $displayName = $input->getArgument('display-name');
-        
+
         // Always merge the admin/developer role when the parameter has been given
         $isAdmin = $input->getOption('admin') ? ['ROLE_ADMIN'] : [];
         $isDeveloper = $input->getOption('developer') ? ['ROLE_DEVELOPER'] : [];


### PR DESCRIPTION
When providing a complete add-user command (`bin/console bolt:add-user --admin admin admin admin@localhost Admin`), the `interact` method is not called, resulting in the admin and developer options to be completely ignored. By detecting their presence in the `execute` method as well, the user is created correctly.

Workaround till merged/released is to use the `bin/console bolt:add-user --role=ROLE_ADMIN admin admin admin@localhost Admin` with the role argument instead.