### PR TITLE
Renamed the Icon method in the Content class

### DIFF
--- a/src/Entity/Content.php
+++ b/src/Entity/Content.php
@@ -358,7 +358,7 @@ class Content
         return $this->getDefinition()->get('locales')->first();
     }
 
-    public function getIcon(): ?string
+    public function getContentTypeIcon(): ?string
     {
         if ($this->getDefinition() === null) {
             throw new \RuntimeException('Content not fully initialized');

--- a/src/Entity/ContentExtrasTrait.php
+++ b/src/Entity/ContentExtrasTrait.php
@@ -39,7 +39,7 @@ trait ContentExtrasTrait
             'statusLink' => $this->contentExtension->getStatusLink($content),
             'deleteLink' => $this->contentExtension->getDeleteLink($content),
             'duplicateLink' => $this->contentExtension->getDuplicateLink($content),
-            'icon' => $this->getIcon(),
+            'icon' => $this->getContentTypeIcon(),
             'name' => $this->getDefinition()->get('name'),
             'singular_name' => $this->getDefinition()->get('singular_name'),
             'feature' => $this->contentExtension->getSpecialFeature($content),

--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -569,7 +569,7 @@ class ContentExtension extends AbstractExtension
     public function icon(?Content $record = null, string $icon = 'question-circle'): string
     {
         if ($record instanceof Content) {
-            $icon = $record->getIcon();
+            $icon = $record->getContentTypeIcon();
         }
 
         $icon = str_replace('fa-', '', $icon);


### PR DESCRIPTION
to avoid name conflicts with fields named icon.

With the current naming it's impossible to name a field `icon` and access it in twig.