### PR TITLE
Detect JSON for non-specialized MySQL platform instances.

### DIFF
--- a/src/Doctrine/Version.php
+++ b/src/Doctrine/Version.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Platforms\MariaDb1027Platform;
 use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQL92Platform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
@@ -95,6 +96,31 @@ class Version
         // MySQL80Platform is implicitly included with MySQL57Platform
         if ($platform instanceof MySQL57Platform || $platform instanceof MariaDb1027Platform) {
             return true;
+        }
+
+        // Corner case where MySQL platform is not specialized.
+        // Was observed with deployment to platform.sh using oracle-mysql service.
+        if ($platform instanceof MySqlPlatform) {
+            // samples:
+            // 8.0.29
+            // 8.0.27-cluster
+            // 10.7.3-MariaDB-1:10.7.3+maria~focal
+            $serverVersion = $this->getPlatform()["server_version"];
+
+            if (!preg_match("/^\d+\.\d+\.\d+/", $serverVersion, $matches)) {
+                // should throw an error or something?
+                return false;
+            }
+
+            $actVersion = $matches[0];
+
+            $isMariaDb = is_int(stripos($serverVersion, "maria"));
+            $minVersion = $isMariaDb
+                ? "10.2.7"  // taken from MariaDb1027Platform docs
+                : "5.7.9" // taken from MySQL57Platform docs
+            ;
+
+            return version_compare($actVersion, $minVersion, ">=");
         }
 
         // PostgreSQL supports JSON from v9.2 and above, later versions are implicitly included


### PR DESCRIPTION
Specific corner-case:

I deployed app to platform.sh and `$platform` object is of basic class `MySqlPlatform`, not specialized as expected at lines above.

This code handles such scenarios for MySQL(ish) databases.