### PR TITLE
chore(local-stack): improve make targets and avoid node17 issues for docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ full-test: ## to run full tests
 	make test
 
 db-create: ## to create database and load fixtures
-	bin/console doctrine:database:create
+	bin/console doctrine:database:create --if-not-exists
 	bin/console doctrine:schema:create -q
 	bin/console doctrine:migrations:sync-metadata-storage -q
 	bin/console doctrine:migrations:version --add --all -n -q
@@ -140,7 +140,7 @@ docker-stancheck: ## to run phpstane with docker
 	docker-compose exec -T php sh -c "vendor/bin/phpstan analyse -c phpstan.neon src"
 
 docker-db-create: ## to create database and load fixtures with docker
-	docker-compose exec -T php sh -c "bin/console doctrine:database:create"
+	docker-compose exec -T php sh -c "bin/console doctrine:database:create --if-not-exists"
 	docker-compose exec -T php sh -c "bin/console doctrine:schema:create"
 	docker-compose exec -T php sh -c "bin/console doctrine:fixtures:load -n"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,14 @@ services:
       - /etc/nginx/conf.d/entrypoint.sh
 
   node:
-    image: node:latest
+    image: node:16.13.0
     volumes:
       - ./:/home/node/app
     working_dir: /home/node/app
+    command:
+      - ./node_modules/.bin/encore
+      - dev
+      - --watch
 
   padm:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
These changes skip database creation if exist for make targets and avoid node 17 openssl3 issues with webpack with docker.

Changelog
---------

* Fix: Fix node image version for docker to avoid node17 openssl3 issues with webpack [(nodejs 17: digital envelope routines::unsupported)](https://github.com/webpack/webpack/issues/14532#ref-commit-abc9d51)
* Chore: Skip database creation if already exist into make targets
* Chore: Start automatically webpack encore dev for watching files into node docker container