### PR TITLE
Fix avatar image sizes when image is not found

### DIFF
--- a/assets/scss/modules/admin/_toolbar.scss
+++ b/assets/scss/modules/admin/_toolbar.scss
@@ -161,6 +161,7 @@
 
     &__profile {
       padding-right: 1rem;
+
       img {
         max-width: 25px;
         height: 25px;

--- a/assets/scss/modules/admin/_toolbar.scss
+++ b/assets/scss/modules/admin/_toolbar.scss
@@ -161,6 +161,10 @@
 
     &__profile {
       padding-right: 1rem;
+      img {
+        max-width: 25px;
+        height: 25px;
+      }
     }
 
     &__filter {


### PR DESCRIPTION
This PR fixes #3234 .

**Before fix:**
![image](https://user-images.githubusercontent.com/6607455/173825100-14111372-67b8-4a8f-ad36-70822540c130.png)

**After fix:**
![image](https://user-images.githubusercontent.com/6607455/173825205-1eb8e57a-01be-4e9b-be18-3721a47197fa.png)
