### PR TITLE
Fix: MySQL was returning case sensitive results.

### DIFF
--- a/src/Doctrine/JsonHelper.php
+++ b/src/Doctrine/JsonHelper.php
@@ -33,7 +33,7 @@ class JsonHelper
                 $resultWhere = 'JSON_GET_TEXT(' . $where . ', 0)';
             } elseif ($version->getPlatform()['driver_name'] === 'mysql') {
                 // MySQL
-                $resultWhere = 'JSON_UNQUOTE(JSON_EXTRACT(' . $where . ", '$[0]'))";
+                $resultWhere = 'CAST(JSON_UNQUOTE(JSON_EXTRACT(' . $where . ", '$[0]')) AS CHAR)";
             } else {
                 // SQLite
                 $resultWhere = 'JSON_EXTRACT(' . $where . ", '$[0]')";


### PR DESCRIPTION
Tested on MySQL 5.7 and 8.0.26, the bolt admin panel search widget on content was only returning case sensitive results.  When the original code was run on MariaDB, the results were case insensitive.  This fix makes MySQL return case insensitive results.  The issue is described in this StackOverflow answers:

- https://stackoverflow.com/a/59000485
- https://stackoverflow.com/a/63519138/4638563

By casting the JSON_EXTRACT to CHAR, it makes the search case insensitive. 

NOTE: Since this is database specific, I am unable to write a test for the issue.