### PR TITLE
Improve responsiveness

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -24,13 +24,13 @@ $(document).ready(function() {
             $('.admin__sidebar')
                 .addClass('admin__sidebar--is-expanded')
                 .removeClass('admin__sidebar--is-collapsed')
-                .removeClass('d-xs-none');
+                .removeClass('d-none');
             $(this).toggleClass('is-active');
         } else {
             $('.admin__sidebar')
                 .addClass('admin__sidebar--is-collapsed')
                 .removeClass('admin__sidebar--is-expanded')
-                .removeClass('d-xs-none');
+                .removeClass('d-none');
             $(this).toggleClass('is-active');
         }
     });

--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -23,12 +23,14 @@ $(document).ready(function() {
         if ($('.admin__sidebar').hasClass('admin__sidebar--is-collapsed')) {
             $('.admin__sidebar')
                 .addClass('admin__sidebar--is-expanded')
-                .removeClass('admin__sidebar--is-collapsed');
+                .removeClass('admin__sidebar--is-collapsed')
+                .removeClass('d-xs-none');
             $(this).toggleClass('is-active');
         } else {
             $('.admin__sidebar')
                 .addClass('admin__sidebar--is-collapsed')
-                .removeClass('admin__sidebar--is-expanded');
+                .removeClass('admin__sidebar--is-expanded')
+                .removeClass('d-xs-none');
             $(this).toggleClass('is-active');
         }
     });

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -92,7 +92,7 @@
         'action.new': 'action.new'|trans,
         'action.view': 'action.view'|trans,
     }|json_encode %}
-    <div class="admin__sidebar d-xs-none d-lg-block">
+    <div class="admin__sidebar d-none d-lg-block">
         <div class="sidebar sidebar--sticky" id="bolt--sidebar">
             <admin-sidebar
               :menu="{{ admin_menu_json }}"

--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -92,7 +92,7 @@
         'action.new': 'action.new'|trans,
         'action.view': 'action.view'|trans,
     }|json_encode %}
-    <div class="admin__sidebar">
+    <div class="admin__sidebar d-xs-none d-lg-block">
         <div class="sidebar sidebar--sticky" id="bolt--sidebar">
             <admin-sidebar
               :menu="{{ admin_menu_json }}"

--- a/templates/_partials/fields/_collection_buttons.html.twig
+++ b/templates/_partials/fields/_collection_buttons.html.twig
@@ -2,11 +2,11 @@
     <div class="btn-group ms-auto me-2" role="group" aria-label="Collection buttons">
     <button class='action-move-up-collection-item btn btn-light btn-sm' style="white-space: nowrap" {% if is_first is defined and is_first %} disabled {% endif %}>
         <i class="fas fa-fw fa-chevron-up"></i>
-        {{ 'collection.move_item_up'|trans }}
+        <span class="d-none d-sm-inline-block">{{ 'collection.move_item_up'|trans }}</span>
     </button>
     <button class='action-move-down-collection-item btn btn-light btn-sm' style="white-space: nowrap" {% if is_last is defined and is_last %} disabled {% endif %}>
         <i class="fas fa-fw fa-chevron-down"></i>
-        {{ 'collection.move_item_down'|trans }}
+        <span class="d-none d-sm-inline-block">{{ 'collection.move_item_down'|trans }}</span>
     </button>
     <button class='action-remove-collection-item btn btn-light-danger btn-sm'
             style="white-space: nowrap"
@@ -16,8 +16,8 @@
             data-modal-button-accept="Delete"
             data-bs-toggle="modal"
             data-bs-target="#resourcesModal">
-        <i class="fas fa-fw fa-trash"></i>
-        {{ 'collection.remove_item'|trans }}
+        <i class="fas fa-fw fa-trash me-xs-0 me-md-1"></i>
+        <span class="d-none d-sm-inline-block">{{ 'collection.remove_item'|trans }}</span>
     </button>
     </div>
 {% endif %}


### PR DESCRIPTION
Fixes #1340.

This PR hides the text of collection's action buttons on small screens giving more room for the title of the collection. 

![image](https://user-images.githubusercontent.com/6607455/176450289-4db82b2c-3f79-4b7f-84aa-e107ad9cf61f.png)

It also fixes an issue with the aside menu on page load.