### PR TITLE
Fixed created date `UTC` in Content Entity

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -152,7 +152,7 @@ class Content
 
     public function __construct(?ContentType $contentTypeDefinition = null)
     {
-        $this->createdAt = new \DateTime();
+        $this->createdAt = $this->convertToUTCFromLocal(new \DateTime());
         $this->status = Statuses::DRAFT;
         $this->taxonomies = new ArrayCollection();
         $this->fields = new ArrayCollection();


### PR DESCRIPTION
These change fixes UTC createdAt in content entity when instanciate.

Fixes #2403

Changelog
-----------
* Fixed: UTC creation date was not effective when creating new content. (see #2403)