### PR TITLE
Add extra fields option for `image` and `imagelist` fields

### DIFF
--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -34,16 +34,36 @@
                     />
                 </div>
                 <div v-if="includeAlt" class="input-group mb-3">
-                    <input
-                        v-model="altData"
-                        :title="name + ' alt'"
-                        class="form-control"
-                        :name="name + '[alt]'"
-                        type="text"
-                        :readonly="readonly"
-                        :pattern="pattern"
-                        :placeholder="getPlaceholder"
-                    />
+                    <div class="col-sm-2">
+                        <label>Alt:</label>
+                    </div>
+                    <div class="col-sm-10">
+                        <input
+                            v-model="altData"
+                            :title="name + ' alt'"
+                            class="form-control"
+                            :name="name + '[alt]'"
+                            type="text"
+                            :readonly="readonly"
+                            :pattern="pattern"
+                            :placeholder="getPlaceholder"
+                        />
+                    </div>
+                </div>
+                <div v-for="(extraFieldProps, extraField) in extraFields" :key="extraField" class="input-group mb-3">
+                    <div class="col-sm-2">
+                        <label>{{ extraFieldProps.label }}:</label>
+                    </div>
+                    <div class="col-sm-10">
+                        <input
+                            v-model="extraData[extraField]"
+                            :title="name + ' ' + extraField"
+                            class="form-control"
+                            :name="name + '[' + extraField + ']'"
+                            type="text"
+                            :placeholder="extraFieldProps.placeholder"
+                        />
+                    </div>
                 </div>
                 <div class="btn-toolbar" role="toolbar">
                     <div class="btn-group me-2" role="group">
@@ -205,6 +225,8 @@ export default {
         errormessage: String | Boolean, //string if errormessage is set, and false otherwise
         pattern: String | Boolean,
         placeholder: String | Boolean,
+        extraFields: Array,
+        extraData: Array,
     },
     data() {
         return {

--- a/assets/js/app/editor/Components/Imagelist.vue
+++ b/assets/js/app/editor/Components/Imagelist.vue
@@ -20,6 +20,8 @@
                 :is-first-in-imagelist="isFirstInImagelist(index)"
                 :is-last-in-imagelist="isLastInImagelist(index)"
                 :readonly="readonly"
+                :extra-fields="extraFields"
+                :extra-data="child"
                 @remove="onRemoveImage"
                 @moveImageUp="onMoveImageUp"
                 @moveImageDown="onMoveImageDown"
@@ -53,6 +55,7 @@ export default {
         attributesLink: String,
         limit: Number,
         readonly: Boolean,
+        extraFields: Array,
     },
     data: function() {
         let counter = 0;

--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -21,6 +21,12 @@ homepage:
                 in the webbrowser, edit <code>sitename:</code> in the configuration file.
         image:
             type: image
+            extra:
+                title:
+                    label: The Title
+                    placeholder: This is the placeholder for the title
+                caption:
+                    label: Caption
         teaser:
             type: html
             localize: true

--- a/src/Configuration/Content/FieldType.php
+++ b/src/Configuration/Content/FieldType.php
@@ -56,6 +56,7 @@ class FieldType extends Collection
             'values' => [],
             'min' => 0,
             'max' => 100000,
+            'extra' => [],
         ]);
     }
 

--- a/src/Entity/Field/ImageField.php
+++ b/src/Entity/Field/ImageField.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Entity\Field;
 
+use Bolt\Configuration\Content\FieldType;
 use Bolt\Entity\Field;
 use Bolt\Entity\FieldInterface;
 use Bolt\Entity\Media;
@@ -32,6 +33,7 @@ class ImageField extends Field implements FieldInterface, MediaAwareInterface, C
             'thumbnail' => '',
             'fieldname' => '',
             'alt' => '',
+            'extra' => [],
             'url' => '',
             'extension' => '',
         ];
@@ -40,6 +42,23 @@ class ImageField extends Field implements FieldInterface, MediaAwareInterface, C
     public function __toString(): string
     {
         return (string) $this->getPath();
+    }
+
+    public function getDefinition(): FieldType
+    {
+        $fieldTypeDefinition = parent::getDefinition();
+
+        // Set a default label based on original key but capitalized.
+        if ($fieldTypeDefinition->has('extra')) {
+            $extra = $fieldTypeDefinition->get('extra');
+            foreach ($extra as $extraField => $extraFieldProperty) {
+                if (! $extraFieldProperty->has('label')) {
+                    $extraFieldProperty['label'] = \ucwords($extraField);
+                }
+            }
+        }
+
+        return $fieldTypeDefinition;
     }
 
     public function getValue(): array

--- a/templates/_partials/fields/image.html.twig
+++ b/templates/_partials/fields/image.html.twig
@@ -29,6 +29,11 @@
         'modal_button_deny': 'modal.button_deny'|trans
     }|json_encode %}
 
+    {% set extraData = {} %}
+    {% for extraKey, extraFieldProps in field.definition.get('extra') %}
+        {% set extraData = extraData|merge({ (extraKey): attribute(field, extraKey) }) %}
+    {% endfor %}
+
     <editor-image
         :id='{{ id|json_encode }}'
         :name='{{ name|json_encode }}'
@@ -48,5 +53,7 @@
         :placeholder='{{ placeholder|json_encode }}'
         :alt='{{ field.get('alt')|json_encode }}'
         :include-alt='{{ field.includeAlt|json_encode }}'
+        :extra-fields='{{ field.definition.get('extra')|json_encode }}'
+        :extra-data='{{ extraData|json_encode }}'
     ></editor-image>
 {% endblock %}

--- a/templates/_partials/fields/imagelist.html.twig
+++ b/templates/_partials/fields/imagelist.html.twig
@@ -43,6 +43,7 @@
         :attributes-link='{{ path('bolt_media_new')|json_encode }}'
         :limit='{{ limit|json_encode }}'
         :readonly='{{ readonly|json_encode }}'
+        :extra-fields='{{ field.definition.get('extra')|json_encode }}'
     ></editor-imagelist>
 
 {% endblock %}

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -17,7 +17,7 @@ class ContentTypesParserTest extends ParserTestBase
 
     public const AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE = 27;
 
-    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 31;
+    public const AMOUNT_OF_ATTRIBUTES_IN_FIELD = 32;
 
     public const ALLOWED_LOCALES = 'en|nl|es|fr|de|pl|it|hu|pt_BR|ja|nb|nn|nl_NL|nl_BE';
 


### PR DESCRIPTION
For both `image`s and `imagelist`s, you can now add an extra property `extra`:
```
extra:
    title:
        label: Titel
        placeholder: Placeholder
    caption:
        label: Caption
    teaser:
        label: Teaser
        placeholder: De teaser in het Nederlands
    teaser_en:
        label: Teaser (EN)
        placeholder: De teaser in het Engels
```

For now I have enabled `label` and `placeholder`, but since it's an key,value-array we can expand it if needed. (I initially had it as: `attrib: [ foo, bar, baz ]` to mimick Bolt 3).

---
This seems to work for me. Somehow the solution looks way simpler than I thought. So please double-check if I haven't missed anything.