### PR TITLE
Replace manual copy to clipboard with tiny library

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon';
 import { Popover } from 'bootstrap';
 import { Tab } from 'bootstrap';
 import { resetModalContent } from './modal';
+import ClipboardJS from "clipboard";
 
 import { version } from '../version';
 window.assetsVersion = version;
@@ -149,22 +150,7 @@ $(document).ready(function() {
     /*
      ** Copy text to clipboard. Used in filemanager actions.
      */
-    $('[data-copy-to-clipboard]').on('click', function(e) {
-        const target = $(e.target);
-
-        let input = document.createElement('input');
-        input.setAttribute('id', 'copy');
-
-        target.parent().append(input);
-        input.value = target.attr('data-copy-to-clipboard');
-        input.focus();
-        input.select();
-        document.execCommand('copy');
-        target
-            .parent()
-            .find('#copy')
-            .remove();
-    });
+    new ClipboardJS('*[data-clipboard-text]');
     /* End of copy text to clipboard */
 
     /*

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "bootstrap": "^5.1.3",
         "browserslist": "^4.16.7",
         "caniuse-lite": "^1.0.30001249",
+        "clipboard": "^2.0.11",
         "codemirror": "^5.62.2",
         "dropzone": "^5.9.2",
         "flagpack": "^1.0.5",

--- a/templates/finder/_files_actions.html.twig
+++ b/templates/finder/_files_actions.html.twig
@@ -25,7 +25,7 @@
             {{ 'files_cards.action_view_original'|trans }}
         </a>
 
-        <span class="dropdown-item" style="cursor: pointer;" data-copy-to-clipboard="{{ url('homepage') ~ original|replace({'/files': 'files'}) }}">
+        <span class="dropdown-item" style="cursor: pointer;" data-clipboard-text="{{ url('homepage') ~ original|replace({'/files': 'files'}) }}">
             <i class="fas fa-clipboard-check"></i> {{ 'files_cards.copy_to_clipboard'|trans }}
         </span>
 


### PR DESCRIPTION
👋 Refactors the Copy filename feature for files, removing ugly hidden input field generation with a tiny library. 

I couldn't update `package-lock.json` without _too_ many unrelated changes because of this error 😔

`This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!`