### PR TITLE
Users overview page dutch translations

### DIFF
--- a/templates/users/listing.html.twig
+++ b/templates/users/listing.html.twig
@@ -106,7 +106,7 @@
         {% endif %}
     </p>
 
-    <h3>Current sessions</h3>
+    <h3>{{ 'listing.current_sessions_header'|trans }}</h3>
     <table class="table">
         <thead>
             <tr>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2679,5 +2679,11 @@
         <target>Remember me? (%duration% days)</target>
       </segment>
     </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Current sessions</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl" trgLang="nl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="messages.nl">
     <unit id="tbB2gib" name="not_available">
       <notes>
@@ -181,7 +181,7 @@
         <target>Copyright</target>
       </segment>
     </unit>
-    <unit id="IaF1MjB" name="label.remembermeduration">
+    <unit id="2hoKa1k" name="label.remembermeduration">
       <notes>
         <note>templates/security/login.twig:80</note>
       </notes>
@@ -1287,13 +1287,13 @@
     <unit id="Iy4HXCU" name="controller.user.title">
       <segment>
         <source>controller.user.title</source>
-        <target><![CDATA[Users & Permissions]]></target>
+        <target><![CDATA[Gebruikers & permissies]]></target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
       <segment>
         <source>controller.user.subtitle</source>
-        <target>To edit users and their permissions</target>
+        <target><![CDATA[Gebruikers & permissies bewerken]]></target>
       </segment>
     </unit>
     <unit id="0Gyf5xr" name="controller.database.check_title">
@@ -1792,6 +1792,18 @@
       <segment>
         <source>placeholder.password</source>
         <target>je wachtwoord</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Bewerk permissies</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Huidige sessies</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.nl.xlf
+++ b/translations/security.nl.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl" trgLang="nl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="security.nl">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
       <segment>

--- a/translations/validators.nl.xlf
+++ b/translations/validators.nl.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl" trgLang="nl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="validators.nl">
     <unit id="zh5oKD9" name="This value should be false.">
       <segment>


### PR DESCRIPTION
Fixes #3047 

This PR adds a new translation label and translations for the heading Current sessions and updates the dutch translations of some text in this page.

![translations](https://user-images.githubusercontent.com/6607455/149372019-0795561e-c235-4339-a471-70563d72bde3.PNG)

