### PR TITLE
Fix version compare for composer self-update versions.

### DIFF
--- a/bin/composer-script/Script.php
+++ b/bin/composer-script/Script.php
@@ -51,7 +51,7 @@ class Script
      */
     public static function runPHP(array $command): int
     {
-        if (version_compare(Composer::getVersion(), '2.3.0', '<')) {
+        if (version_compare(Composer::getVersion(), '2.3-dev', '<')) {
             // Composer 2.2.x or lower
             /* @phpstan-ignore-next-line */
             $process = new Process(implode(' ', $command));


### PR DESCRIPTION
To avoid error on installing:

[TypeError]                                                                                                                                                                                             
  Symfony\Component\Process\Process::__construct(): Argument #1 ($command) must be of type array, string given, called in bolt/web/vendor/bolt/core/bin/composer-script  
  /Script.php on line 57  

We need to fix compare version constraint. 
Composer self-update command updates composer to v2.3-dev+xxxx that is lower than current constraint.