### PR TITLE
Make it possible to add custom class in Select field

### DIFF
--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -25,7 +25,7 @@
 
 {% block field %}
     <editor-select
-        :classname="{{ "wide-options"|json_encode }}"
+        :classname="{{ ['wide-options ', class]|join|json_encode }}"
         :value="{{ value|json_encode }}"
         :name='{{ name|json_encode }}'
         :id='{{ id|json_encode }}'


### PR DESCRIPTION
Fixes #2975 

It seems only the `"wide-options"` class was being added by default. I've kept this class to be rendered since there is some CSS targeting that class.