### PR TITLE
Maintain field order.

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -472,13 +472,14 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
                         $field = FieldRepository::factory($fieldDefinition, $name);
                         // Note, $collection side is set by $collection->setValue() below
                         $field->setParent($collection);
-                        $newFields[] = $field;
+                        $newFields[$order] = $field;
                         $field->setSortorder($order);
                         $content->addField($field);
                         $this->updateField($field, $value, $locale);
                         $tm->applyTranslations($field, $collectionName, $orderId);
                     }
                 }
+                ksort($newFields);
                 $collection->setValue($newFields);
             }
         }


### PR DESCRIPTION
After finishing computation, restore fields order.

Observed during record preview.