### PR TITLE
Allow symfony/flex v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/dependency-injection": "^5.3",
         "symfony/dotenv": "^5.3",
         "symfony/expression-language": "^5.3",
-        "symfony/flex": "^1.17",
+        "symfony/flex": "^1.17|^2",
         "symfony/form": "^5.3",
         "symfony/framework-bundle": "^5.3",
         "symfony/http-client": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/dependency-injection": "^5.3",
         "symfony/dotenv": "^5.3",
         "symfony/expression-language": "^5.3",
-        "symfony/flex": "^1.17|^2",
+        "symfony/flex": "^1.17 || ^2.0",
         "symfony/form": "^5.3",
         "symfony/framework-bundle": "^5.3",
         "symfony/http-client": "^5.3",


### PR DESCRIPTION
Symfony/flex v2 should be compatible with Bolt, so lets allow it. See https://github.com/symfony/flex/releases/tag/v2.0.0 for the release notes, it is basically a versions which only support composer 2.1+ & PHP 8.0+.