### PR TITLE
Add `cascade={"persist"}` to Field#content relation

### DIFF
--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -64,7 +64,7 @@ class Field implements FieldInterface, TranslatableInterface
     private $version;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields")
+     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields", cascade={"persist"})
      * @ORM\JoinColumn(nullable=false)
      */
     private $content;


### PR DESCRIPTION
When programmatically creating content, this: 

```
$this->entityManager->persist($this->currentrecord);
```

Could give the following error:

![zoho-error](https://user-images.githubusercontent.com/1833361/136191532-3d043118-bce1-4e73-bfad-1e9ce21c06bc.JPG)

This PR fixes this error. 