### PR TITLE
Date issues in Bolt 5

### DIFF
--- a/assets/js/app/editor/Components/Date.vue
+++ b/assets/js/app/editor/Components/Date.vue
@@ -105,7 +105,7 @@ export default {
                 wrap: true,
                 altFormat: 'F j, Y',
                 altInput: true,
-                dateFormat: 'Z',
+                dateFormat: 'Y-m-d h:i',
                 enableTime: false,
             },
         };

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -330,7 +330,7 @@ class SelectQuery implements QueryInterface
             $fieldName = preg_replace('/(_[0-9]+)$/', '', $key);
             // Use strtotime on 'date' fields to allow selections like "today", "in 3 weeks" or "this year"
             if (in_array($fieldName, $dateFields, true) && (strtotime($param) !== false)) {
-                $param = Carbon::createFromTimestamp(strtotime($param))->toIso8601ZuluString('millisecond');
+                $param = date('c', strtotime($param));
             }
 
             if (in_array($fieldName, $this->regularFields, true) && ! in_array($fieldName, $numberFields, true)) {

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -330,7 +330,7 @@ class SelectQuery implements QueryInterface
             $fieldName = preg_replace('/(_[0-9]+)$/', '', $key);
             // Use strtotime on 'date' fields to allow selections like "today", "in 3 weeks" or "this year"
             if (in_array($fieldName, $dateFields, true) && (strtotime($param) !== false)) {
-                $param = date('c', strtotime($param));
+                $param = date('Y-m-d h:i', strtotime($param));
             }
 
             if (in_array($fieldName, $this->regularFields, true) && ! in_array($fieldName, $numberFields, true)) {

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -330,7 +330,7 @@ class SelectQuery implements QueryInterface
             $fieldName = preg_replace('/(_[0-9]+)$/', '', $key);
             // Use strtotime on 'date' fields to allow selections like "today", "in 3 weeks" or "this year"
             if (in_array($fieldName, $dateFields, true) && (strtotime($param) !== false)) {
-                $param = Carbon::parse(strtotime($param))->toIso8601ZuluString('millisecond');
+                $param = Carbon::createFromTimestamp(strtotime($param))->toIso8601ZuluString('millisecond');
             }
 
             if (in_array($fieldName, $this->regularFields, true) && ! in_array($fieldName, $numberFields, true)) {

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -330,7 +330,7 @@ class SelectQuery implements QueryInterface
             $fieldName = preg_replace('/(_[0-9]+)$/', '', $key);
             // Use strtotime on 'date' fields to allow selections like "today", "in 3 weeks" or "this year"
             if (in_array($fieldName, $dateFields, true) && (strtotime($param) !== false)) {
-                $param = Carbon::parse((string) strtotime($param))->toIso8601ZuluString('milisecond');
+                $param = Carbon::parse(strtotime($param))->toIso8601ZuluString('millisecond');
             }
 
             if (in_array($fieldName, $this->regularFields, true) && ! in_array($fieldName, $numberFields, true)) {


### PR DESCRIPTION
This (#2993) bug has a bunch of things that nee to be done:

- [x] Find out where the data gets saved as Zulu
- [x] Change this to the normal Y-m-d h:i format
- [x] See if date filtering works with a 'between' query ( ' >= date ' & ' <= date' )

Fixes #2993 
