### PR TITLE
Fix the Other Content menu icon

### DIFF
--- a/src/Menu/BackendMenuBuilder.php
+++ b/src/Menu/BackendMenuBuilder.php
@@ -373,7 +373,7 @@ final class BackendMenuBuilder implements BackendMenuBuilderInterface
                     'uri' => $this->urlGenerator->generate('bolt_menupage', ['slug' => $slug]),
                     'extras' => [
                         'name' => $label,
-                        'icon' => $contentType->get('icon_many'),
+                        'icon' => "fa-map-signs",
                         'slug' => $slug,
                     ],
                 ]);


### PR DESCRIPTION
Fixes #2923 and makes the icon in the menu consistent with the icon on the Other content page

![image](https://user-images.githubusercontent.com/7093518/141270804-ca76a2b2-de55-496f-8e2d-c46c45aded87.png)
