### PR TITLE
Avoid running node service as root user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     volumes:
       - ./:/home/node/app
     working_dir: /home/node/app
+    user: node
     command:
       - ./node_modules/.bin/encore
       - dev


### PR DESCRIPTION
Hello!

The current node image used for compiling assets is run using it's default user, which is `root`. However, the image is providing an existing non-root user which is `node`. This one should be used, as mentioned in the [docker node best practices](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user).

## Current problem 

When starting the project, assets under the `/public/assets` folder are generated using the `node` image as `root` user, so the files and subfolders are created with `root:root` ownership.

This causes a following Webpack subtask to fail : 

![webpack-cli-error](https://user-images.githubusercontent.com/3305030/151984817-be533241-1d33-4bb6-a487-af3b0ea40e5f.png)

## Solution

As Bolt is not running a custom image for this service, but is using docker-compose, the easiest tweak would be to just switch the user for the `node` service to the `node` user. Generated file would then inherit the ownership of parents folders on host.