### PR TITLE
New feature: Allow empty value for select form controls, based on user setting.

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -3,7 +3,6 @@
         <multiselect
             ref="vselect"
             v-model="selected"
-            :allow-empty="allowempty"
             :limit="1000"
             :multiple="multiple"
             :options="options"
@@ -73,7 +72,6 @@ export default {
         options: Array,
         optionslimit: Number,
         multiple: Boolean,
-        allowempty: Boolean,
         taggable: Boolean,
         readonly: Boolean,
         classname: String,

--- a/src/Cache/RelatedOptionsUtilityCacher.php
+++ b/src/Cache/RelatedOptionsUtilityCacher.php
@@ -10,10 +10,10 @@ class RelatedOptionsUtilityCacher extends RelatedOptionsUtility implements Cachi
 
     public const CACHE_CONFIG_KEY = 'related_options';
 
-    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, int $maxAmount): array
+    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount): array
     {
         $this->setCacheKey([$contentTypeSlug, $order, $format, (string) $required, $maxAmount]);
 
-        return $this->execute([parent::class, __FUNCTION__], [$contentTypeSlug, $order, $format, $required, $maxAmount]);
+        return $this->execute([parent::class, __FUNCTION__], [$contentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount]);
     }
 }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -16,7 +16,7 @@ use Knp\DoctrineBehaviors\Contract\Entity\TranslatableInterface;
 use Knp\DoctrineBehaviors\Model\Translatable\TranslatableTrait;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;
-use Tightenco\Collect\Support\Collection as LaravelCollection;
+use Tightenco\Collect\Support\Collection;
 use Twig\Environment;
 use Twig\Markup;
 
@@ -155,7 +155,7 @@ class Field implements FieldInterface, TranslatableInterface
         }
     }
 
-    public function setDefinition($name, LaravelCollection $definition): void
+    public function setDefinition($name, Collection $definition): void
     {
         $this->fieldTypeDefinition = FieldType::mock($name, $definition);
     }
@@ -177,7 +177,7 @@ class Field implements FieldInterface, TranslatableInterface
         $default = $this->getDefaultValue();
 
         if ($this->isNew() && $default !== null) {
-            if (! $default instanceof LaravelCollection) {
+            if (! $default instanceof Collection) {
                 throw new \RuntimeException('Default value of field ' . $this->getName() . ' is ' . gettype($default) . ' but it should be an array.');
             }
 
@@ -439,4 +439,40 @@ class Field implements FieldInterface, TranslatableInterface
     {
         self::$twig = $twig;
     }
+
+    public function allowEmpty(): bool
+    {
+        return self::definitionAllowsEmpty($this->getDefinition());
+    }
+
+    public static function definitionAllowsEmpty(Collection $definition): bool
+    {
+        return self::settingsAllowEmpty(
+            $definition->get('allow_empty', null),
+            $definition->get('required', null)
+        );
+    }
+
+    /**
+     * True if settings allow empty value.
+     *
+     * Settings priority:
+     * - allow_empty
+     * - required
+     *
+     * Defaults to true.
+     */
+    public static function settingsAllowEmpty(?bool $allowEmpty, ?bool $required): bool
+    {
+        if (!is_null($allowEmpty)) {
+            return boolval($allowEmpty);
+        }
+
+        if (!is_null($required)) {
+            return !boolval($required);
+        }
+
+        return true;
+    }
+
 }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -474,5 +474,4 @@ class Field implements FieldInterface, TranslatableInterface
 
         return true;
     }
-
 }

--- a/src/Entity/Field/SelectField.php
+++ b/src/Entity/Field/SelectField.php
@@ -44,7 +44,7 @@ class SelectField extends Field implements FieldInterface, RawPersistable, \Iter
     {
         $value = parent::getValue();
 
-        if (empty($value) && $this->getDefinition()->get('required')) {
+        if (empty($value) && !$this->allowEmpty()) {
             $value = $this->getDefinition()->get('values');
 
             // Pick the first key from Collection, or the full value as string, like `entries/id,title`

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -507,7 +507,7 @@ class ContentExtension extends AbstractExtension
         // We need to add this as a 'dummy' option for when the user is allowed
         // not to pick an option. This is needed, because otherwise the `select`
         // would default to the first option.
-        if ($taxonomy['required'] === false) {
+        if (Field::definitionAllowsEmpty($taxonomy)) {
             $options[] = [
                 'key' => '',
                 'value' => '',
@@ -549,7 +549,7 @@ class ContentExtension extends AbstractExtension
             $orders = $orders[$taxonomy['slug']] ?? [];
         }
 
-        if (empty($values) && $taxonomy['required']) {
+        if (empty($values) && !Field::definitionAllowsEmpty($taxonomy)) {
             $values[] = key($taxonomy['options']);
             $orders = array_fill(0, count($values), 0);
         }

--- a/src/Twig/FieldExtension.php
+++ b/src/Twig/FieldExtension.php
@@ -169,7 +169,7 @@ class FieldExtension extends AbstractExtension
 
         $options = [];
 
-        if ($definition->get('required') === false) {
+        if ($field->allowEmpty()) {
             $options = [[
                 'key' => '',
                 'value' => '(choose a template)',
@@ -227,7 +227,7 @@ class FieldExtension extends AbstractExtension
         // We need to add this as a 'dummy' option for when the user is allowed
         // not to pick an option. This is needed, because otherwise the `select`
         // would default to the one.
-        if (! $field->getDefinition()->get('required', true)) {
+        if ($field->allowEmpty()) {
             $options[] = [
                 'key' => '',
                 'value' => '',
@@ -259,7 +259,7 @@ class FieldExtension extends AbstractExtension
         // We need to add this as a 'dummy' option for when the user is allowed
         // not to pick an option. This is needed, because otherwise the `select`
         // would default to the one.
-        if (! $field->getDefinition()->get('required', true)) {
+        if ($field->allowEmpty()) {
             $options[] = [
                 'key' => '',
                 'value' => '',

--- a/src/Twig/RelatedExtension.php
+++ b/src/Twig/RelatedExtension.php
@@ -138,7 +138,7 @@ class RelatedExtension extends AbstractExtension
         return null;
     }
 
-    public function getRelatedOptions(string $contentTypeSlug, ?string $order = null, string $format = '', ?bool $required = false): Collection
+    public function getRelatedOptions(string $contentTypeSlug, ?string $order = null, string $format = '', ?bool $required = false, ?bool $allowEmpty = false): Collection
     {
         $maxAmount = $this->config->get('maximum_listing_select', 1000);
 
@@ -148,7 +148,7 @@ class RelatedExtension extends AbstractExtension
             $order = $contentType->get('order');
         }
 
-        $options = $this->optionsUtility->fetchRelatedOptions($contentTypeSlug, $order, $format, $required, $maxAmount);
+        $options = $this->optionsUtility->fetchRelatedOptions($contentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount);
 
         return new Collection($options);
     }

--- a/src/Utils/RelatedOptionsUtility.php
+++ b/src/Utils/RelatedOptionsUtility.php
@@ -3,6 +3,7 @@
 namespace Bolt\Utils;
 
 use Bolt\Entity\Content;
+use Bolt\Entity\Field;
 use Bolt\Storage\Query;
 
 /**
@@ -27,7 +28,7 @@ class RelatedOptionsUtility
     /**
      * Decorated by `Bolt\Cache\RelatedOptionsUtilityCacher`
      */
-    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, int $maxAmount): array
+    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount): array
     {
         $pager = $this->query->getContent($contentTypeSlug, ['order' => $order])
             ->setMaxPerPage($maxAmount)
@@ -40,7 +41,7 @@ class RelatedOptionsUtility
         // We need to add this as a 'dummy' option for when the user is allowed
         // not to pick an option. This is needed, because otherwise the `select`
         // would default to the first one.
-        if ($required === false) {
+        if (Field::settingsAllowEmpty($allowEmpty, $required)) {
             $options[] = [
                 'key' => '',
                 'value' => '',

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -36,6 +36,5 @@
         :autocomplete="{{ autocomplete }}"
         :readonly="{{ readonly|json_encode }}"
         :errormessage='{{ errormessage|json_encode }}'
-        :allowempty="{{ required ? 'false' : 'true' }}"
     ></editor-select>
 {% endblock %}

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -2,7 +2,8 @@
 
 {% for contentType, relation in record.definition.relations %}
 
-    {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required) %}
+    {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty) %}
+
     {% set value = record|related_values(contentType) %}
 
     <div class="form-group is-normal">
@@ -26,7 +27,6 @@
                     :options="{{ options }}"
                     :multiple="{{ relation.multiple ? 'true' : 'false' }}"
                     :taggable=false
-                    :allowempty="{{ relation.required ? 'false' : 'true' }}"
                     :searchable=true
             ></editor-select>
         </div>

--- a/templates/content/_taxonomies.html.twig
+++ b/templates/content/_taxonomies.html.twig
@@ -39,7 +39,6 @@
                             :options="{{ options }}"
                             :multiple="{{ definition.multiple ? 'true' : 'false' }}"
                             :taggable="{{ (definition.behaves_like == 'tags') ? 'true' : 'false' }}"
-                            :allowempty="{{ definition.required ? 'false' : 'true' }}"
                     ></editor-select>
                 {% if definition.has_sortorder %}
                     </div>


### PR DESCRIPTION
## Use case
- have a required select field;
- select field must not pre-select any option;
- user must deliberately choose an option;

Current Bolt behaviour automatically selects first option if field is required.

## Solution

Add a configuration setting called `allow_empty` which enables developer to force an empty option for select control, even when control is required.

`allow_empty` setting is available in following definitions:
- select field
- relations
- taxonomies

Image below shows definitions with these settings:
```
required: true
allow_empty: true
```

![sample_relations_and_taxonomies](https://user-images.githubusercontent.com/422623/148603777-fbf42741-28fb-4a14-98c9-c000dbc7c090.png)

## Testing

Manually tested these combinations:

| required | allow_empty |
| - | - |
| none | none |
| none | true |
| none | false |
| true | none |
| true | true |
| true | false |
| false | none |
| false | true |
| false | false |

## Further improvements
- automatic validation. Given empty option is added automatically, Bolt can automatically validate select value and return an error.
- unit test