### PR TITLE
Cache `setLink` in Canonical

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -186,7 +186,7 @@ class Canonical
 
     public function generateLink(?string $route, ?array $params, $canonical = false): string
     {
-        $cacheKey = 'generateLink_' . md5($route . implode('-', $params) . (string) $canonical);
+        $cacheKey = 'bolt.generateLink_' . md5($route . implode('-', $params) . (string) $canonical);
 
         $link = $this->cache->get($cacheKey, function (ItemInterface $item) use ($route, $params, $canonical) {
             $item->tag('routes');

--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -14,6 +14,9 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 class Canonical
 {
@@ -44,13 +47,21 @@ class Canonical
     /** @var RouterInterface */
     private $router;
 
-    public function __construct(Config $config, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, RouterInterface $router, string $defaultLocale)
+    /** @var Stopwatch */
+    private $stopwatch;
+
+    /** @var TagAwareCacheInterface */
+    private $cache;
+
+    public function __construct(Config $config, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, RouterInterface $router, string $defaultLocale, Stopwatch $stopwatch, TagAwareCacheInterface $cache)
     {
         $this->config = $config;
         $this->urlGenerator = $urlGenerator;
         $this->request = $requestStack->getCurrentRequest() ?? Request::createFromGlobals();
         $this->defaultLocale = $defaultLocale;
         $this->router = $router;
+        $this->stopwatch = $stopwatch;
+        $this->cache = $cache;
 
         $this->init();
     }
@@ -173,8 +184,23 @@ class Canonical
         $this->path = $this->generateLink($route, $params, false);
     }
 
-    public function generateLink(?string $route, ?array $params, $canonical = false): ?string
+    public function generateLink(?string $route, ?array $params, $canonical = false): string
     {
+        $cacheKey = 'generateLink_' . md5($route . implode('-', $params) . (string) $canonical);
+
+        $link = $this->cache->get($cacheKey, function (ItemInterface $item) use ($route, $params, $canonical) {
+            $item->tag('routes');
+
+            return $this->generateLinkCacheHelper($route, $params, $canonical);
+        });
+
+        return $link;
+    }
+
+    private function generateLinkCacheHelper(?string $route, ?array $params, $canonical = false): string
+    {
+        $this->stopwatch->start('bolt.GenerateLink');
+
         $removeDefaultLocaleOnCanonical = $this->config->get('general/localization/remove_default_locale_on_canonical', true);
         $hasDefaultLocale = isset($params['_locale']) && $params['_locale'] === $this->defaultLocale;
 
@@ -197,15 +223,19 @@ class Canonical
         }
 
         try {
-            return $this->urlGenerator->generate(
+            $link = $this->urlGenerator->generate(
                 $route,
                 $params,
                 $canonical ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH
             );
         } catch (InvalidParameterException | MissingMandatoryParametersException | RouteNotFoundException | \TypeError $e) {
             // Just use the current URL /shrug
-            return $canonical ? $this->request->getUri() : $this->request->getPathInfo();
+            $link = $canonical ? $this->request->getUri() : $this->request->getPathInfo();
         }
+
+        $this->stopwatch->stop('bolt.GenerateLink');
+
+        return $link;
     }
 
     private function routeRequiresParam(string $route, string $param): bool


### PR DESCRIPTION
Split out part of #2853 

Note: This breaks stuff if you change the `bolt.backend_url` in `services.yaml`. 

We'll need to somehow detect changes in config, and call `$this->cache->invalidateTags(['routes']);`