### PR TITLE
Fix `number` field

### DIFF
--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -54,6 +54,8 @@ class FieldType extends Collection
             'maxlength' => '',
             'autocomplete' => true,
             'values' => [],
+            'min' => 1,
+            'max' => 1000,
         ]);
     }
 

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -2,15 +2,17 @@
 
 {% block field %}
 
-  {# ---
-  Removed `mode`
-  Note: The difference between `float` and `integer` is useless,
-        because with `any` it still steps with `1`,  whereas you'd
-        rather want to step with `0.01` for floats.
-  --- #}
+  {% if not mode|default %}
+    {% set mode = field.definition.mode|default('float') %}
+  {% endif %}
+
   {% set min = field.definition.min %}
   {% set max = field.definition.max %}
   {% set step = field.definition['step']|default(1) %}
+
+  {% if mode == 'float' %}
+    {% set step = field.definition['step']|default("'any'") %}
+  {% endif %}
 
   <editor-number
     :id='{{ id|json_encode }}'

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -2,18 +2,10 @@
 
 {% block field %}
 
-  {# set mode #}
-  {% if not mode|default %}
-    {% set mode = field.definition.mode|default('float') %}
-  {% endif %}
+  {% set mode = field.definition.mode|default('float') %}
+  {% set min = field.definition.min %}
+  {% set max = field.definition.max %}
 
-  {# set min & max #}
-  {% if not min|default or max|default %}
-    {% set min = 0 %}
-    {% set max = 1000 %}
-  {% endif %}
-
-  {# set step #}
   {% if not step|default and field.definition['step'] is defined %}
     {% set step = field.definition.step %}
   {% elseif not step|default %}

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -2,23 +2,15 @@
 
 {% block field %}
 
-  {% set mode = field.definition.mode|default('float') %}
+  {# ---
+  Removed `mode`
+  Note: The difference between `float` and `integer` is useless,
+        because with `any` it still steps with `1`,  whereas you'd
+        rather want to step with `0.01` for floats.
+  --- #}
   {% set min = field.definition.min %}
   {% set max = field.definition.max %}
-
-  {% if not step|default and field.definition['step'] is defined %}
-    {% set step = field.definition.step %}
-  {% elseif not step|default %}
-    {# default step values #}
-    {% if mode == 'float' %}
-      {% set step = "'any'" %}
-    {% elseif mode == 'integer' %}
-      {% set step = 1 %}
-    {% else %}
-      {# field mode unknown #}
-      {% set step = 1 %}
-    {% endif %}
-  {% endif %}
+  {% set step = field.definition['step']|default(1) %}
 
   <editor-number
     :id='{{ id|json_encode }}'

--- a/templates/_partials/fields/number.html.twig
+++ b/templates/_partials/fields/number.html.twig
@@ -2,14 +2,12 @@
 
 {% block field %}
 
-  {% if not mode|default %}
-    {% set mode = field.definition.mode|default('float') %}
-  {% endif %}
-
   {% set min = field.definition.min %}
   {% set max = field.definition.max %}
+  {% set mode = field.definition.mode|default('float') %}
   {% set step = field.definition['step']|default(1) %}
 
+  {# --- if the mode is `float` and `step` is not set, use the magical 'any' --- #}
   {% if mode == 'float' %}
     {% set step = field.definition['step']|default("'any'") %}
   {% endif %}


### PR DESCRIPTION
Fixes #3217. In the original code, if `min` OR `max` were not set, it would always get the default values `1` and `1000`.

I don't know if there's any side-effects with these changes, but seems to be working for me.