### PR TITLE
[#2909] fix(configuration): use environment variables into config settings

### DIFF
--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -189,10 +189,10 @@ class Config
     {
         $value = Arr::get($this->data, $path, $default);
 
-        // Basic getenv parser, for values like `%env(FOO_BAR)%`
+        // Basic $_ENV parser, for values like `%env(FOO_BAR)%`
         if (is_string($value) && preg_match('/%env\(([A-Z0-9_]+)\)%/', $value, $matches)) {
-            if (getenv($matches[1])) {
-                $value = getenv($matches[1]);
+            if (isset($_ENV[$matches[1]])) {
+                $value = $_ENV[$matches[1]];
             }
         }
 


### PR DESCRIPTION
These changes use $_ENV instead of getenv to retrieve environment variables.

Fixes #2909

Changelog
---------

* Fixed: Dynamic configuration values are not resolving correctly (see #2909)