### PR TITLE
Updates to allow custom theming for security area

### DIFF
--- a/assets/js/app/toolbar/Components/Toolbar.vue
+++ b/assets/js/app/toolbar/Components/Toolbar.vue
@@ -5,7 +5,7 @@
         </div>
 
         <div v-if="isImpersonator" class="toolbar-impersonation">
-            <a :href="backendPrefix + '?_switch_user=_exit'" class="btn btn-warning">
+            <a :href="urlPaths['bolt_dashboard'] + '?_switch_user=_exit'" class="btn btn-warning">
                 <i class="fas fa-sign-out-alt fa-fw"></i>
                 {{ labels['action.stop_impersonating'] }}
             </a>
@@ -15,7 +15,7 @@
             <a href="/" target="_blank"> <i class="fas fa-sign-out-alt"></i>{{ labels['action.view_site'] }} </a>
         </div>
 
-        <form :action="backendPrefix" class="toolbar-item toolbar-item__filter input-group">
+        <form :action="urlPaths['bolt_dashboard']" class="toolbar-item toolbar-item__filter input-group">
             <label for="global-search" class="sr-only">{{ labels['general.label.search'] }}</label>
             <input
                 id="global-search"
@@ -56,13 +56,13 @@
             <div class="profile__dropdown dropdown-menu dropdown-menu-right">
                 <ul>
                     <li>
-                        <a :href="backendPrefix + 'profile-edit'">
+                        <a :href="urlPaths['bolt_profile_edit']">
                             <i class="fas fa-user-edit fa-fw"></i>
                             {{ labels['action.edit_profile'] }}
                         </a>
                     </li>
                     <li>
-                        <a :href="backendPrefix + 'logout'">
+                        <a :href="urlPaths['bolt_logout']">
                             <i class="fas fa-sign-out-alt fa-fw"></i>
                             {{ labels['action.logout'] }}
                         </a>
@@ -95,6 +95,7 @@ export default {
         siteName: String,
         menu: Array,
         labels: Object,
+        urlPaths: Object,
         backendPrefix: String,
         isImpersonator: Boolean,
         filterValue: String,

--- a/src/Controller/Backend/AuthenticationController.php
+++ b/src/Controller/Backend/AuthenticationController.php
@@ -34,8 +34,10 @@ class AuthenticationController extends TwigAwareController implements BackendZon
 
         // last authentication error (if any)
         $error = $authenticationUtils->getLastAuthenticationError();
+        
+        $templates = $this->templateChooser->forLogin();
 
-        return $this->render('@bolt/security/login.html.twig', [
+        return $this->render($templates, [
             'error' => $error,
             'loginForm' => $form->createView(),
         ]);

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -476,6 +476,10 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
 
         $definition = empty($fieldDefinition) ? $content->getDefinition()->get('fields')->get($fieldName) : $fieldDefinition;
 
+        if (empty($definition)) {
+            throw new \Exception("Content type `{$content->getContentType()}` doesn't have field `{$fieldName}`.");
+        }
+
         if ($content->hasField($fieldName)) {
             $field = $content->getField($fieldName);
         }

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -87,26 +87,7 @@ class TwigAwareController extends AbstractController
             $parameters['theme'] = $this->config->get('theme');
         }
 
-        $this->setThemePackage();
-        $this->setTwigLoader();
-
-        // Resolve string|array of templates into the first one that is found.
-        if (is_array($template)) {
-            $templates = (new Collection($template))
-                ->map(function ($element): ?string {
-                    if ($element instanceof TemplateselectField) {
-                        return $element->__toString();
-                    }
-
-                    return $element;
-                })
-                ->filter()
-                ->toArray();
-            $template = $this->twig->resolveTemplate($templates);
-        }
-
-        // Render the template
-        $content = $this->twig->render($template, $parameters);
+        $content = $this->renderTemplate($template, $parameters);
 
         // Make sure we have a Response
         if ($response === null) {
@@ -222,6 +203,32 @@ class TwigAwareController extends AbstractController
         // set `files` package
         $filesPackage = new PathPackage('/files/', new EmptyVersionStrategy());
         $this->packages->addPackage('files', $filesPackage);
+    }
+
+    /**
+     * Renders a template, with theme support.
+     */
+    public function renderTemplate($template, array $parameters = []): string
+    {
+        $this->setThemePackage();
+        $this->setTwigLoader();
+
+        // Resolve string|array of templates into the first one that is found.
+        if (is_array($template)) {
+            $templates = (new Collection($template))
+                ->map(function ($element): ?string {
+                    if ($element instanceof TemplateselectField) {
+                        return $element->__toString();
+                    }
+
+                    return $element;
+                })
+                ->filter()
+                ->toArray();
+            $template = $this->twig->resolveTemplate($templates);
+        }
+
+        return $this->twig->render($template, $parameters);
     }
 
     public function createPager(Query $query, string $contentType, int $pageSize, string $order)

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -199,12 +199,15 @@ class Field implements FieldInterface, TranslatableInterface
 
         $result = [];
 
+        $currentLocale = $this->getCurrentLocale();
         foreach ($this->getTranslations() as $translation) {
             $locale = $translation->getLocale();
             $this->setCurrentLocale($locale);
             $value = $this->getParsedValue();
             $result[$locale] = $value;
         }
+        // restore current locale
+        $this->setCurrentLocale($currentLocale);
 
         return $result;
     }

--- a/src/Form/ResetPasswordRequestFormType.php
+++ b/src/Form/ResetPasswordRequestFormType.php
@@ -25,10 +25,14 @@ class ResetPasswordRequestFormType extends AbstractType
     {
         $builder
             ->add('email', EmailType::class, [
+                'label' => 'label.email',
                 'constraints' => [
                     new NotBlank([
                         'message' => $this->translator->trans('form.empty_email'),
                     ]),
+                ],
+                'attr' => [
+                    'placeholder' => $this->translator->trans('placeholder.email'),
                 ],
             ])
         ;

--- a/src/Security/AuthenticationEntryPointRedirector.php
+++ b/src/Security/AuthenticationEntryPointRedirector.php
@@ -7,20 +7,24 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AuthenticationEntryPointRedirector implements AuthenticationEntryPointInterface
 {
+    private $translator;
+
     private $urlGenerator;
 
-    public function __construct(UrlGeneratorInterface $urlGenerator)
+    public function __construct(TranslatorInterface $translator, UrlGeneratorInterface $urlGenerator)
     {
+        $this->translator = $translator;
         $this->urlGenerator = $urlGenerator;
     }
 
     public function start(Request $request, AuthenticationException $authException = null)
     {
         // add a custom flash message and redirect to the login page
-        $request->getSession()->getFlashBag()->add('warning', 'You have to login in order to access this page.');
+        $request->getSession()->getFlashBag()->add('warning', $this->translator->trans('You have to login in order to access this page.', [], 'security'));
 
         return new RedirectResponse($this->urlGenerator->generate('bolt_login'));
     }

--- a/src/TemplateChooser.php
+++ b/src/TemplateChooser.php
@@ -164,4 +164,68 @@ class TemplateChooser
 
         return $templates->unique()->filter()->toArray();
     }
+
+    public function forLogin(): array
+    {
+        $templates = new Collection();
+
+        // First candidate: Theme-specific config.
+        $templates->push($this->config->get('theme/login_template'));
+
+        // Second candidate: global config.
+        $templates->push($this->config->get('general/login_template'));
+
+        // Third candidate: default value.
+        $templates->push('@bolt/security/login.html.twig');
+
+        return $templates->unique()->filter()->toArray();
+    }
+
+    public function forResetPasswordCheckEmail(): array
+    {
+        $templates = new Collection();
+
+        // First candidate: Theme-specific config.
+        $templates->push($this->config->get('theme/reset_password_settings/check_email_template'));
+
+        // Second candidate: global config.
+        $templates->push($this->config->get('general/reset_password_settings/check_email_template'));
+
+        // Third candidate: default value.
+        $templates->push('@bolt/reset_password/check_email.html.twig');
+
+        return $templates->unique()->filter()->toArray();
+    }
+
+    public function forResetPasswordRequest(): array
+    {
+        $templates = new Collection();
+
+        // First candidate: Theme-specific config.
+        $templates->push($this->config->get('theme/reset_password_settings/request_template'));
+
+        // Second candidate: global config.
+        $templates->push($this->config->get('general/reset_password_settings/request_template'));
+
+        // Third candidate: default value.
+        $templates->push('@bolt/reset_password/request.html.twig');
+
+        return $templates->unique()->filter()->toArray();
+    }
+
+    public function forResetPasswordReset(): array
+    {
+        $templates = new Collection();
+
+        // First candidate: Theme-specific config.
+        $templates->push($this->config->get('theme/reset_password_settings/reset_template'));
+
+        // Second candidate: global config.
+        $templates->push($this->config->get('general/reset_password_settings/reset_template'));
+
+        // Third candidate: default value.
+        $templates->push('@bolt/reset_password/reset.html.twig');
+
+        return $templates->unique()->filter()->toArray();
+    }
 }

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -43,10 +43,17 @@
             'general.label.search': 'general.label.search'|trans,
         }|json_encode %}
 
+        {% set url_paths = {
+            'bolt_dashboard': path('bolt_dashboard'),
+            'bolt_logout': path('bolt_logout'),
+            'bolt_profile_edit': path('bolt_profile_edit'),
+        }|json_encode %}
+
         <admin-toolbar
             site-name="{{ config.get('general/sitename') }}"
             :menu="{{ admin_menu_json }}"
             :labels="{{ labels }}"
+            :url-paths="{{ url_paths }}"
             backend-prefix="{{ path('bolt_dashboard') }}"
             :avatar="{{ user_avatar|json_encode }}"
             :is-impersonator="{{ is_granted('IS_IMPERSONATOR')|json_encode }}"

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -2691,12 +2691,6 @@
         <target>Upload Options</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>You have to login in order to access this page.</target>
-      </segment>
-    </unit>
     <unit id="hKmDb7q" name="Share secure preview link">
       <segment>
         <source>Share secure preview link</source>
@@ -2707,6 +2701,12 @@
       <segment>
         <source>Order</source>
         <target>Order</target>
+      </segment>
+    </unit>
+    <unit id="0" name="placeholder.email">
+      <segment>
+        <source>placeholder.email</source>
+        <target>your email</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.en.xlf
+++ b/translations/security.en.xlf
@@ -97,5 +97,11 @@
         <target>User is disabled.</target>
       </segment>
     </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>You have to login in order to access this page.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
My goal was to customize templating around security:
- /login
- /reset-password
- /reset-password/check-email
- /reset-password/reset
- Reset Password email

These commits:
- add flexibility to allow custom theming
- fix various bugs ([this one](https://github.com/bolt/core/commit/a6644f09e4a3e0745da9d4df054f53170ee46855) was ugly)
- add/improve translated strings