### PR TITLE
update 'dynamic' routing based on names of content types and taxonomies

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -16,6 +16,14 @@ frontend:
   prefix: /
   type: annotation
 
+#
+# Special loader for dynamic routes based on names of content types and taxonomies.
+# Both for front-end and for the admin.
+#
+dynamic_routes:
+    resource: 'bolt.dynamic_route_loader::loadRoutes'
+    type: service
+
 # ------------------------------------------------------------------------------
 # Place your own routes here, that have a LOWER priority than the default routes.
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -170,3 +170,6 @@ services:
         decorates: 'api_platform.doctrine.orm.data_persister'
 
     Symfony\Component\DependencyInjection\ContainerInterface: '@service_container'
+
+    bolt.dynamic_route_loader:
+        class: Bolt\Routing\DynamicRouteLoader

--- a/src/Configuration/Config.php
+++ b/src/Configuration/Config.php
@@ -82,7 +82,7 @@ class Config
                 $this->cache->delete(self::CACHE_KEY);
                 [$data] = $this->getCache();
 
-                // Clear the entire cache in order to re-generate %bolt.requirement.contenttypes%
+                // Clear the entire cache in order to re-generate routing table
                 $this->clearCacheController->clearcache($this->kernel);
             }
         }

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -24,6 +24,7 @@ use Bolt\Repository\FieldRepository;
 use Bolt\Repository\MediaRepository;
 use Bolt\Repository\RelationRepository;
 use Bolt\Repository\TaxonomyRepository;
+use Bolt\Routing\DynamicRouteLoader;
 use Bolt\Security\ContentVoter;
 use Bolt\Utils\TranslationsManager;
 use Bolt\Validator\ContentValidatorInterface;
@@ -133,25 +134,15 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
     }
 
     /**
-     * @Route(
-     *     "/edit/{_locale}/{contentTypeSlug}/{slugOrId}",
-     *     name="bolt_edit_content_slug",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
-     *     methods={"GET"})
-     * @Route(
-     *     "/edit/{contentTypeSlug}/{slugOrId}",
-     *     name="bolt_edit_content_slug",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
-     *     methods={"GET"})
+     * @see DynamicRouteLoader for content type based routes to this method.
+     *
      * @Route(
      *     "/edit/{slugOrId}",
      *     name="bolt_edit_content_slug",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
      *     methods={"GET"})
      * @Route(
      *     "/edit/{_locale}/{slugOrId}",
      *     name="bolt_edit_content_slug",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
      *     methods={"GET"})
      */
     public function editFromSlug(?string $contentTypeSlug = null, $slugOrId): Response

--- a/src/Controller/Frontend/DetailController.php
+++ b/src/Controller/Frontend/DetailController.php
@@ -7,6 +7,7 @@ namespace Bolt\Controller\Frontend;
 use Bolt\Configuration\Content\ContentType;
 use Bolt\Controller\TwigAwareController;
 use Bolt\Repository\ContentRepository;
+use Bolt\Routing\DynamicRouteLoader;
 use Bolt\Utils\ContentHelper;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -26,16 +27,7 @@ class DetailController extends TwigAwareController implements FrontendZoneInterf
     }
 
     /**
-     * @Route(
-     *     "/{contentTypeSlug}/{slugOrId}",
-     *     name="record",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
-     *     methods={"GET|POST"})
-     * @Route(
-     *     "/{_locale}/{contentTypeSlug}/{slugOrId}",
-     *     name="record_locale",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
-     *     methods={"GET|POST"})
+     * @see DynamicRouteLoader for routes to this method.
      *
      * @param string|int $slugOrId
      */

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -9,6 +9,7 @@ use Bolt\Configuration\Content\ContentType;
 use Bolt\Controller\TwigAwareController;
 use Bolt\Entity\Content;
 use Bolt\Repository\ContentRepository;
+use Bolt\Routing\DynamicRouteLoader;
 use Bolt\Storage\Query;
 use Pagerfanta\Adapter\ArrayAdapter;
 use Pagerfanta\Pagerfanta;
@@ -28,16 +29,7 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
     }
 
     /**
-     * @Route(
-     *     "/{contentTypeSlug}",
-     *     name="listing",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
-     *     methods={"GET|POST"})
-     * @Route(
-     *     "/{_locale}/{contentTypeSlug}",
-     *     name="listing_locale",
-     *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
-     *     methods={"GET|POST"})
+     * @see DynamicRouteLoader for routes to this method.
      */
     public function listing(ContentRepository $contentRepository, string $contentTypeSlug, ?string $_locale = null): Response
     {

--- a/src/Controller/Frontend/TaxonomyController.php
+++ b/src/Controller/Frontend/TaxonomyController.php
@@ -8,24 +8,14 @@ use Bolt\Configuration\Content\TaxonomyType;
 use Bolt\Controller\TwigAwareController;
 use Bolt\Entity\Content;
 use Bolt\Repository\ContentRepository;
+use Bolt\Routing\DynamicRouteLoader;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class TaxonomyController extends TwigAwareController implements FrontendZoneInterface
 {
     /**
-     * @Route(
-     *     "/{taxonomyslug}/{slug}",
-     *     name="taxonomy",
-     *     requirements={"taxonomyslug"="%bolt.requirement.taxonomies%"},
-     *     methods={"GET|POST"}
-     * )
-     * @Route(
-     *     "/{_locale}/{taxonomyslug}/{slug}",
-     *     name="taxonomy_locale",
-     *     requirements={"taxonomyslug"="%bolt.requirement.taxonomies%", "_locale": "%app_locales%"},
-     *     methods={"GET|POST"}
-     * )
+     * @see DynamicRouteLoader for routes to this method.
      */
     public function listing(ContentRepository $contentRepository, string $taxonomyslug, string $slug): Response
     {

--- a/src/Routing/DynamicRouteLoader.php
+++ b/src/Routing/DynamicRouteLoader.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Bolt\Routing;
+
+use Bolt\Configuration\Config;
+use Bolt\Controller\Backend\ContentEditController;
+use Bolt\Controller\Frontend\DetailController;
+use Bolt\Controller\Frontend\ListingController;
+use Bolt\Controller\Frontend\TaxonomyController;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Defines routes for content types and taxonomies based on their names. It does so by loading content types
+ * and taxonomies from the config, and creating routes for every name.
+ *
+ * @see Config
+ */
+class DynamicRouteLoader implements RouteLoaderInterface
+{
+    /** @var Config $config */
+    private $config;
+
+    /** @var string $locales '|' separated string of locales enabled in this Bolt application */
+    private $locales;
+
+    /**
+     * @param Config $config
+     * @param string $locales '|' separated string of locales, see services.yaml
+     */
+    public function __construct(Config $config, string $locales)
+    {
+        $this->config = $config;
+        $this->locales = $locales;
+    }
+
+    public function loadRoutes(): RouteCollection
+    {
+        $routes = new RouteCollection();
+
+        $contentTypes = $this->config->get('contenttypes');
+        $contentTypeSlugs = $contentTypes
+            ->pluck('slug')
+            ->concat($contentTypes->pluck('singular_slug'))
+            ->unique()
+            ->implode('|');
+
+        $taxonomies = $this->config->get('taxonomies');
+        $taxonomySlugs = $taxonomies
+            ->pluck('slug')
+            ->concat($taxonomies->pluck('singular_slug'))
+            ->unique()
+            ->implode('|');
+
+        // ListingController::listing (front-end)
+        /*
+         * OLD method annotations, for reference, not in use.
+         *
+         * @Route(
+         *     "/{contentTypeSlug}",
+         *     name="listing",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
+         *     methods={"GET|POST"})
+         * @Route(
+         *     "/{_locale}/{contentTypeSlug}",
+         *     name="listing_locale",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
+         *     methods={"GET|POST"})
+         */
+        $listingControllerDefaults = [
+            '_controller' => ListingController::class . '::listing',
+        ];
+        $routes->add('listing',
+            (new Route('/{contentTypeSlug}',
+                $listingControllerDefaults,
+                [
+                    'contentTypeSlug' => $contentTypeSlugs
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+
+        $routes->add('listing_locale',
+            (new Route(
+                '/{_locale}/{contentTypeSlug}/{slugOrId}',
+                $listingControllerDefaults,
+                [
+                    'contentTypeSlug' => $contentTypeSlugs,
+                    '_locale' => $this->locales,
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+
+        // DetailController::record() (front-end)
+        /*
+         * OLD method annotations, for reference, not in use.
+         *
+         * @Route(
+         *     "/{contentTypeSlug}/{slugOrId}",
+         *     name="record",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
+         *     methods={"GET|POST"})
+         * @Route(
+         *     "/{_locale}/{contentTypeSlug}/{slugOrId}",
+         *     name="record_locale",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%", "_locale": "%app_locales%"},
+         *     methods={"GET|POST"})
+         */
+        $datailControllerDefaults = [
+            '_controller' => DetailController::class . '::record',
+        ];
+        $routes->add('record',
+            (new Route(
+                '/{contentTypeSlug}/{slugOrId}',
+                $datailControllerDefaults,
+                [
+                    'contentTypeSlug' => $contentTypeSlugs
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+        $routes->add(
+            'record_locale',
+            (new Route(
+                '/{_locale}/{contentTypeSlug}/{slugOrId}',
+                $datailControllerDefaults,
+                [
+                    'contentTypeSlug' => $contentTypeSlugs,
+                    '_locale' => $this->locales,
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+
+        // TaxonomyController::listing() (front-end)
+        /*
+         * OLD method annotations, for reference, not in use.
+         *
+         * @Route(
+         *     "/{taxonomyslug}/{slug}",
+         *     name="taxonomy",
+         *     requirements={"taxonomyslug"="%bolt.requirement.taxonomies%"},
+         *     methods={"GET|POST"}
+         * )
+         * @Route(
+         *     "/{_locale}/{taxonomyslug}/{slug}",
+         *     name="taxonomy_locale",
+         *     requirements={"taxonomyslug"="%bolt.requirement.taxonomies%", "_locale": "%app_locales%"},
+         *     methods={"GET|POST"}
+         * )
+         */
+        $taxonomyControllerDefaults = [
+            '_controller' => TaxonomyController::class . '::listing',
+        ];
+        $routes->add('taxonomy',
+            (new Route(
+                '/{taxonomyslug}/{slug}',
+                $taxonomyControllerDefaults,
+                [
+                    'taxonomyslug' => $taxonomySlugs
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+        $routes->add(
+            'taxonomy_locale',
+            (new Route(
+                '/{_locale}/{taxonomyslug}/{slug}',
+                $taxonomyControllerDefaults,
+                [
+                    'taxonomyslug' => $taxonomySlugs,
+                    '_locale' => $this->locales,
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+
+        // routes for ContentEditController::editFromSlug
+        /*
+         * OLD method annotations, for reference, not in use.
+         *
+         * @Route(
+         *     "/edit/{_locale}/{contentTypeSlug}/{slugOrId}",
+         *     name="bolt_edit_content_slug",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
+         *     methods={"GET"})
+         * @Route(
+         *     "/edit/{contentTypeSlug}/{slugOrId}",
+         *     name="bolt_edit_content_slug",
+         *     requirements={"contentTypeSlug"="%bolt.requirement.contenttypes%"},
+         *     methods={"GET"})
+         */
+        $contentEditControllerDefaults = [
+            '_controller' => ContentEditController::class . '::editFromSlug',
+        ];
+        $routes->add('taxonomy',
+            (new Route(
+                '/{taxonomyslug}/{slug}',
+                $contentEditControllerDefaults,
+                [
+                    ['contentTypeSlug' => $contentTypeSlugs]
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+        $routes->add(
+            'taxonomy_locale',
+            (new Route(
+                '/{_locale}/{taxonomyslug}/{slug}',
+                $contentEditControllerDefaults,
+                [
+                    'contentTypeSlug' => $contentTypeSlugs,
+                    '_locale' => '.*',
+                ])
+            )->setMethods(['GET', 'POST'])
+        );
+
+        return $routes;
+    }
+}


### PR DESCRIPTION
This change moves content-type and taxonomy routing config from Kernel + annotations to a RouteLoader service class. By doing so it removes (some of) the dependencies of Kernel.php on config parsers, the use of these parsers by Kernel.php can be problematic/confusing for developers working on or using Bolt because it removes the possibility to override (parts of) the Config.php class, for example during testing.
As the Config.php class is itself a service, so it could not be used by the kernel (you cannot use services while configuring the service container)
