### PR TITLE
Update float field so it uses step='any' by default

### DIFF
--- a/assets/js/app/editor/Components/Number.vue
+++ b/assets/js/app/editor/Components/Number.vue
@@ -26,7 +26,7 @@ export default {
         id: String,
         value: String,
         name: String,
-        step: Number,
+        step: Number | String,
         type: String,
         disabled: Boolean,
         required: Boolean,

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -13,7 +13,7 @@
   {% elseif not step|default %}
     {# default step values #}
     {% if mode == 'float' %}
-      {% set step = 0.5 %}
+      {% set step = "'any'" %}
     {% elseif mode == 'integer' %}
       {% set step = 1 %}
     {% else %}


### PR DESCRIPTION
This way the amount of decimals after the comma isn't fixed by default