### PR TITLE
Improve image and files modals

### DIFF
--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -66,6 +66,7 @@
                                 data-bs-toggle="modal"
                                 data-bs-target="#resourcesModal"
                                 :data-modal-title="labels.modal_title_files"
+                                data-modal-dialog-class="modal-xl"
                                 @click="selectServerFile($event)"
                             >
                                 <i class="fas fa-fw fa-th"></i>
@@ -240,7 +241,7 @@ export default {
                 rar: 'fa-file-archive',
                 gz: 'fa-file-archive',
             };
-            let modalContent = '<div class="row row-cols-1 row-cols-md-3 g-2">';
+            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-2">';
             inputOptions.forEach((element, key) => {
                 let filenameExtension = element.text
                     .split('.')
@@ -281,6 +282,8 @@ export default {
                     var modalTitle = resourcesModal.querySelector('.modal-title');
                     var modalBody = resourcesModal.querySelector('.modal-body');
                     var modalBodyContent = this.generateModalContent(inputOptions);
+                    
+                    modalDialog.classList.add(button.getAttribute('data-modal-dialog-class'));
                     modalTitle.innerHTML = title;
                     modalBody.innerHTML = modalBodyContent;
 

--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -241,7 +241,7 @@ export default {
                 rar: 'fa-file-archive',
                 gz: 'fa-file-archive',
             };
-            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-2">';
+            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-2">';
             inputOptions.forEach((element, key) => {
                 let filenameExtension = element.text
                     .split('.')
@@ -253,11 +253,11 @@ export default {
                             <i class="fas fa-solid ${fileIcons[filenameExtension] ??
                                 'fa-file'} fa-5x me-0 align-self-center"></i>
                             <div class="card-body px-2">
-                                <div class="form-check">
+                                <div class="form-check ps-0">
                                     <input class="form-check-input" type="checkbox" value="${
                                         element.value
                                     }" id="flexCheckDefault-${key}">
-                                    <label class="form-check-label d-inline fs-6 fw-normal" for="flexCheckDefault-${key}">
+                                    <label class="form-check-label d-inline fs-6 fw-normal d-block" for="flexCheckDefault-${key}">
                                         ${element.text}
                                     </label>
                                 </div>
@@ -279,10 +279,11 @@ export default {
                     var saveButton = document.getElementById('modalButtonAccept');
                     var button = event.target;
                     var title = button.getAttribute('data-modal-title');
+                    var modalDialog = resourcesModal.querySelector('.modal-dialog');
                     var modalTitle = resourcesModal.querySelector('.modal-title');
                     var modalBody = resourcesModal.querySelector('.modal-body');
                     var modalBodyContent = this.generateModalContent(inputOptions);
-                    
+
                     modalDialog.classList.add(button.getAttribute('data-modal-dialog-class'));
                     modalTitle.innerHTML = title;
                     modalBody.innerHTML = modalBodyContent;

--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -256,7 +256,7 @@ export default {
                                     <input class="form-check-input" type="checkbox" value="${
                                         element.value
                                     }" id="flexCheckDefault-${key}">
-                                    <label class="form-check-label d-inline fs-6" for="flexCheckDefault-${key}">
+                                    <label class="form-check-label d-inline fs-6 fw-normal" for="flexCheckDefault-${key}">
                                         ${element.text}
                                     </label>
                                 </div>

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -78,6 +78,7 @@
                                 data-bs-target="#resourcesModal"
                                 :data-modal-title="labels.modal_title_images"
                                 :data-initiator="id"
+                                data-modal-dialog-class="modal-xl"
                                 @click="selectServerFile($event)"
                             >
                                 <i class="fas fa-fw fa-th"></i>
@@ -279,12 +280,12 @@ export default {
             this.$refs.selectFile.click();
         },
         generateModalContent(inputOptions) {
-            let modalContent = '<div class="row row-cols-1 row-cols-md-3 g-2">';
+            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-2">';
             inputOptions.forEach((element, key) => {
                 modalContent += `
                     <div class="col">
                         <div class="card h-100">
-                            <img src="/thumbs/140×73×crop/${element.value}" loading="lazy">
+                            <img src="/thumbs/523×294×crop/${element.value}" loading="lazy">
                             <div class="card-body px-2">
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" value="${element.value}" id="flexCheckDefault-${key}">
@@ -320,9 +321,12 @@ export default {
                     var saveButton = document.getElementById('modalButtonAccept');
                     var button = event.target;
                     var title = button.getAttribute('data-modal-title');
+                    var modalDialog = resourcesModal.querySelector('.modal-dialog');
                     var modalTitle = resourcesModal.querySelector('.modal-title');
                     var modalBody = resourcesModal.querySelector('.modal-body');
                     var modalBodyContent = this.generateModalContent(inputOptions);
+
+                    modalDialog.classList.add(button.getAttribute('data-modal-dialog-class'));
                     modalTitle.innerHTML = title;
                     modalBody.innerHTML = modalBodyContent;
 

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -280,16 +280,16 @@ export default {
             this.$refs.selectFile.click();
         },
         generateModalContent(inputOptions) {
-            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-2">';
+            let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-2">';
             inputOptions.forEach((element, key) => {
                 modalContent += `
                     <div class="col">
                         <div class="card h-100">
                             <img src="/thumbs/523×294×crop/${element.value}" loading="lazy">
                             <div class="card-body px-2">
-                                <div class="form-check">
+                                <div class="form-check ps-0">
                                     <input class="form-check-input" type="checkbox" value="${element.value}" id="flexCheckDefault-${key}">
-                                    <label class="form-check-label d-inline fs-6 fw-normal" for="flexCheckDefault-${key}">
+                                    <label class="form-check-label d-inline fs-6 fw-normal d-block" for="flexCheckDefault-${key}">
                                         ${element.text}
                                     </label>
                                 </div>

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -288,7 +288,7 @@ export default {
                             <div class="card-body px-2">
                                 <div class="form-check">
                                     <input class="form-check-input" type="checkbox" value="${element.value}" id="flexCheckDefault-${key}">
-                                    <label class="form-check-label d-inline fs-6" for="flexCheckDefault-${key}">
+                                    <label class="form-check-label d-inline fs-6 fw-normal" for="flexCheckDefault-${key}">
                                         ${element.text}
                                     </label>
                                 </div>

--- a/assets/scss/modules/base/_modals.scss
+++ b/assets/scss/modules/base/_modals.scss
@@ -1,0 +1,30 @@
+.modal {
+  .form-check-input {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    margin-top: 0;
+    left: 1.5em;
+    border-color: transparent;
+    border-radius: 0;
+    &:hover {
+      cursor: pointer;
+    }
+    &:checked {
+      border: 2px solid rgba(24, 99, 175, 0.3);
+      background-color: rgba(24, 99, 175, 0.3);
+      background-position-y: -22px;
+      background-repeat: no-repeat;
+      background-position-x: center;
+    }
+  }
+
+  .form-check-label {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/assets/scss/modules/base/base.scss
+++ b/assets/scss/modules/base/base.scss
@@ -5,3 +5,4 @@
 @import '_buttons';
 @import '_badges';
 @import '_tables';
+@import "_modals";


### PR DESCRIPTION
This PR adds some modifications to the cards show on file/image modals:

- Make modal larger to fit more images. On small screen 2 cards per row are displayed. On big screens 4 cards per row are displayed.
- If resource name is too large adds ellipsis at the end of the name.
- Make resource name use normal font weight instead of bold
- Resource is selected on click

![image](https://user-images.githubusercontent.com/6607455/169855997-bea3deeb-3977-44e4-bc23-e5121211f385.png)
