### PR TITLE
Feature/prev and next class

### DIFF
--- a/src/Twig/ContentExtension.php
+++ b/src/Twig/ContentExtension.php
@@ -487,7 +487,7 @@ class ContentExtension extends AbstractExtension
         return new Collection($taxonomies);
     }
 
-    public function pager(Environment $twig, ?Pagerfanta $records = null, string $template = '@bolt/helpers/_pager_basic.html.twig', string $class = 'pagination', int $surround = 3)
+    public function pager(Environment $twig, ?Pagerfanta $records = null, string $template = '@bolt/helpers/_pager_basic.html.twig', string $class = 'pagination', string $previousLinkClass = 'previous', string $nextLinkClass = 'next', int $surround = 3)
     {
         $params = array_merge(
             $this->requestStack->getCurrentRequest()->get('_route_params'),
@@ -502,6 +502,8 @@ class ContentExtension extends AbstractExtension
             'records' => $records,
             'surround' => $surround,
             'class' => $class,
+            'previous_link_class' => $previousLinkClass,
+            'next_link_class' => $nextLinkClass,
             'route' => $this->requestStack->getCurrentRequest()->get('_route'),
             'routeParams' => $params,
         ];

--- a/templates/helpers/_pager_basic.html.twig
+++ b/templates/helpers/_pager_basic.html.twig
@@ -6,6 +6,8 @@ Predefined variables:
  - `routeParams`: Parameters to pass in to `{{ path() }}` to create the correct url
  - `surround`: The amount of items to show around the 'current' one. "3" by default.
  - `class`: The main CSS class to apply to the pager. "pagination" by default
+ - `previous_link_class`: The CSS class to apply to the previous link in the pagination. "previous" by default.
+ - `next_link_class`: The CSS class to apply to the next link in the pagination. "next" by default.
 
 #}
 
@@ -25,7 +27,7 @@ Predefined variables:
 
         {# Previous Button #}
         {% set p = routeParams|merge({page: records.hasPreviousPage ? records.previousPage : 1 }) %}
-        {% with {'path': path(route, p), 'label': 'pager.previous'|trans, 'enabled': records.hasPreviousPage } only %}
+        {% with {'path': path(route, p), 'label': 'pager.previous'|trans, 'enabled': records.hasPreviousPage, 'class': previous_link_class } only %}
             {{ block('item') }}
         {% endwith %}
 
@@ -61,7 +63,7 @@ Predefined variables:
         {% endif %}
 
         {% set p = routeParams|merge({page: records.hasNextPage ? records.nextPage : records.nbPages }) %}
-        {% with {'path': path(route, p), 'label': 'pager.next'|trans, 'enabled': records.hasNextPage } only %}
+        {% with {'path': path(route, p), 'label': 'pager.next'|trans, 'enabled': records.hasNextPage, 'class': next_link_class } only %}
             {{ block('item') }}
         {% endwith %}
     </ul>


### PR DESCRIPTION
Fixes #2822 

This PR adds previous and next classes to the links for the default pagination template.

A PR documentation has been created https://github.com/bolt/docs/pull/1255 on how to use this new feature.