### PR TITLE
Make it possible for GlobalVoter.php to vote on non-bolt users.

### DIFF
--- a/config/bolt/permissions.yaml
+++ b/config/bolt/permissions.yaml
@@ -10,8 +10,10 @@
 assignable_roles: [ROLE_DEVELOPER, ROLE_ADMIN, ROLE_CHIEF_EDITOR, ROLE_EDITOR, ROLE_USER, ROLE_WEBSERVICE]
 
 # These permissions are the 'global' permissions; these are not tied
-# to any content types, but rather apply to global, non-content activity in
-# Bolt's backend. Most of these permissions map directly to backend routes;
+# to any content types. Most of them apply to global, non-content activity 
+# in Bolt's backend but there are exceptions like the api:* permissions
+# used to manage access to the api-platform based requests.
+# Most of these permissions map directly to backend routes;
 # keep in mind, however, that routes do not always correspond to URL paths 1:1.
 # The default set defined here is appropriate for most sites, so most likely,
 # you will not have to change it.

--- a/src/Security/GlobalVoter.php
+++ b/src/Security/GlobalVoter.php
@@ -45,12 +45,8 @@ class GlobalVoter extends Voter
     {
         $user = $token->getUser();
 
-        if (! $user instanceof User) {
-            // the user must be logged in; if not, deny access
-            return false;
-        }
-
-        if ($user->getStatus() !== UserStatus::ENABLED) {
+        // Deny if the user is a Bolt\Entity\User and not enabled
+        if ($user instanceof User && $user->getStatus() !== UserStatus::ENABLED) {
             return false;
         }
 


### PR DESCRIPTION
This is a suggested 'fix' for issue https://github.com/bolt/core/issues/3079 

This needs to be discussed a bit before merging it in I'd say, especially if this could be the right fix for the wrong problem. 

Should global permissions used in the admin be mixed with permissions used for the front end? If the answer is 'yes' than I'd say this change should probably go in, if the answer is 'no' there should be another solution I'd say.

The global permissions I'm referring to are of course the API ones: 

```
    api:get: [ ROLE_WEBSERVICE ] # allow read access to Bolt's RESTful and GraphQL API
    api:post: [ ROLE_WEBSERVICE ] # allow write access to Bolt's RESTful and GraphQL API
    api:delete: [ ROLE_WEBSERVICE ] # allow delete access to Bolt's RESTful and GraphQL API
```

Reading the docs here https://github.com/bolt/core/blob/02b828cbe08cb7b3ee9c273ee8aa27cd1b91749d/config/bolt/permissions.yaml#L14 state explicitly the permissions are meant for the admin back-end. That documentation is not in line with the usage for the api access at the moment.