### PR TITLE
Update Date.vue dateFormat to include seconds

### DIFF
--- a/assets/js/app/editor/Components/Date.vue
+++ b/assets/js/app/editor/Components/Date.vue
@@ -105,7 +105,7 @@ export default {
                 wrap: true,
                 altFormat: 'F j, Y',
                 altInput: true,
-                dateFormat: 'Y-m-d H:i',
+                dateFormat: 'Y-m-d H:i:S',
                 enableTime: false,
             },
         };

--- a/tests/cypress/integration/edit_record_1_field.spec.js
+++ b/tests/cypress/integration/edit_record_1_field.spec.js
@@ -96,7 +96,7 @@ describe('As an Admin I want to be able to make use of the date & datetime field
         cy.get('.flatpickr-calendar.open input.cur-year').type('2019');
         cy.get('.flatpickr-calendar.open span[aria-label="March 15, 2019"]').click();
 
-        cy.get('input[name="fields[date]"]').should('have.value', '2019-03-15 00:00');
+        cy.get('input[name="fields[date]"]').should('have.value', '2019-03-15 00:00:00');
     })
 
     it('checks if an admin can use the datetime field with an AM time (with AM/PM selector)', () => {
@@ -119,7 +119,7 @@ describe('As an Admin I want to be able to make use of the date & datetime field
         });
         cy.get('.flatpickr-calendar.open span[aria-label="May 10, 2020"]').click();
 
-        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-05-10 11:30');
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-05-10 11:30:00');
     })
 
     it('checks if an admin can use the datetime field with a PM time (with AM/PM selector)', () => {
@@ -142,7 +142,7 @@ describe('As an Admin I want to be able to make use of the date & datetime field
         });
         cy.get('.flatpickr-calendar.open span[aria-label="July 20, 2020"]').click();
 
-        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30');
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30:00');
     })
 
     it('checks if an admin can use the datetime field with an AM time (without AM/PM selector)', () => {
@@ -159,7 +159,7 @@ describe('As an Admin I want to be able to make use of the date & datetime field
         cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('15');
         cy.get('.flatpickr-calendar.open span[aria-label="janvier 28, 2020"]').click();
 
-        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-01-28 10:15');
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-01-28 10:15:00');
     })
 
     it('checks if an admin can use the datetime field with a PM time (without AM/PM selector)', () => {
@@ -176,6 +176,6 @@ describe('As an Admin I want to be able to make use of the date & datetime field
         cy.get('.flatpickr-calendar.open input.flatpickr-minute').type('30');
         cy.get('.flatpickr-calendar.open span[aria-label="juillet 20, 2020"]').click();
 
-        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30');
+        cy.get('input[name="fields[datetime]"]').should('have.value', '2020-07-20 22:30:00');
     })
 });


### PR DESCRIPTION
Added seconds to dateFormat to fix issue with date-compare between database original and edited version, causing users that didn't have the right to change publication dates to be denied making edits.

This fixes https://github.com/bolt/core/issues/3082

Note, this is only for the `dateFormat`, this is used 'behind the scenes' in this vue component and is used to post to the server, the actual format shown is specified in `altFormat`.