### PR TITLE
Additional fix for `type: number` field, set default to `min: 0`.

### DIFF
--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -54,7 +54,7 @@ class FieldType extends Collection
             'maxlength' => '',
             'autocomplete' => true,
             'values' => [],
-            'min' => 1,
+            'min' => 0,
             'max' => 1000,
         ]);
     }


### PR DESCRIPTION
See also #3231