### PR TITLE
Update _pager_tailwind.html.twig

### DIFF
--- a/templates/helpers/_pager_tailwind.html.twig
+++ b/templates/helpers/_pager_tailwind.html.twig
@@ -13,7 +13,7 @@ Predefined variables:
 {% set end = min(records.currentPage + surround, records.nbPages) %}
 
 {% block item %}
-    {% set tailwind = 'w-10 h-10 md:flex justify-center items-center hidden cursor-pointer leading-5 transition duration-150 ease-in rounded-full text-black no-underline' %}
+    {% set tailwind = 'w-10 md:flex justify-center items-center hidden cursor-pointer leading-5 transition duration-150 ease-in rounded-full text-black no-underline' %}
     {% if path is defined %}
         <a href="{{ path(route, p) }}" class="{{ tailwind }} {{ class }}">{{ label|default('…') }}</a>
     {% elseif enabled is defined and enabled == false %}


### PR DESCRIPTION
The w-12 class didnt exist anymore so the pager looked ugly this fixes that issue.

Before:
<img width="262" alt="Screenshot 2021-10-27 at 11 26 34" src="https://user-images.githubusercontent.com/40595903/139038724-baa667d0-e36a-4d11-b836-d074cd3ca610.png">

After:
<img width="368" alt="Screenshot 2021-10-27 at 11 26 55" src="https://user-images.githubusercontent.com/40595903/139038792-a7927aae-6146-4dfe-af04-a07ab3b219db.png">


