### PR TITLE
Fix date format to save PM time

### DIFF
--- a/assets/js/app/editor/Components/Date.vue
+++ b/assets/js/app/editor/Components/Date.vue
@@ -105,7 +105,7 @@ export default {
                 wrap: true,
                 altFormat: 'F j, Y',
                 altInput: true,
-                dateFormat: 'Y-m-d h:i',
+                dateFormat: 'Y-m-d H:i',
                 enableTime: false,
             },
         };

--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -330,7 +330,7 @@ class SelectQuery implements QueryInterface
             $fieldName = preg_replace('/(_[0-9]+)$/', '', $key);
             // Use strtotime on 'date' fields to allow selections like "today", "in 3 weeks" or "this year"
             if (in_array($fieldName, $dateFields, true) && (strtotime($param) !== false)) {
-                $param = date('Y-m-d h:i', strtotime($param));
+                $param = date('Y-m-d H:i', strtotime($param));
             }
 
             if (in_array($fieldName, $this->regularFields, true) && ! in_array($fieldName, $numberFields, true)) {

--- a/tests/cypress/integration/edit_record_1_field.spec.js
+++ b/tests/cypress/integration/edit_record_1_field.spec.js
@@ -50,3 +50,132 @@ describe('As an Admin I want to be able to make use of the embed, infobox and im
         cy.get('input[name="fields[image][alt]"]').should('be.empty');
     })
 });
+
+describe('As an Admin I want to be able to make use of the date & datetime fields', () => {
+    before(() => {
+        // First, switch an account to a locale which isn't using an AM/PM system (french for example)
+        cy.login('john_editor', 'john%1');
+
+        cy.visit('/bolt/profile-edit');
+        cy.get('#multiselect-user_locale > div > div.multiselect__select').scrollIntoView();
+        cy.get('#multiselect-user_locale > div > div.multiselect__select').click();
+        cy.contains('French (français, fr)').click();
+
+        cy.get('#editcontent > button').scrollIntoView();
+        cy.get('form[id="editcontent"]').submit();
+
+        cy.visit('/bolt/logout');
+    })
+
+    after(() => {
+        cy.visit('/bolt/logout');
+
+        // Revert the locale to avoid surprises in other tests
+        cy.login('john_editor', 'john%1');
+
+        cy.visit('/bolt/profile-edit');
+        cy.get('#multiselect-user_locale > div > div.multiselect__select').scrollIntoView();
+        cy.get('#multiselect-user_locale > div > div.multiselect__select').click();
+        cy.contains('English (English, en)').click();
+
+        cy.get('#editcontent > button').scrollIntoView();
+        cy.get('form[id="editcontent"]').submit();
+
+        cy.visit('/bolt/logout');
+    })
+
+    it('checks if an admin can use the date field', () => {
+        cy.login();
+        cy.visit('/bolt/edit/44');
+        cy.get('a[id="other-tab"]').click();
+
+        cy.get('#field--field-date button[aria-label="Date picker"]').click();
+        cy.get('#field--field-date input.editor--date').should('have.class', 'active');
+
+        cy.get('.flatpickr-calendar.open select.flatpickr-monthDropdown-months').select('March');
+        cy.get('.flatpickr-calendar.open input.cur-year').type('2019');
+        cy.get('.flatpickr-calendar.open span[aria-label="March 15, 2019"]').click();
+
+        cy.get('input[name="fields[date]"]').should('have.value', '2019-03-15 00:00');
+    })
+
+    it('checks if an admin can use the datetime field with an AM time (with AM/PM selector)', () => {
+        cy.login();
+        cy.visit('/bolt/edit/44');
+        cy.get('a[id="other-tab"]').click();
+
+        cy.get('#field--field-datetime button[aria-label="Date picker"]').click();
+        cy.get('#field--field-datetime input.editor--date').should('have.class', 'active');
+
+        cy.get('.flatpickr-calendar.open select.flatpickr-monthDropdown-months').select('May');
+        cy.get('.flatpickr-calendar.open input.cur-year').type('2020');
+        cy.get('.flatpickr-calendar.open input.flatpickr-hour').type('11');
+        cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('30');
+        cy.get('.flatpickr-calendar.open span.flatpickr-am-pm').then(($element) => {
+            if($element.html() === 'PM') {
+                // Switch to AM
+                $element.click();
+            }
+        });
+        cy.get('.flatpickr-calendar.open span[aria-label="May 10, 2020"]').click();
+
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-05-10 11:30');
+    })
+
+    it('checks if an admin can use the datetime field with a PM time (with AM/PM selector)', () => {
+        cy.login();
+        cy.visit('/bolt/edit/44');
+        cy.get('a[id="other-tab"]').click();
+
+        cy.get('#field--field-datetime button[aria-label="Date picker"]').click();
+        cy.get('#field--field-datetime input.editor--date').should('have.class', 'active');
+
+        cy.get('.flatpickr-calendar.open select.flatpickr-monthDropdown-months').select('July');
+        cy.get('.flatpickr-calendar.open input.cur-year').type('2020');
+        cy.get('.flatpickr-calendar.open input.flatpickr-hour').type('22');
+        cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('30');
+        cy.get('.flatpickr-calendar.open span.flatpickr-am-pm').then(($element) => {
+            if($element.html() === 'AM') {
+                // Switch to PM
+                $element.click();
+            }
+        });
+        cy.get('.flatpickr-calendar.open span[aria-label="July 20, 2020"]').click();
+
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30');
+    })
+
+    it('checks if an admin can use the datetime field with an AM time (without AM/PM selector)', () => {
+        cy.login('john_editor', 'john%1');
+        cy.visit('/bolt/edit/44');
+        cy.get('a[id="other-tab"]').click();
+
+        cy.get('#field--field-datetime button[aria-label="Date picker"]').click();
+        cy.get('#field--field-datetime input.editor--date').should('have.class', 'active');
+
+        cy.get('.flatpickr-calendar.open select.flatpickr-monthDropdown-months').select('janvier');
+        cy.get('.flatpickr-calendar.open input.cur-year').type('2020');
+        cy.get('.flatpickr-calendar.open input.flatpickr-hour').type('10');
+        cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('15');
+        cy.get('.flatpickr-calendar.open span[aria-label="janvier 28, 2020"]').click();
+
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-01-28 10:15');
+    })
+
+    it('checks if an admin can use the datetime field with a PM time (without AM/PM selector)', () => {
+        cy.login('john_editor', 'john%1');
+        cy.visit('/bolt/edit/44');
+        cy.get('a[id="other-tab"]').click();
+
+        cy.get('#field--field-datetime button[aria-label="Date picker"]').click();
+        cy.get('#field--field-datetime input.editor--date').should('have.class', 'active');
+
+        cy.get('.flatpickr-calendar.open select.flatpickr-monthDropdown-months').select('juillet');
+        cy.get('.flatpickr-calendar.open input.cur-year').type('2020');
+        cy.get('.flatpickr-calendar.open input.flatpickr-hour').type('22');
+        cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('30');
+        cy.get('.flatpickr-calendar.open span[aria-label="juillet 20, 2020"]').click();
+
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30');
+    })
+});


### PR DESCRIPTION
Hello! 
The recent changes to the format handled by date & datetime fields introduced a few bugs : 

Having the `h` format instead of `H` for hour will :
- make default hour stored for date fields as `12:00` 
- make default hour for query comparison as `12:00` (e.g. when using `where { date: '>yesterday' }`)
- only store the hour in a range between 0 and 12 on a `datetime` field when you type a PM hour (with or without the AM/PM selector) 

Fixes #3024