### PR TITLE
Allow prefix and postfix text on relationships and taxonomies input field

### DIFF
--- a/templates/_macro/_macro.html.twig
+++ b/templates/_macro/_macro.html.twig
@@ -98,3 +98,25 @@
         {{- datetime|date('c') -}}
     </abbr>
 {% endapply %}{% endmacro %}
+
+{#
+ Variables
+    'prefix': Is the prefix string
+    'id':     Is a string
+#}
+{% macro generatePrefix(prefix, id) %}{% apply spaceless %}
+    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
+        <div id="{{ id }} ~ '_prefix'" class="form--helper">{{ prefix|markdown }}</div>
+    {% endif %}
+{% endapply %}{% endmacro %}
+
+{#
+ Variables
+    'postfix': Is the postfix string
+    'id':      Is a string
+#}
+{% macro generatePostfix(postfix, id) %}{% apply spaceless %}
+    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
+        <div id="{{ id }} ~ '_postfix'" class="form--helper">{{ postfix|markdown }}</div>
+    {% endif %}
+{% endapply %}{% endmacro %}

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -122,18 +122,6 @@
 {# Set the locale #}
 {% set localize = field.definition.localize|default %}
 
-
-{# Set the prefix and postfix attributes #}
-{#{% set prefix = prefix|default(field.definition.prefix|default) %}#}
-{#{% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
-{#    {% set prefix = '<div id="' ~ id ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
-{#{% endif %}#}
-
-{#{% set postfix = postfix|default(field.definition.postfix|default) %}#}
-{#{% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
-{#    {% set postfix = '<div id="' ~ id ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
-{#{% endif %}#}
-
 {%- endapply -%}
 
 <!-- field "{{ label }}" (type: {{ type }}{% if variant != 'normal' %}, variant: {{ variant }}{% endif %}) -->
@@ -142,6 +130,7 @@
     id="field--{{ id }}"
 >
 
+{# Print prefix #}
 {% if field.definition['prefix']|default() is not empty %}
     {{ macro.generatePrefix(field.definition['prefix']|default(), id) }}
 {% endif %}
@@ -163,6 +152,7 @@
 
 {% if variant == 'inline' %}</div></div>{% endif %}
 
+{# Print postfix #}
 {% if field.definition['postfix']|default() is not empty %}
     {{ macro.generatePostfix(field.definition['postfix']|default(), id) }}
 {% endif %}

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -1,3 +1,5 @@
+{% import '_macro/_macro.html.twig' as macro %}
+
 {%- apply spaceless -%}
 
 {# This template fragment is used to "extend" the different fields, used in
@@ -120,16 +122,17 @@
 {# Set the locale #}
 {% set localize = field.definition.localize|default %}
 
-{# Set the prefix and postfix attributes #}
-{% set prefix = prefix|default(field.definition.prefix|default) %}
-{% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
-    {% set prefix = '<div id="' ~ id ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
-{% endif %}
 
-{% set postfix = postfix|default(field.definition.postfix|default) %}
-{% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
-    {% set postfix = '<div id="' ~ id ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
-{% endif %}
+{# Set the prefix and postfix attributes #}
+{#{% set prefix = prefix|default(field.definition.prefix|default) %}#}
+{#{% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
+{#    {% set prefix = '<div id="' ~ id ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
+{#{% endif %}#}
+
+{#{% set postfix = postfix|default(field.definition.postfix|default) %}#}
+{#{% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
+{#    {% set postfix = '<div id="' ~ id ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
+{#{% endif %}#}
 
 {%- endapply -%}
 
@@ -139,7 +142,9 @@
     id="field--{{ id }}"
 >
 
-{{ prefix|raw }}
+{% if field.definition['prefix']|default() is not empty %}
+    {{ macro.generatePrefix(field.definition['prefix']|default(), id) }}
+{% endif %}
 
 {% if variant == 'inline' %}<div class="row"><div class="col-3">{% endif %}
 
@@ -158,7 +163,9 @@
 
 {% if variant == 'inline' %}</div></div>{% endif %}
 
-{{ postfix|raw }}
+{% if field.definition['postfix']|default() is not empty %}
+    {{ macro.generatePostfix(field.definition['postfix']|default(), id) }}
+{% endif %}
 
 {{ separator|raw }}
 </div>

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -2,8 +2,9 @@
 {% for contentType, relation in record.definition.relations %}
 
     {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required) %}
-    {% set value = record|related_values(contentType) %}{# Set the prefix and postfix attributes #}
+    {% set value = record|related_values(contentType) %}
 
+    {# Set the prefix and postfix attributes #}
     {% set prefix = prefix|default(relation['prefix']|default) %}
     {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
         {% set prefix = '<div id="' ~ contentType ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -2,9 +2,20 @@
 {% for contentType, relation in record.definition.relations %}
 
     {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required) %}
-    {% set value = record|related_values(contentType) %}
+    {% set value = record|related_values(contentType) %}{# Set the prefix and postfix attributes #}
+
+    {% set prefix = prefix|default(relation['prefix']|default) %}
+    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
+        {% set prefix = '<div id="' ~ contentType ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
+    {% endif %}
+
+    {% set postfix = postfix|default(relation['postfix']|default) %}
+    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
+        {% set postfix = '<div id="' ~ contentType ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
+    {% endif %}
 
     <div class="form-group is-normal">
+        {{ prefix|raw }}
 
         {% include '@bolt/_partials/fields/_label.html.twig' with {
             'id': 'relationship-' ~ contentType,
@@ -24,6 +35,8 @@
                     :searchable=true
             ></editor-select>
         </div>
+
+        {{ postfix|raw }}
 
     </div>
 

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -1,23 +1,16 @@
 {% import '_macro/_macro.html.twig' as macro %}
+
 {% for contentType, relation in record.definition.relations %}
 
     {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required) %}
     {% set value = record|related_values(contentType) %}
 
-    {# Set the prefix and postfix attributes #}
-{#    {% set prefix = prefix|default(relation['prefix']|default) %}#}
-{#    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
-{#        {% set prefix = '<div id="' ~ contentType ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
-{#    {% endif %}#}
-
-{#    {% set postfix = postfix|default(relation['postfix']|default) %}#}
-{#    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
-{#        {% set postfix = '<div id="' ~ contentType ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
-{#    {% endif %}#}
-
     <div class="form-group is-normal">
 
-        {{ macro.generatePrefix(relation['prefix']|default, contentType) }}
+        {# Print prefix #}
+        {% if relation['prefix']|default() is not empty %}
+            {{ macro.generatePrefix(relation['prefix']|default, contentType) }}
+        {% endif %}
 
         {% include '@bolt/_partials/fields/_label.html.twig' with {
             'id': 'relationship-' ~ contentType,
@@ -38,7 +31,10 @@
             ></editor-select>
         </div>
 
-        {{ macro.generatePostfix(relation['postfix']|default, contentType) }}
+        {# Print postfix #}
+        {% if relation['postfix']|default() is not empty %}
+            {{ macro.generatePostfix(relation['postfix']|default, contentType) }}
+        {% endif %}
 
     </div>
 

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -1,22 +1,23 @@
-
+{% import '_macro/_macro.html.twig' as macro %}
 {% for contentType, relation in record.definition.relations %}
 
     {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required) %}
     {% set value = record|related_values(contentType) %}
 
     {# Set the prefix and postfix attributes #}
-    {% set prefix = prefix|default(relation['prefix']|default) %}
-    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
-        {% set prefix = '<div id="' ~ contentType ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
-    {% endif %}
+{#    {% set prefix = prefix|default(relation['prefix']|default) %}#}
+{#    {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
+{#        {% set prefix = '<div id="' ~ contentType ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
+{#    {% endif %}#}
 
-    {% set postfix = postfix|default(relation['postfix']|default) %}
-    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
-        {% set postfix = '<div id="' ~ contentType ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
-    {% endif %}
+{#    {% set postfix = postfix|default(relation['postfix']|default) %}#}
+{#    {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
+{#        {% set postfix = '<div id="' ~ contentType ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
+{#    {% endif %}#}
 
     <div class="form-group is-normal">
-        {{ prefix|raw }}
+
+        {{ macro.generatePrefix(relation['prefix']|default, contentType) }}
 
         {% include '@bolt/_partials/fields/_label.html.twig' with {
             'id': 'relationship-' ~ contentType,
@@ -37,7 +38,7 @@
             ></editor-select>
         </div>
 
-        {{ postfix|raw }}
+        {{ macro.generatePostfix(relation['postfix']|default, contentType) }}
 
     </div>
 

--- a/templates/content/_taxonomies.html.twig
+++ b/templates/content/_taxonomies.html.twig
@@ -1,3 +1,4 @@
+{% import '_macro/_macro.html.twig' as macro %}
 {% for taxonomy in record.definition.taxonomy %}
 
         {% set definition = config.get('taxonomies/' ~ taxonomy) %}
@@ -5,21 +6,21 @@
 
             {% set options = taxonomy_options(definition) %}
             {% set value = taxonomy_values(record.taxonomies, definition) %}
-            
-            {# Set the prefix and postfix attributes #}
-            {% set prefix = prefix|default(definition['prefix']|default) %}
-            {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
-                {% set prefix = '<div id="' ~ taxonomy ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
-            {% endif %}
 
-            {% set postfix = postfix|default(definition['postfix']|default) %}
-            {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
-                {% set postfix = '<div id="' ~ taxonomy ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
-            {% endif %}
+{#            #}{# Set the prefix and postfix attributes #}
+{#            {% set prefix = prefix|default(definition['prefix']|default) %}#}
+{#            {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
+{#                {% set prefix = '<div id="' ~ taxonomy ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
+{#            {% endif %}#}
+
+{#            {% set postfix = postfix|default(definition['postfix']|default) %}#}
+{#            {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
+{#                {% set postfix = '<div id="' ~ taxonomy ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
+{#            {% endif %}#}
 
             <div class="form-group is-normal">
 
-                {{ prefix|raw }}
+                {{ macro.generatePrefix(definition['prefix'], taxonomy) }}
 
                 {% include '@bolt/_partials/fields/_label.html.twig' with {
                     'id': 'taxonomy-' ~ definition.slug,
@@ -39,7 +40,7 @@
                     ></editor-select>
                 </div>
 
-                {{ postfix|raw }}
+                {{ macro.generatePostfix(definition['postfix'], taxonomy) }}
 
             </div>
 

--- a/templates/content/_taxonomies.html.twig
+++ b/templates/content/_taxonomies.html.twig
@@ -6,7 +6,19 @@
             {% set options = taxonomy_options(definition) %}
             {% set value = taxonomy_values(record.taxonomies, definition) %}
 
+            {% set prefix = prefix|default(definition['prefix']|default) %}
+            {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
+                {% set prefix = '<div id="' ~ taxonomy ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}
+            {% endif %}
+
+            {% set postfix = postfix|default(definition['postfix']|default) %}
+            {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}
+                {% set postfix = '<div id="' ~ taxonomy ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}
+            {% endif %}
+
             <div class="form-group is-normal">
+
+                {{ prefix|raw }}
 
                 {% include '@bolt/_partials/fields/_label.html.twig' with {
                     'id': 'taxonomy-' ~ definition.slug,
@@ -25,6 +37,8 @@
                             :allowempty="{{ definition.required ? 'false' : 'true' }}"
                     ></editor-select>
                 </div>
+
+                {{ postfix|raw }}
 
             </div>
 

--- a/templates/content/_taxonomies.html.twig
+++ b/templates/content/_taxonomies.html.twig
@@ -5,7 +5,8 @@
 
             {% set options = taxonomy_options(definition) %}
             {% set value = taxonomy_values(record.taxonomies, definition) %}
-
+            
+            {# Set the prefix and postfix attributes #}
             {% set prefix = prefix|default(definition['prefix']|default) %}
             {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}
                 {% set prefix = '<div id="' ~ taxonomy ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}

--- a/templates/content/_taxonomies.html.twig
+++ b/templates/content/_taxonomies.html.twig
@@ -1,4 +1,5 @@
 {% import '_macro/_macro.html.twig' as macro %}
+
 {% for taxonomy in record.definition.taxonomy %}
 
         {% set definition = config.get('taxonomies/' ~ taxonomy) %}
@@ -7,20 +8,12 @@
             {% set options = taxonomy_options(definition) %}
             {% set value = taxonomy_values(record.taxonomies, definition) %}
 
-{#            #}{# Set the prefix and postfix attributes #}
-{#            {% set prefix = prefix|default(definition['prefix']|default) %}#}
-{#            {% if prefix and not (prefix starts with '<p' or prefix starts with '<span' or prefix starts with '<div') %}#}
-{#                {% set prefix = '<div id="' ~ taxonomy ~ '_prefix" class="form--helper">' ~ prefix|markdown ~ '</div>' %}#}
-{#            {% endif %}#}
-
-{#            {% set postfix = postfix|default(definition['postfix']|default) %}#}
-{#            {% if postfix and not (postfix starts with '<p' or postfix starts with '<span' or postfix starts with '<div') %}#}
-{#                {% set postfix = '<div id="' ~ taxonomy ~ '_postfix" class="form--helper">' ~ postfix|markdown ~ '</div>' %}#}
-{#            {% endif %}#}
-
             <div class="form-group is-normal">
 
-                {{ macro.generatePrefix(definition['prefix'], taxonomy) }}
+                {# Print prefix #}
+                {% if definition['prefix']|default() is not empty %}
+                    {{ macro.generatePrefix(definition['prefix'], taxonomy) }}
+                {% endif %}
 
                 {% include '@bolt/_partials/fields/_label.html.twig' with {
                     'id': 'taxonomy-' ~ definition.slug,
@@ -40,7 +33,10 @@
                     ></editor-select>
                 </div>
 
-                {{ macro.generatePostfix(definition['postfix'], taxonomy) }}
+                {# Print postfix #}
+                {% if definition['postfix']|default() is not empty %}
+                    {{ macro.generatePostfix(definition['postfix'], taxonomy) }}
+                {% endif %}
 
             </div>
 


### PR DESCRIPTION
Fixes #2989 