### PR TITLE
Add non-supported SVG HTML element to HTML Sanitiser

### DIFF
--- a/src/Utils/Sanitiser.php
+++ b/src/Utils/Sanitiser.php
@@ -79,7 +79,7 @@ class Sanitiser
      */
     private function createNonSupportedElements(?\HTMLPurifier_Definition $definition, array $allowedTags)
     {
-        if(array_search('svg', $allowedTags)){
+        if (array_search('svg', $allowedTags)) {
             $definition->addElement('svg', 'Block', 'Flow', 'Common');
         }
     }

--- a/src/Utils/Sanitiser.php
+++ b/src/Utils/Sanitiser.php
@@ -77,7 +77,7 @@ class Sanitiser
     /**
      * Handles the creation of non-supported HTML elements by HTMLPurifier out of the box
      */
-    private function createNonSupportedElements(?\HTMLPurifier_Definition $definition, array $allowedTags)
+    private function createNonSupportedElements(\HTMLPurifier_HTMLDefinition $definition, array $allowedTags)
     {
         if (array_search('svg', $allowedTags)) {
             $definition->addElement('svg', 'Block', 'Flow', 'Common');

--- a/src/Utils/Sanitiser.php
+++ b/src/Utils/Sanitiser.php
@@ -60,6 +60,10 @@ class Sanitiser
         // Allow src tag in iframe for embed fields
         $definition->addAttribute('iframe', 'src', 'Text');
 
+        // Create non supported elements
+        $this->createNonSupportedElements($definition, explode(',',$allowedTags));
+
+
         $this->purifier = new \HTMLPurifier($purifierConfig);
 
         return $this->purifier;
@@ -68,5 +72,15 @@ class Sanitiser
     public function clean(string $html): string
     {
         return $this->getPurifier()->purify($html);
+    }
+
+    /**
+     * Handles the creation of non-supported HTML elements by HTMLPurifier out of the box
+     */
+    private function createNonSupportedElements(?\HTMLPurifier_Definition $definition, array $allowedTags)
+    {
+        if(array_search('svg', $allowedTags)){
+            $definition->addElement('svg', 'Block', 'Flow', 'Common');
+        }
     }
 }


### PR DESCRIPTION
Fixes #2898 

Since HTMLPurifier does not support SVG Elements out of the box, this PR adds the SVG Element to the definition, preventing the backend from breaking