### PR TITLE
An empty image alt made the page throw an error

### DIFF
--- a/public/theme/skeleton/partials/_image.twig
+++ b/public/theme/skeleton/partials/_image.twig
@@ -3,7 +3,7 @@
         <a href="{{ record|image }}">
             <img src="{{ thumbnail(record, 1368, 1026) }}" alt="{{ (record|image).alt|default(record|title) }}">
         </a>
-        {% if image.alt %}
+        {% if image.alt|default('') %}
             <figcaption>{{ image.alt }}</figcaption>
         {% endif %}
     </figure>


### PR DESCRIPTION
If you create a field with an empty alt attribute it returns an error in the standard skeleton theme