### PR TITLE
Bugfix Fix autocomplete for Relation 

### DIFF
--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -27,7 +27,7 @@
                     :options="{{ options }}"
                     :multiple="{{ relation.multiple ? 'true' : 'false' }}"
                     :taggable=false
-                    :searchable=true
+                    :autocomplete=true
             ></editor-select>
         </div>
 


### PR DESCRIPTION
it looks like searchable not used in assets/js/app/editor/Components/Select.vue   only  **:searchable="autocomplete || taggable"**