### PR TITLE
Fix setting new fields on collection.

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -459,13 +459,13 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
 
                 $collection = $this->getFieldToUpdate($content, $collectionName, $collectionDefinition);
 
+                $newFields = [];
                 foreach ($collectionItems as $name => $instances) {
                     // order field is only used to determine the order in which fields are submitted
                     if ($name === 'order') {
                         continue;
                     }
 
-                    $newFields = [];
                     foreach ($instances as $orderId => $value) {
                         $order = $orderArray[$orderId];
                         $fieldDefinition = $collection->getDefinition()->get('fields')->get($name);
@@ -478,8 +478,8 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
                         $this->updateField($field, $value, $locale);
                         $tm->applyTranslations($field, $collectionName, $orderId);
                     }
-                    $collection->setValue($newFields);
                 }
+                $collection->setValue($newFields);
             }
         }
     }


### PR DESCRIPTION
Bug observed when previewing a record with collection field.
Only last item in collection was available.

`$newFields` variable must be initialized outside the loop in order to capture all collection fields.