### PR TITLE
Improved the twig filter "current"

### DIFF
--- a/src/Twig/FrontendMenuExtension.php
+++ b/src/Twig/FrontendMenuExtension.php
@@ -60,6 +60,6 @@ class FrontendMenuExtension extends AbstractExtension
     {
         $uri = $item['uri'] ?? '';
 
-        return $uri === $this->requestStack->getCurrentRequest()->getRequestUri();
+        return $uri === $this->requestStack->getCurrentRequest()->getPathInfo();
     }
 }


### PR DESCRIPTION
which did return false on matching routes with parameters:

![image](https://user-images.githubusercontent.com/14187981/172844120-75f3f585-6201-400d-b013-677c7164693c.png)

This returned `false`, because we compare the full strings:

```
public function isCurrent($item): bool
{
    $uri = $item['uri'] ?? '';

    return $uri === $this->requestStack->getCurrentRequest()->getPathInfo();
}
```