### PR TITLE
Initialize Canonical with real request.

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -55,6 +55,12 @@ class Canonical
         $this->init();
     }
 
+    public function initFromRequest(Request $request): void
+    {
+        $this->request = $request;
+        $this->init();
+    }
+
     public function init(): void
     {
         // Ensure in request cycle (even for override).

--- a/src/Event/Subscriber/CanonicalSubscriber.php
+++ b/src/Event/Subscriber/CanonicalSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bolt\Event\Subscriber;
+
+use Bolt\Canonical;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class CanonicalSubscriber implements EventSubscriberInterface
+{
+    private $canonical;
+
+    public function __construct(Canonical $canonical)
+    {
+        $this->canonical = $canonical;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // ensure initialization with real request
+        $this->canonical->initFromRequest($request);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 0],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Initialization in constructor works when request comes from browser.

But when request comes from test, initialization fails b/c request doesn't exist at container creation time.

Thus, listen to kernel.request event and initialize canonical from there.

-----------------------

This seems to be a larger issue in the codebase.

@bobdenotter Let's discuss.