### PR TITLE
Add edit link icon to related content in select/multiselect lists

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -43,6 +43,13 @@
                         </div>
                         <!-- eslint-disable-next-line vue/no-v-html -->
                         <span v-html="props.option.value"></span>
+
+                        <div v-if="props.option.link_to_record_url" class="multiselect__tag__edit">
+                            <a :href="props.option.link_to_record_url" target="_blank" rel="noopener noreferrer">
+                                <i class="far fa-edit me-0"></i>
+                            </a>
+                        </div>
+
                         <i
                             tabindex="1"
                             class="multiselect__tag-icon"

--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -26,6 +26,16 @@
                 <span class="status me-2" :class="`is-${props.option.key}`"></span>
                 {{ props.option.value | raw }}
             </template>
+
+            <template v-if="props.option.link_to_record_url" slot="singleLabel" slot-scope="props">
+                <span v-html="props.option.value"></span>
+                <div class="multiselect__tag__edit">
+                    <a :href="props.option.link_to_record_url" target="_blank" rel="noopener noreferrer">
+                        <i class="far fa-edit me-0"></i>
+                    </a>
+                </div>
+            </template>
+
             <template v-if="name !== 'status'" slot="tag" slot-scope="props">
                 <span :class="{ empty: props.option.value == '' }" @drop="drop($event)" @dragover="allowDrop($event)">
                     <span

--- a/assets/scss/vendor/multiselect.scss
+++ b/assets/scss/vendor/multiselect.scss
@@ -218,6 +218,7 @@ fieldset[disabled] .multiselect {
 .multiselect__tag__edit {
   display: inline-block;
   margin-left: 0.22rem;
+
   i {
     font-weight: bold;
   }

--- a/assets/scss/vendor/multiselect.scss
+++ b/assets/scss/vendor/multiselect.scss
@@ -215,6 +215,14 @@ fieldset[disabled] .multiselect {
   color: $vue-multiselect-tag-icon-color-hover;
 }
 
+.multiselect__tag__edit {
+  display: inline-block;
+  margin-left: 0.22rem;
+  i {
+    font-weight: bold;
+  }
+}
+
 .multiselect__current {
   line-height: list.slash($vue-multiselect-min-height, 2);
   min-height: $vue-multiselect-min-height;

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -310,6 +310,7 @@ showcases:
             multiple: true
             order: title
             label: Select zero or more pages
+            link_to_record: true
     taxonomy: [ categories, tags ]
     show_on_dashboard: true
     default_status: published

--- a/src/Cache/RelatedOptionsUtilityCacher.php
+++ b/src/Cache/RelatedOptionsUtilityCacher.php
@@ -2,6 +2,7 @@
 
 namespace Bolt\Cache;
 
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Utils\RelatedOptionsUtility;
 
 class RelatedOptionsUtilityCacher extends RelatedOptionsUtility implements CachingInterface
@@ -10,10 +11,10 @@ class RelatedOptionsUtilityCacher extends RelatedOptionsUtility implements Cachi
 
     public const CACHE_CONFIG_KEY = 'related_options';
 
-    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount): array
+    public function fetchRelatedOptions(ContentType $fromContentType, string $contentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount, bool $linkToRecord): array
     {
         $this->setCacheKey([$contentTypeSlug, $order, $format, (string) $required, $maxAmount]);
 
-        return $this->execute([parent::class, __FUNCTION__], [$contentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount]);
+        return $this->execute([parent::class, __FUNCTION__], [$fromContentType, $contentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount, $linkToRecord]);
     }
 }

--- a/src/Twig/RelatedExtension.php
+++ b/src/Twig/RelatedExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Twig;
 
 use Bolt\Configuration\Config;
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Content;
 use Bolt\Entity\Relation;
 use Bolt\Repository\RelationRepository;
@@ -138,17 +139,17 @@ class RelatedExtension extends AbstractExtension
         return null;
     }
 
-    public function getRelatedOptions(string $contentTypeSlug, ?string $order = null, string $format = '', ?bool $required = false, ?bool $allowEmpty = false): Collection
+    public function getRelatedOptions(ContentType $fromContentType, string $toContentTypeSlug, ?string $order = null, string $format = '', ?bool $required = false, ?bool $allowEmpty = false, bool $linkToRecord = false): Collection
     {
         $maxAmount = $this->config->get('general/maximum_listing_select', 1000);
 
-        $contentType = $this->config->getContentType($contentTypeSlug);
+        $contentType = $this->config->getContentType($toContentTypeSlug);
 
         if (! $order) {
             $order = $contentType->get('order');
         }
 
-        $options = $this->optionsUtility->fetchRelatedOptions($contentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount);
+        $options = $this->optionsUtility->fetchRelatedOptions($fromContentType, $toContentTypeSlug, $order, $format, $required, $allowEmpty, $maxAmount, $linkToRecord);
 
         return new Collection($options);
     }

--- a/src/Utils/RelatedOptionsUtility.php
+++ b/src/Utils/RelatedOptionsUtility.php
@@ -62,8 +62,8 @@ class RelatedOptionsUtility
             ];
 
             // Generate URL for related record if the link_to_record option is defined in relations in the contenttypes.yaml
-            if(isset($fromContentTypeRelationDefinition['link_to_record'])) {
-                if($fromContentTypeRelationDefinition['link_to_record']) {
+            if (isset($fromContentTypeRelationDefinition['link_to_record'])) {
+                if ($fromContentTypeRelationDefinition['link_to_record']) {
                     $options[$key]["link_to_record_url"] = $this->router->generate('bolt_content_edit', ['id' => $record->getId()]);
                 }
             }

--- a/src/Utils/RelatedOptionsUtility.php
+++ b/src/Utils/RelatedOptionsUtility.php
@@ -2,9 +2,11 @@
 
 namespace Bolt\Utils;
 
+use Bolt\Configuration\Content\ContentType;
 use Bolt\Entity\Content;
 use Bolt\Entity\Field;
 use Bolt\Storage\Query;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Utility class to get the 'Related Records' as options to show as a pull-down in the Editor.
@@ -19,23 +21,27 @@ class RelatedOptionsUtility
     /** @var ContentHelper */
     private $contentHelper;
 
-    public function __construct(Query $query, ContentHelper $contentHelper)
+    /** @var UrlGeneratorInterface */
+    private $router;
+
+    public function __construct(Query $query, ContentHelper $contentHelper, UrlGeneratorInterface $router)
     {
         $this->query = $query;
         $this->contentHelper = $contentHelper;
+        $this->router = $router;
     }
 
     /**
      * Decorated by `Bolt\Cache\RelatedOptionsUtilityCacher`
      */
-    public function fetchRelatedOptions(string $contentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount): array
+    public function fetchRelatedOptions(ContentType $fromContentType, string $toContentTypeSlug, string $order, string $format, bool $required, ?bool $allowEmpty, int $maxAmount, bool $linkToRecord): array
     {
-        $pager = $this->query->getContent($contentTypeSlug, ['order' => $order])
+        $pager = $this->query->getContent($toContentTypeSlug, ['order' => $order])
             ->setMaxPerPage($maxAmount)
             ->setCurrentPage(1);
 
         $records = iterator_to_array($pager->getCurrentPageResults());
-
+        $fromContentTypeRelationDefinition = $fromContentType->get('relations')->get($toContentTypeSlug);
         $options = [];
 
         // We need to add this as a 'dummy' option for when the user is allowed
@@ -49,11 +55,18 @@ class RelatedOptionsUtility
         }
 
         /** @var Content $record */
-        foreach ($records as $record) {
-            $options[] = [
+        foreach ($records as $key => $record) {
+            $options[$key] = [
                 'key' => $record->getId(),
                 'value' => $this->contentHelper->get($record, $format),
             ];
+
+            // Generate URL for related record if the link_to_record option is defined in relations in the contenttypes.yaml
+            if(isset($fromContentTypeRelationDefinition['link_to_record'])) {
+                if($fromContentTypeRelationDefinition['link_to_record']) {
+                    $options[$key]["link_to_record_url"] = $this->router->generate('bolt_content_edit', ['id' => $record->getId()]);
+                }
+            }
         }
 
         return $options;

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -1,20 +1,22 @@
 {% import '_macro/_macro.html.twig' as macro %}
 
-{% for contentType, relation in record.definition.relations %}
+{% set fromContentType = record.definition %}
 
-    {% set options = related_options(contentType, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty) %}
+{% for toContentTypeSlug, relation in record.definition.relations %}
+{#    {% dump(relation) %}#}
+    {% set options = related_options(fromContentType, toContentTypeSlug, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty, relation.link_to_record|default(false), ) %}
 
-    {% set value = record|related_values(contentType) %}
+    {% set value = record|related_values(toContentTypeSlug) %}
 
     <div class="mb-4">
 
         {# Print prefix #}
         {% if relation['prefix']|default() is not empty %}
-            {{ macro.generatePrefix(relation['prefix']|default, contentType) }}
+            {{ macro.generatePrefix(relation['prefix']|default, toContentTypeSlug) }}
         {% endif %}
 
         {% include '@bolt/_partials/fields/_label.html.twig' with {
-            'id': 'relationship-' ~ contentType,
+            'id': 'relationship-' ~ toContentTypeSlug,
             'label': relation.label,
             'required': relation.required
         } %}
@@ -22,8 +24,8 @@
         <div>
             <editor-select
                     :value="{{ value }}"
-                    :name="'relationship[{{ contentType }}]'"
-                    :id="'relationship-{{ contentType }}'"
+                    :name="'relationship[{{ toContentTypeSlug }}]'"
+                    :id="'relationship-{{ toContentTypeSlug }}'"
                     :options="{{ options }}"
                     :multiple="{{ relation.multiple ? 'true' : 'false' }}"
                     :taggable=false
@@ -33,7 +35,7 @@
 
         {# Print postfix #}
         {% if relation['postfix']|default() is not empty %}
-            {{ macro.generatePostfix(relation['postfix']|default, contentType) }}
+            {{ macro.generatePostfix(relation['postfix']|default, toContentTypeSlug) }}
         {% endif %}
 
     </div>

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -3,9 +3,8 @@
 {% set fromContentType = record.definition %}
 
 {% for toContentTypeSlug, relation in record.definition.relations %}
-{#    {% dump(relation) %}#}
-    {% set options = related_options(fromContentType, toContentTypeSlug, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty, relation.link_to_record|default(false), ) %}
 
+    {% set options = related_options(fromContentType, toContentTypeSlug, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty, relation.link_to_record|default(false), ) %}
     {% set value = record|related_values(toContentTypeSlug) %}
 
     <div class="mb-4">


### PR DESCRIPTION
This PR implements the new feature mentioned on issue #3189.

![image](https://user-images.githubusercontent.com/6607455/166947351-f7bc9d9e-c5d7-41ca-8078-2d0b022143ab.png)

The following features still need to be implemented to have a more complete support of this new feature:

- [x] Add edit link icons on relationships multiselect lists
- [x] Add edit link icon on relationships single select lists
- [x] Add edit link icon on multiselect fields with related content
- [x] Add edit link icon on select fields with related content
- [x] Add documentation for new `link_to_record` option  