### PR TITLE
Redirect 'GET on Preview' link to edit page

### DIFF
--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -36,6 +36,7 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
      *     name="record_locale",
      *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
      *     methods={"GET|POST"})
+     *
      * @param string|int $slugOrId
      */
     public function record($slugOrId, ?string $contentTypeSlug = null, bool $requirePublished = true, ?string $_locale = null): Response

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -36,11 +36,6 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
      *     name="record_locale",
      *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
      *     methods={"GET|POST"})
-     * @Route(
-     *     "/preview/{slugOrId}",
-     *     name="record",
-     *     methods={"GET"})
-     *
      * @param string|int $slugOrId
      */
     public function record($slugOrId, ?string $contentTypeSlug = null, bool $requirePublished = true, ?string $_locale = null): Response

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -36,6 +36,10 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
      *     name="record_locale",
      *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
      *     methods={"GET|POST"})
+     * @Route(
+     *     "/preview/{slugOrId}",
+     *     name="record",
+     *     methods={"GET"})
      *
      * @param string|int $slugOrId
      */

--- a/src/Controller/Frontend/PreviewController.php
+++ b/src/Controller/Frontend/PreviewController.php
@@ -11,8 +11,10 @@ use Bolt\Entity\Content;
 use Bolt\Event\ContentEvent;
 use Bolt\Security\ContentVoter;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class PreviewController extends TwigAwareController implements FrontendZoneInterface
@@ -25,14 +27,19 @@ class PreviewController extends TwigAwareController implements FrontendZoneInter
     /** @var EventDispatcherInterface */
     private $dispatcher;
 
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
     public function __construct(
         ContentEditController $contentEditController,
         EventDispatcherInterface $dispatcher,
-        CsrfTokenManagerInterface $csrfTokenManager)
+        CsrfTokenManagerInterface $csrfTokenManager,
+        UrlGeneratorInterface $urlGenerator)
     {
         $this->contentEditController = $contentEditController;
         $this->dispatcher = $dispatcher;
         $this->csrfTokenManager = $csrfTokenManager;
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**
@@ -49,5 +56,15 @@ class PreviewController extends TwigAwareController implements FrontendZoneInter
         $this->dispatcher->dispatch($event, ContentEvent::ON_PREVIEW);
 
         return $this->renderSingle($content, false);
+    }
+
+    /**
+     * @Route("/preview/{id}", name="bolt_content_edit_get", methods={"GET"}, requirements={"id": "\d+"})
+     */
+    public function previewThroughGet(int $id): RedirectResponse
+    {
+        $url = $this->urlGenerator->generate('bolt_content_edit', ['id' => $id]);
+
+        return new RedirectResponse($url);
     }
 }


### PR DESCRIPTION
Sometimes clients or editors paste links to specific pages with a URL they've copy/pasted from a preview. Like `https://example.org/preview/123`. 

This will give an error like: 

<img width="1203" alt="image" src="https://user-images.githubusercontent.com/1833361/140055210-4fe81001-b716-4d9b-b13c-e51f3736a4b7.png">

This PR allows a `GET` request to that page (assuming it's published, similar to the existing "detail view") 