### PR TITLE
Reverse search and replace array's in str_replace

### DIFF
--- a/src/Storage/SelectQuery.php
+++ b/src/Storage/SelectQuery.php
@@ -604,7 +604,7 @@ class SelectQuery implements QueryInterface
                 return sprintf("JSON_SEARCH(%s, 'one', %s) != ''", $valueAlias, $parameter[0]);
             }, $expressions);
 
-            return str_replace($expressions, $newExpressions, $filter->getExpression());
+            return str_replace(array_reverse($expressions), array_reverse($newExpressions), $filter->getExpression());
         }
 
         $originalLeftExpression = 'content.' . $filter->getKey();


### PR DESCRIPTION
The parameters in the search array are appended with an index number. This causes problems when the elements in the array exceed 10 because the first element will find a part in the 10th element (e.g. `content.topics = :topics_1` and `content.topics = :topics_10`). The resulting query will be corrupted because the 0  (in case of the 10th element) will not be replaced and left dangling in the string.
This change fixes this by reversing the array's, so the largest string will be looked up and replaced first.