### PR TITLE
Use single quotes for query string literals

### DIFF
--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -42,11 +42,11 @@ class TimedPublishSubscriber implements EventSubscriberInterface
         // Publish timed Content records when 'publish_at' has passed and Depublish published Content
         // records when 'depublish_at' has passed. Note: Placeholders in DBAL don't work for tablenames.
         $queryPublish = sprintf(
-            'update %scontent SET status = "published", published_at = :now  WHERE status = "timed" AND published_at < :now',
+            'update %scontent SET status = \'published\', published_at = :now  WHERE status = \'timed\' AND published_at < :now',
             $this->tablePrefix
         );
         $queryDepublish = sprintf(
-            'update %scontent SET status = "held", depublished_at = :now WHERE status = "published" AND depublished_at < :now',
+            'update %scontent SET status = \'held\', depublished_at = :now WHERE status = \'published\' AND depublished_at < :now',
             $this->tablePrefix
         );
 


### PR DESCRIPTION
Using a double quote(") character for string literals is not ANSI compatible and should only be used for quoting identifiers.

---
Issue can be reproduced by running bolt on a PostgreSQL backend. The PostgreSQL logs will mention the following:
``` log
2022-05-06 11:37:20.048 UTC [31716] <user>@<database> ERROR:  column "timed" does not exist at character 81
2022-05-06 11:37:20.048 UTC [31716] <user>@<database> STATEMENT:  update bolt_content SET status = "published", published_at = $1  WHERE status = "timed" AND published_at < $2
```

[PostgreSQL docs](https://www.postgresql.org/docs/9.3/sql-syntax-lexical.html):
> A string constant in SQL is an arbitrary sequence of characters bounded by single quotes ('), for example 'This is a string'. 
> There is a second kind of identifier: the delimited identifier or quoted identifier. It is formed by enclosing an arbitrary sequence of characters in double-quotes (") 

[MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/string-literals.html):
> If the [ANSI_QUOTES](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes) SQL mode is enabled, string literals can be quoted only within single quotation marks because a string quoted within double quotation marks is interpreted as an identifier.
