### PR TITLE
fix(setup-command): skip creating the database if it already exists

### DIFF
--- a/src/Command/SetupCommand.php
+++ b/src/Command/SetupCommand.php
@@ -47,7 +47,7 @@ class SetupCommand extends Command
         // See: https://github.com/doctrine/DoctrineBundle/issues/542
         $options = ['-q' => true];
         if ($this->connection->getDatabasePlatform()->getName() !== 'sqlite') {
-            $options[] = ['--if-not-exists' => true];
+            $options['--if-not-exists'] = true;
         }
 
         $command = $this->getApplication()->find('doctrine:database:create');


### PR DESCRIPTION
The "--if-not-exists" is on a nested array and ignored by the doctrine command for database creation.

![image](https://user-images.githubusercontent.com/2675747/141383586-58380849-c81a-48cd-8c01-38aae89cbdbe.png)