### PR TITLE
Fix `{% setcontent where { … } %}` for Checkbox fields

### DIFF
--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -618,7 +618,7 @@ class SelectQuery implements QueryInterface
         // Special case for checkbox fields: https://github.com/bolt/core/pull/2843
         if ($this->utils->isFieldType($this, $fieldName, CheckboxField::TYPE)) {
             return '0 + ' . JsonHelper::wrapJsonFunction($valueAlias, null, $this->em->getConnection());
-        };
+        }
 
         return JsonHelper::wrapJsonFunction($valueAlias, null, $this->em->getConnection());
     }


### PR DESCRIPTION
Fix setcontent clauses like this:

```
            {% setcontent stickyNewsItem = 'news' where { sticky: true } returnsingle %}
```

Where `sticky` is a Checkbox field (`type: checkbox`). 

This only showed up on MySQL 5.7 and MySQL 8.

Fixes #2593
Fixes #2838
Fixes part of #2748
Fixes #2547