### PR TITLE
Enable the hash functionality for tabs instead of pills

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
 
     /*
      ** Hash on tabs functionality
-     ** When there is a Bootstrap data-toggle="pill" element, append the hash to the link
+     ** When there is a Bootstrap data-toggle="tab" element, append the hash to the link
      */
     let url = location.href.replace(/\/$/, '');
     if (location.hash) {
@@ -49,7 +49,7 @@ $(document).ready(function() {
         }, 50);
     }
 
-    $('a[data-bs-toggle="pill"]').on('click', function() {
+    $('a[data-bs-toggle="tab"]').on('click', function() {
         let newUrl;
         const hash = $(this).attr('href');
         newUrl = url.split('#')[0] + hash;


### PR DESCRIPTION
Fixes #3261

I have replace the target `data-bs-toggle="pill"` by `data-bs-toggle="tab"` to fix that issue. It seems in our source code we are not using any HTML element with an attribute like `data-bs-toggle="pill"`. 

It should be safe to replace

