### PR TITLE
Fix loading of modal text when removing collection item

### DIFF
--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -175,7 +175,7 @@ $(document).ready(function() {
 
     // Reset the content of a modal to it's default
 
-    $('[data-bs-toggle="modal"]').on('click', function(event) {
+    window.$(document).on('click', '[data-bs-toggle="modal"]', function(event) {
         let resourcesModal = document.getElementById('resourcesModal');
 
         let saveButton = document.getElementById('modalButtonAccept');

--- a/assets/js/app/common.js
+++ b/assets/js/app/common.js
@@ -180,13 +180,12 @@ $(document).ready(function() {
 
         let saveButton = document.getElementById('modalButtonAccept');
 
-        let title = event.target.getAttribute('data-modal-title');
+        let title = event.currentTarget.getAttribute('data-modal-title');
         let modalTitle = resourcesModal.querySelector('.modal-title');
 
         let modalBody = resourcesModal.querySelector('.modal-body');
-        let body = event.target.getAttribute('data-modal-body');
-
-        let targetURL = event.target.getAttribute('href');
+        let body = event.currentTarget.getAttribute('data-modal-body');
+        let targetURL = event.currentTarget.getAttribute('href');
 
         modalTitle.innerHTML = title;
         modalBody.innerHTML = body;


### PR DESCRIPTION
Fixes #3266 

Using `event.currentTarget` instead of `event.target` we can target the button element to get the `data-attribute` values needed to populate the content of the modal even if the user click on the icon or text of the button.

Using event delegation like `window.$(document).on('click', '[data-bs-toggle="modal"]', function(event)` is what we need to make sure new added collection item remove buttons trigger the load of the modal text.