### PR TITLE
Add Fixtures for SEO field

### DIFF
--- a/src/DataFixtures/ContentFixtures.php
+++ b/src/DataFixtures/ContentFixtures.php
@@ -399,6 +399,13 @@ class ContentFixtures extends BaseFixture implements DependentFixtureInterface, 
 
 
                 break;
+            case 'seo':
+                $data = ['keywords' => '', 'shortlink' => '', 'canonical' => '', 'robots' => '', 'og' => ''];
+                $data['title'] = $this->faker->sentence(4, true);
+                $data['description'] = $this->faker->sentence(120, true);
+                $data = [json_encode($data)];
+
+                break;
             default:
                 $data = [$this->faker->sentence(6, true)];
         }


### PR DESCRIPTION
Fixes #2946 

When the SEO extension is installed the Fixtures generate a non valid value for the the SEO field. This PR makes sure that the value assigned to a SEO field is valid and prevents the backend from breaking when rendering a non valid value for the SEO field.