### PR TITLE
Fix setPath: Don't override existing `$route`, if we already have one

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -166,7 +166,7 @@ class Canonical
     {
         if (! $route && ! $this->request->attributes->has('_route')) {
             return;
-        } elseif ($this->request->attributes->has('_route')) {
+        } elseif (! $route) {
             $route = $this->request->attributes->get('_route');
         }
 


### PR DESCRIPTION
Followup to: #2871 

Fixes: #2874 