### PR TITLE
Bump flex to ^1.17, v1.13 is going to stop working very soon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/dependency-injection": "^5.1",
         "symfony/dotenv": "^5.1",
         "symfony/expression-language": "^5.1",
-        "symfony/flex": "1.13.*",
+        "symfony/flex": "^1.17",
         "symfony/form": "^5.1",
         "symfony/framework-bundle": "^5.1",
         "symfony/http-client": "^5.1",

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "se/selenium-server-standalone": "^3.141",
         "symfony/browser-kit": "^5.1",
         "symfony/css-selector": "^5.1",
-        "symplify/easy-coding-standard": "^8.2.3"
+        "symplify/easy-coding-standard": "^8.0 || ^9.0"
     },
     "conflict": {
         "doctrine/common": ">=3.0",


### PR DESCRIPTION
We're going to shutdown the flex-server very soon and this locked version will stop working.
It could be great to unlock this constraint on the 4.2 branch, which is the only one affected.
Unless you think this version is too old and it's considered out of maintenance?