### PR TITLE
Add new paginate function for arrays

### DIFF
--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -124,7 +124,6 @@ final class ArrayExtension extends AbstractExtension
 
     /**
      * Paginate filter results so you wont have random amounts of pages in random pages
-     * @var Pagerfanta|array $array
      */
     public function paginate($array, int $pageSize = 10): Pagerfanta
     {

--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -9,10 +9,14 @@ use Bolt\Entity\Field\NumberField;
 use Bolt\Utils\ContentHelper;
 use Carbon\Carbon;
 use Iterator;
+use Pagerfanta\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Pagerfanta\Pagerfanta;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
+use Twig\TwigFunction;
+
 
 /**
  * Bolt specific Twig functions and filters that provide array manipulation.
@@ -29,12 +33,16 @@ final class ArrayExtension extends AbstractExtension
 
     /** @var string */
     private $defaultLocale;
+    
+    /** @var RequestStack */
+    private $requestStack;    
 
-    public function __construct(ContentHelper $contentHelper, LocaleExtension $localeExtension, string $defaultLocale)
+    public function __construct(ContentHelper $contentHelper, LocaleExtension $localeExtension, string $defaultLocale, RequestStack $requestStack)
     {
         $this->contentHelper = $contentHelper;
         $this->localeExtension = $localeExtension;
         $this->defaultLocale = $defaultLocale;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -48,6 +56,16 @@ final class ArrayExtension extends AbstractExtension
             new TwigFilter('order', [$this, 'order'], $env),
             new TwigFilter('shuffle', [$this, 'shuffle']),
             new TwigFilter('length', [$this, 'length'], $env),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('paginate', [$this, 'paginate']),
         ];
     }
 
@@ -102,6 +120,34 @@ final class ArrayExtension extends AbstractExtension
             return $this->orderHelper($a, $b, $orderOnSecondary, $orderAscendingSecondary, $locale);
         });
 
+        return $array;
+    }
+
+    /**
+     * Paginate filter results so you wont have random amounts of pages in random pages
+     * @var Pagerfanta|array $array
+     */
+    public function paginate($array, int $pageSize = 10): Pagerfanta
+    {
+        if ($array instanceof Pagerfanta) {
+            return $array;
+        }
+        $array = new Pagerfanta(new ArrayAdapter($array));
+        $array->setMaxPerPage($pageSize);
+
+        $currentPage = array_merge(
+            $this->requestStack->getCurrentRequest()->get('_route_params'),
+            $this->requestStack->getCurrentRequest()->query->all()
+        );
+        //Set the default page to 1 if the page is not set
+        if (array_key_exists('page', $currentPage)){
+            $array->setCurrentPage((int) $currentPage["page"]);
+        }
+        else {
+            $array->setCurrentPage(1);
+        }
+
+        $array->getNbResults();
         return $array;
     }
 

--- a/src/Twig/ArrayExtension.php
+++ b/src/Twig/ArrayExtension.php
@@ -10,13 +10,12 @@ use Bolt\Utils\ContentHelper;
 use Carbon\Carbon;
 use Iterator;
 use Pagerfanta\Adapter\ArrayAdapter;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Pagerfanta\Pagerfanta;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
-
 
 /**
  * Bolt specific Twig functions and filters that provide array manipulation.
@@ -35,7 +34,7 @@ final class ArrayExtension extends AbstractExtension
     private $defaultLocale;
     
     /** @var RequestStack */
-    private $requestStack;    
+    private $requestStack;
 
     public function __construct(ContentHelper $contentHelper, LocaleExtension $localeExtension, string $defaultLocale, RequestStack $requestStack)
     {
@@ -140,10 +139,9 @@ final class ArrayExtension extends AbstractExtension
             $this->requestStack->getCurrentRequest()->query->all()
         );
         //Set the default page to 1 if the page is not set
-        if (array_key_exists('page', $currentPage)){
+        if (array_key_exists('page', $currentPage)) {
             $array->setCurrentPage((int) $currentPage["page"]);
-        }
-        else {
+        } else {
             $array->setCurrentPage(1);
         }
 


### PR DESCRIPTION
If you filter the results from a setcontent query it returns an array with the records but the normal pager puts these records on the page they used to be. This paginate function will group these records to the same page