### PR TITLE
Fix #3106 : Select field with empty value

### DIFF
--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -464,12 +464,12 @@ class Field implements FieldInterface, TranslatableInterface
      */
     public static function settingsAllowEmpty(?bool $allowEmpty, ?bool $required): bool
     {
-        if (!is_null($allowEmpty)) {
-            return boolval($allowEmpty);
+        if (null !== $allowEmpty) {
+            return $allowEmpty;
         }
 
-        if (!is_null($required)) {
-            return !boolval($required);
+        if (null !== $required) {
+            return !$required;
         }
 
         return true;

--- a/src/Twig/FieldExtension.php
+++ b/src/Twig/FieldExtension.php
@@ -267,9 +267,7 @@ class FieldExtension extends AbstractExtension
             ];
         }
 
-        if (! empty($field->getDefinition()->get('limit'))) {
-            $maxAmount = $field->getDefinition()->get('limit');
-        } else {
+        if (empty($maxAmount = $field->getDefinition()->get('limit'))) {
             $maxAmount = $this->config->get('general/maximum_listing_select', 200);
         }
 
@@ -280,7 +278,7 @@ class FieldExtension extends AbstractExtension
             'order' => $order,
         ];
 
-        $options = $this->selectOptionsHelper($contentTypeSlug, $params, $field, $format);
+        $options = array_merge($options, $this->selectOptionsHelper($contentTypeSlug, $params, $field, $format));
 
         return new Collection($options);
     }


### PR DESCRIPTION
Fix issue #3106 where select field with content type as options can't have an empty value.