### PR TITLE
Fix error thrown by extensions with no config options defined

### DIFF
--- a/src/Extension/ConfigTrait.php
+++ b/src/Extension/ConfigTrait.php
@@ -46,7 +46,7 @@ trait ConfigTrait
 
         foreach ($filenames as $filename) {
             if (is_readable($filename)) {
-                $config = array_merge($config, $yamlParser->parseFile($filename));
+                $config = array_merge($config, $yamlParser->parseFile($filename) ?? [] );
             }
         }
 


### PR DESCRIPTION
This PR fixes #3158. 

`array_merge($config, $yamlParser->parseFile($filename));` could return `null` when the config file of an extension was empty or config options are commented out. Now it will default to an empty array to avoid breaking the `/bolt/extensions` extensions listing page