### PR TITLE
fix number field template so it works within a collection field.

### DIFF
--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -26,7 +26,7 @@
     :id='{{ id|json_encode }}'
     name="{{ name }}"
     value="{{ value }}"
-    :step="{{ step }}"
+    :step="{{ step|raw }}"
     :required="{{ required|json_encode }}"
     :readonly="{{ readonly|json_encode }}"
     :errormessage="{{ errormessage|json_encode }}"


### PR DESCRIPTION
since v5.1.5, commit #3122  when number field "mode" is "float" (which is by default), the step is "'any'" by default (note the single quote wrapped by the double quote).  
This "'any'" value should not be escaped because it breaks when the number field is used within a collection. 

For instance, bellow is an extract of an "editor-collection" component generated by the backend when using a collection field having "number" field as child,
we can see it use a :template prop filled with escaped templates of fields members : 
```
 <editor-collection
      :existing-fields='[]'
      :templates='[{ ..  &lt;editor-number  ...  value=\&quot;\&quot;\n    :step=\&quot;&amp;#039;any&amp;#039;\&quot;\n    ...'
      :labels='...'
      :limit='200'
      :name="&quot;gallery_slider_images&quot;"
      :variant="&quot;collapsed&quot;"
    ></editor-collection>
```

Without applying a |raw filter, the value is double encoded and generates :
 
`:step=\&quot;&amp;#039;any&amp;#039;\&quot;`  (which decoded is the same as `:step=\"&#039;any&#039;\"`

instead of `:step=\&quot;&#039;any&#039;\&quot;` (which decoded is the same as `:step=\"'any'\"`)

This leads to a vue compilation error : 

```
[Vue warn]: Error compiling template:
 ...
<editor-number :id='&quot;field-gallery_slider_images-slider_image_set-6241de74820e3-coord_y&quot;' name="collections[gallery_slider_images][slider_image_set][6241de74820e3][coord_y]" value="" :step="&#039;any&#039;" :required="false" :readonly="false" :errormessage="false" :pattern="false" :placeholder="&quot;&quot;" ></editor-number>
...
- invalid expression: expected expression, got '&' in &#039;any&#039; Raw expression: :step="&#039;any&#039;"
```

However when using number field directly (ie without a collection field) it's was working. 

Using the |raw filter makes it work in both cases.

Note : this regression can lead to data loss when saving broken collections ...