### PR TITLE
Made the checkbox template recognise a false string as a value

### DIFF
--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -151,10 +151,12 @@
 
 {% if variant == 'inline' %}</div></div>{% endif %}
 
-{# Print postfix #}
-{% if field.definition['postfix']|default() is not empty %}
-    {{ macro.generatePostfix(field.definition['postfix']|default(), id) }}
-{% endif %}
+{% block postfix %}
+    {# Print postfix #}
+    {% if field.definition['postfix']|default() is not empty %}
+        {{ macro.generatePostfix(field.definition['postfix']|default(), id) }}
+    {% endif %}
+{% endblock %}
 
 {{ separator|raw }}
 </div>

--- a/templates/_partials/fields/checkbox.html.twig
+++ b/templates/_partials/fields/checkbox.html.twig
@@ -1,5 +1,11 @@
 {% extends '@bolt/_partials/fields/_base.html.twig' %}
 
+{% block postfix %}
+    {% if not hidePostfix|default(false) %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% block field %}
     {# set mode #}
     {% if not mode|default %}

--- a/templates/_partials/fields/checkbox.html.twig
+++ b/templates/_partials/fields/checkbox.html.twig
@@ -6,7 +6,7 @@
         {% set mode = field.definition.mode|default('checkbox') %}
     {% endif %}
 
-    {% set value = value ? true : false %}
+    {% set value = value and value !== 'false' ? true : false %}
 
     <editor-checkbox
         :id="{{ name|json_encode }}"

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -7,6 +7,12 @@
      - multiple: A boolean to set whether or not we allow multiple selections
  #}
 
+{% block label %}
+    {% if not hideLabel|default(false) %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% if options is not defined %}
     {% set options = select_options(field) %}
 {% endif %}


### PR DESCRIPTION
to be able to include it without the value being overwritten by the base template.


Better explanation:

I'm creating my own field template, which includes checkboxes.

I include the checkbox like this:
```
{% include '@bolt/_partials/fields/checkbox.html.twig' with {
    name:  'autoplay-' ~ id,
    label: 'autoplay'|trans,
    value: autoplay,
} %}
```

The value I pass is either `true` or `false`, obviously.
If I pass `false` the value is somehow overwritten, I'm guessing because they both extend the same base template and both use variables named `value`. 

This now opens the option to pass `false` as a string, which stops twig from using the base template `value`.


Edit on the second commit:

I've also added the option to not print the postfix.
If I include the checkbox template I need this option to prevent multiple identical postfixes.