### PR TITLE
Use requestStack to access current request when needed.

### DIFF
--- a/src/Canonical.php
+++ b/src/Canonical.php
@@ -58,23 +58,29 @@ class Canonical
 
     public function getRequest(): Request
     {
-        // always try to use current request
         if ($this->request === null) {
-            $this->request = $this->requestStack->getCurrentRequest() ?? Request::createFromGlobals();
-            $this->init();
+            // Use default value.
+            $this->setRequest();
         }
 
         return $this->request;
     }
 
-    public function init(): void
+    public function setRequest(?Request $request = null): void
     {
-        // Ensure in request cycle (even for override).
-        if ($this->getRequest() === null || $this->getRequest()->getHost() === '') {
+        // Default to current request (if any).
+        if ($request === null) {
+            $request = $this->requestStack->getCurrentRequest() ?? Request::createFromGlobals();
+        }
+
+        $this->request = $request;
+
+        // Nothing to do if request is empty.
+        if ($this->request === null || $this->request->getHost() === '') {
             return;
         }
 
-        $requestUrl = parse_url($this->getRequest()->getSchemeAndHttpHost());
+        $requestUrl = parse_url($this->request->getSchemeAndHttpHost());
 
         $configCanonical = (string) $this->config->get('general/canonical', $this->getRequest()->getSchemeAndHttpHost());
 

--- a/src/Event/Subscriber/CanonicalSubscriber.php
+++ b/src/Event/Subscriber/CanonicalSubscriber.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bolt\Event\Subscriber;
+
+use Bolt\Canonical;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class CanonicalSubscriber implements EventSubscriberInterface
+{
+    private $canonical;
+
+    public function __construct(Canonical $canonical)
+    {
+        $this->canonical = $canonical;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        // ensure initialization with real request
+        $this->canonical->getRequest();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 0],
+            ],
+        ];
+    }
+}

--- a/src/Menu/FrontendMenu.php
+++ b/src/Menu/FrontendMenu.php
@@ -21,29 +21,29 @@ final class FrontendMenu implements FrontendMenuBuilderInterface
     /** @var FrontendMenuBuilder */
     private $menuBuilder;
 
-    /** @var Request */
-    private $request;
-
     /** @var Stopwatch */
     private $stopwatch;
 
     /** @var Config */
     private $config;
 
+    /** @var RequestStack */
+    private $requestStack;
+
     public function __construct(FrontendMenuBuilder $menuBuilder, TagAwareCacheInterface $cache, RequestStack $requestStack, Stopwatch $stopwatch, Config $config)
     {
         $this->cache = $cache;
         $this->menuBuilder = $menuBuilder;
-        $this->request = $requestStack->getCurrentRequest();
         $this->stopwatch = $stopwatch;
         $this->config = $config;
+        $this->requestStack = $requestStack;
     }
 
     public function buildMenu(Environment $twig, ?string $name = null): array
     {
         $this->stopwatch->start('bolt.frontendMenu');
 
-        $key = 'bolt.frontendMenu_' . ($name ?: 'main') . '_' . $this->request->getLocale();
+        $key = 'bolt.frontendMenu_' . ($name ?: 'main') . '_' . $this->requestStack->getCurrentRequest()->getLocale();
 
         $menu = $this->cache->get($key, function (ItemInterface $item) use ($name, $twig) {
             $item->expiresAfter($this->config->get('general/caching/frontend_menu'));


### PR DESCRIPTION
Storing current request in constructor isn't a good idea.
In general, it works (eg: when request from browser or most tests).

But not always.
EG: when test extends WebTestCase and login is executed through `$this->loginUser()`, then container is built without an active request.
Thus, request is null in constructors ...

Proper fix implies storing `$requestStack` and accessing current request when required.

This PR fixes Canonical and FrontendMenu (these failed in my use-case, so far).