### PR TITLE
No versioning in webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bolt",
-    "version": "5.1.99.1",
+    "version": "5.1.99.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "bolt",
-            "version": "5.1.99.1",
+            "version": "5.1.99.2",
             "license": "MIT",
             "dependencies": {
                 "@popperjs/core": "^2.11.5",
@@ -1905,6 +1905,25 @@
                 "postcss": "^8.2"
             }
         },
+        "node_modules/@csstools/postcss-nested-calc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-1.0.0.tgz",
+            "integrity": "sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==",
+            "dev": true,
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2"
+            }
+        },
         "node_modules/@csstools/postcss-normalize-display-values": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.1.tgz",
@@ -1963,6 +1982,25 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-1.0.1.tgz",
             "integrity": "sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==",
+            "dev": true,
+            "dependencies": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^12 || ^14 || >=16"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/csstools"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2"
+            }
+        },
+        "node_modules/@csstools/postcss-text-decoration-shorthand": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-1.0.0.tgz",
+            "integrity": "sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -2967,9 +3005,9 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3064,9 +3102,9 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -3727,9 +3765,9 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -3832,9 +3870,9 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.182",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+            "version": "4.14.184",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+            "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
         },
         "node_modules/@types/mdast": {
             "version": "3.0.10",
@@ -3860,9 +3898,9 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
         },
         "node_modules/@types/node": {
-            "version": "18.6.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-            "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
+            "version": "18.7.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+            "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ=="
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -3984,9 +4022,9 @@
             "dev": true
         },
         "node_modules/@types/uglify-js": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.16.0.tgz",
-            "integrity": "sha512-0yeUr92L3r0GLRnBOvtYK1v2SjqMIqQDHMl7GLb+l2L8+6LSFWEEWEIgVsPdMn5ImLM8qzWT8xFPtQYpp8co0g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.0.tgz",
+            "integrity": "sha512-3HO6rm0y+/cqvOyA8xcYLweF0TKXlAxmQASjbOi49Co51A1N4nR4bEwBgRoD9kNM+rqFGArjKr654SLp2CoGmQ==",
             "dependencies": {
                 "source-map": "^0.6.1"
             }
@@ -5584,14 +5622,72 @@
                 "strip-ansi": "^6.0.0"
             }
         },
-        "node_modules/@vue/compiler-sfc": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.8.tgz",
-            "integrity": "sha512-2DK4YWKfgLnW9VDR9gnju1gcYRk3flKj8UNsms7fsRmFcg35slVTZEkqwBtX+wJBXaamFfn6NxSsZh3h12Ix/Q==",
+        "node_modules/@vue/compiler-core": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.37.tgz",
+            "integrity": "sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==",
+            "optional": true,
+            "peer": true,
             "dependencies": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "optional": true,
+            "peer": true
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
+            "integrity": "sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.2.37",
+                "@vue/shared": "3.2.37"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz",
+            "integrity": "sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.37",
+                "@vue/compiler-dom": "3.2.37",
+                "@vue/compiler-ssr": "3.2.37",
+                "@vue/reactivity-transform": "3.2.37",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7",
+                "postcss": "^8.1.10",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "optional": true,
+            "peer": true
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.37.tgz",
+            "integrity": "sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.2.37",
+                "@vue/shared": "3.2.37"
             }
         },
         "node_modules/@vue/component-compiler-utils": {
@@ -5658,6 +5754,34 @@
                 "html-webpack-plugin": ">=2.26.0",
                 "webpack": ">=4.0.0"
             }
+        },
+        "node_modules/@vue/reactivity-transform": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.37.tgz",
+            "integrity": "sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.37",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7"
+            }
+        },
+        "node_modules/@vue/reactivity-transform/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "optional": true,
+            "peer": true
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
+            "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==",
+            "optional": true,
+            "peer": true
         },
         "node_modules/@vue/test-utils": {
             "version": "1.3.0",
@@ -7766,9 +7890,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001375",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
-            "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
+            "version": "1.0.30001381",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+            "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8366,9 +8490,9 @@
             }
         },
         "node_modules/codemirror": {
-            "version": "5.65.7",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.7.tgz",
-            "integrity": "sha512-zb67cXzgugIQmb6tfD4G11ILjYoMfTjwcjn+cWsa4GewlI2adhR/h3kolkoCQTm1msD/1BuqVTKuO09ELsS++A=="
+            "version": "5.65.8",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.8.tgz",
+            "integrity": "sha512-TNGkSkkoAsmZSf6W6g35LMVQJBHKasc2CKwhr/fTxSYun7cn6J+CbtyNjV/MYlFVkNTsqZoviegyCZimWhoMMA=="
         },
         "node_modules/codemirror-spell-checker": {
             "version": "1.1.2",
@@ -9273,9 +9397,9 @@
             }
         },
         "node_modules/css-minimizer-webpack-plugin/node_modules/cssnano": {
-            "version": "5.1.12",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.12.tgz",
-            "integrity": "sha512-TgvArbEZu0lk/dvg2ja+B7kYoD7BBCmn3+k58xD0qjrGHsFzXY/wKTo9M5egcUCabPol05e/PVoIu79s2JN4WQ==",
+            "version": "5.1.13",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+            "integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
             "dev": true,
             "dependencies": {
                 "cssnano-preset-default": "^5.2.12",
@@ -9938,9 +10062,9 @@
             }
         },
         "node_modules/cssdb": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.6.3.tgz",
-            "integrity": "sha512-7GDvDSmE+20+WcSMhP17Q1EVWUrLlbxxpMDqG731n8P99JhnQZHR9YvtjPvEHfjFUjvQJvdpKCjlKOX+xe4UVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.0.tgz",
+            "integrity": "sha512-HmRYATZ4Gf8naf6sZmwKEyf7MXAC0ZxjsamtNNgmuWpQgoO973zsE/1JMIohEYsSi5e3n7vQauCLv7TWSrOlrw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -10231,9 +10355,9 @@
             }
         },
         "node_modules/cypress/node_modules/@types/node": {
-            "version": "14.18.23",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
-            "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
+            "version": "14.18.25",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.25.tgz",
+            "integrity": "sha512-9pLfceRSrKIsv/MISN6RoFWTIzka36Uk2Uuf5a8cHyDYhEgl5Hm5dXoe621KULeBjt+cFsY18mILsWWtJeG80w==",
             "dev": true
         },
         "node_modules/cypress/node_modules/ansi-styles": {
@@ -10511,9 +10635,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.4",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-            "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
+            "version": "1.11.5",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+            "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
             "dev": true
         },
         "node_modules/de-indent": {
@@ -11202,9 +11326,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.213",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
-            "integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
+            "version": "1.4.225",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+            "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw=="
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -13611,9 +13735,9 @@
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
         },
         "node_modules/hotkeys-js": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.4.tgz",
-            "integrity": "sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q=="
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.5.tgz",
+            "integrity": "sha512-T0G8CUZ6Q1IOgPnLK1hDXR8DqgKF/VWEsHvZgi6CM7Ub9oOAzvWuJ3Qhc/9nFQaR26MfFOZSwULHrtCnsUX7zA=="
         },
         "node_modules/hpack.js": {
             "version": "2.1.6",
@@ -17213,9 +17337,9 @@
             "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
         },
         "node_modules/js-beautify": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.5.tgz",
-            "integrity": "sha512-P2BfZBhXchh10uZ87qMKpM2tfcDXLA+jDiWU/OV864yWdTGzLUGNAdp9Y1ID5ubpNVGls3cZ1UMcO8myUB+UyA==",
+            "version": "1.14.6",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.6.tgz",
+            "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
             "dev": true,
             "dependencies": {
                 "config-chain": "^1.1.13",
@@ -17504,20 +17628,20 @@
             "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw=="
         },
         "node_modules/launch-editor": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.5.0.tgz",
-            "integrity": "sha512-coRiIMBJ3JF7yX8nZE4Fr+xxUy+3WTRsDSwIzHghU28gjXwkAWsvac3BpZrL/jHtbiqQ4TiRAyTJmsgErNk1jQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+            "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
             "dependencies": {
                 "picocolors": "^1.0.0",
                 "shell-quote": "^1.7.3"
             }
         },
         "node_modules/launch-editor-middleware": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.5.0.tgz",
-            "integrity": "sha512-kv9MMO81pbYjznk9j/DBu0uBGxIpT6uYhGajq6fxdGEPb+DCRBoS96jGkhe3MJumdY3zZFkuS8CFPTZI9DaBNw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.6.0.tgz",
+            "integrity": "sha512-K2yxgljj5TdCeRN1lBtO3/J26+AIDDDw+04y6VAiZbWcTdBwsYN6RrZBnW5DN/QiSIdKNjKdATLUUluWWFYTIA==",
             "dependencies": {
-                "launch-editor": "^2.5.0"
+                "launch-editor": "^2.6.0"
             }
         },
         "node_modules/launch-editor/node_modules/picocolors": {
@@ -18006,7 +18130,7 @@
             "version": "0.25.9",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
             "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "sourcemap-codec": "^1.4.8"
             }
@@ -18065,9 +18189,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-            "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
+            "version": "4.0.19",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+            "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -19110,9 +19234,9 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-            "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -20172,9 +20296,9 @@
             }
         },
         "node_modules/portfinder": {
-            "version": "1.0.29",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.29.tgz",
-            "integrity": "sha512-Z5+DarHWCKlufshB9Z1pN95oLtANoY5Wn9X3JGELGyQ6VhEcBfT2t+1fGUBq7MwUant6g/mqowH+4HifByPbiQ==",
+            "version": "1.0.32",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+            "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
             "dependencies": {
                 "async": "^2.6.4",
                 "debug": "^3.2.7",
@@ -21734,57 +21858,59 @@
             }
         },
         "node_modules/postcss-preset-env": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.7.2.tgz",
-            "integrity": "sha512-1q0ih7EDsZmCb/FMDRvosna7Gsbdx8CvYO5hYT120hcp2ZAuOHpSzibujZ4JpIUcAC02PG6b+eftxqjTFh5BNA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.0.tgz",
+            "integrity": "sha512-leqiqLOellpLKfbHkD06E04P6d9ZQ24mat6hu4NSqun7WG0UhspHR5Myiv/510qouCjoo4+YJtNOqg5xHaFnCA==",
             "dev": true,
             "dependencies": {
-                "@csstools/postcss-cascade-layers": "^1.0.4",
-                "@csstools/postcss-color-function": "^1.1.0",
-                "@csstools/postcss-font-format-keywords": "^1.0.0",
-                "@csstools/postcss-hwb-function": "^1.0.1",
-                "@csstools/postcss-ic-unit": "^1.0.0",
-                "@csstools/postcss-is-pseudo-class": "^2.0.6",
-                "@csstools/postcss-normalize-display-values": "^1.0.0",
-                "@csstools/postcss-oklab-function": "^1.1.0",
+                "@csstools/postcss-cascade-layers": "^1.0.5",
+                "@csstools/postcss-color-function": "^1.1.1",
+                "@csstools/postcss-font-format-keywords": "^1.0.1",
+                "@csstools/postcss-hwb-function": "^1.0.2",
+                "@csstools/postcss-ic-unit": "^1.0.1",
+                "@csstools/postcss-is-pseudo-class": "^2.0.7",
+                "@csstools/postcss-nested-calc": "^1.0.0",
+                "@csstools/postcss-normalize-display-values": "^1.0.1",
+                "@csstools/postcss-oklab-function": "^1.1.1",
                 "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-                "@csstools/postcss-stepped-value-functions": "^1.0.0",
-                "@csstools/postcss-trigonometric-functions": "^1.0.1",
-                "@csstools/postcss-unset-value": "^1.0.1",
-                "autoprefixer": "^10.4.7",
-                "browserslist": "^4.21.0",
+                "@csstools/postcss-stepped-value-functions": "^1.0.1",
+                "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
+                "@csstools/postcss-trigonometric-functions": "^1.0.2",
+                "@csstools/postcss-unset-value": "^1.0.2",
+                "autoprefixer": "^10.4.8",
+                "browserslist": "^4.21.3",
                 "css-blank-pseudo": "^3.0.3",
                 "css-has-pseudo": "^3.0.4",
                 "css-prefers-color-scheme": "^6.0.3",
-                "cssdb": "^6.6.3",
-                "postcss-attribute-case-insensitive": "^5.0.1",
+                "cssdb": "^7.0.0",
+                "postcss-attribute-case-insensitive": "^5.0.2",
                 "postcss-clamp": "^4.1.0",
-                "postcss-color-functional-notation": "^4.2.3",
+                "postcss-color-functional-notation": "^4.2.4",
                 "postcss-color-hex-alpha": "^8.0.4",
-                "postcss-color-rebeccapurple": "^7.1.0",
+                "postcss-color-rebeccapurple": "^7.1.1",
                 "postcss-custom-media": "^8.0.2",
                 "postcss-custom-properties": "^12.1.8",
                 "postcss-custom-selectors": "^6.0.3",
-                "postcss-dir-pseudo-class": "^6.0.4",
-                "postcss-double-position-gradients": "^3.1.1",
+                "postcss-dir-pseudo-class": "^6.0.5",
+                "postcss-double-position-gradients": "^3.1.2",
                 "postcss-env-function": "^4.0.6",
                 "postcss-focus-visible": "^6.0.4",
                 "postcss-focus-within": "^5.0.4",
                 "postcss-font-variant": "^5.0.0",
-                "postcss-gap-properties": "^3.0.3",
-                "postcss-image-set-function": "^4.0.6",
+                "postcss-gap-properties": "^3.0.5",
+                "postcss-image-set-function": "^4.0.7",
                 "postcss-initial": "^4.0.1",
-                "postcss-lab-function": "^4.2.0",
+                "postcss-lab-function": "^4.2.1",
                 "postcss-logical": "^5.0.4",
                 "postcss-media-minmax": "^5.0.0",
-                "postcss-nesting": "^10.1.9",
+                "postcss-nesting": "^10.1.10",
                 "postcss-opacity-percentage": "^1.1.2",
-                "postcss-overflow-shorthand": "^3.0.3",
+                "postcss-overflow-shorthand": "^3.0.4",
                 "postcss-page-break": "^3.0.4",
-                "postcss-place": "^7.0.4",
-                "postcss-pseudo-class-any-link": "^7.1.5",
+                "postcss-place": "^7.0.5",
+                "postcss-pseudo-class-any-link": "^7.1.6",
                 "postcss-replace-overflow-wrap": "^4.0.0",
-                "postcss-selector-not": "^6.0.0",
+                "postcss-selector-not": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
@@ -23518,9 +23644,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.77.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-            "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -23833,9 +23959,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.54.4",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-            "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+            "version": "1.54.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.5.tgz",
+            "integrity": "sha512-p7DTOzxkUPa/63FU0R3KApkRHwcVZYC0PLnLm5iyZACyp15qSi32x7zVUhRdABAATmkALqgGrjCJAcWvobmhHw==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -24629,7 +24755,7 @@
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/spdx-correct": {
             "version": "3.1.1",
@@ -25496,9 +25622,9 @@
             }
         },
         "node_modules/stylelint/node_modules/flatted": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-            "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ=="
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
         },
         "node_modules/stylelint/node_modules/get-stdin": {
             "version": "8.0.0",
@@ -26050,15 +26176,15 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-            "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
+            "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
             "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.7",
+                "@jridgewell/trace-mapping": "^0.3.14",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
-                "terser": "^5.7.2"
+                "terser": "^5.14.1"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -26414,9 +26540,9 @@
             }
         },
         "node_modules/trumbowyg": {
-            "version": "2.25.1",
-            "resolved": "https://registry.npmjs.org/trumbowyg/-/trumbowyg-2.25.1.tgz",
-            "integrity": "sha512-bmmV1qC+fTLfyVpLE5iZjCzHG5DfAwM7p8K2fdq6L1kOi+IrVJk/qGFVEEmYyJ0Ofd1z3g2vavfABpmkVLzV6A==",
+            "version": "2.25.2",
+            "resolved": "https://registry.npmjs.org/trumbowyg/-/trumbowyg-2.25.2.tgz",
+            "integrity": "sha512-wpWZzvmYgDHBiDBEWZ+YrYfeWmWdwAwudb1mNquRX7VpVqbzetNfrM307E1qgq36v+Gviu4r1V9ITFD8zZvmhg==",
             "peerDependencies": {
                 "jquery": ">=1.8"
             }
@@ -27122,11 +27248,11 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
         },
         "node_modules/vue": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.8.tgz",
-            "integrity": "sha512-ncwlZx5qOcn754bCu5/tS/IWPhXHopfit79cx+uIlLMyt3vCMGcXai5yCG5y+I6cDmEj4ukRYyZail9FTQh7lQ==",
+            "version": "2.7.9",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.9.tgz",
+            "integrity": "sha512-GeWCvAUkjzD5q4A3vgi8ka5r9bM6g8fmNmx/9VnHDKCaEzBcoVw+7UcQktZHrJ2jhlI+Zv8L57pMCIwM4h4MWg==",
             "dependencies": {
-                "@vue/compiler-sfc": "2.7.8",
+                "@vue/compiler-sfc": "2.7.9",
                 "csstype": "^3.1.0"
             }
         },
@@ -27419,9 +27545,9 @@
             }
         },
         "node_modules/vue-template-compiler": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.8.tgz",
-            "integrity": "sha512-eQqdcUpJKJpBRPDdxCNsqUoT0edNvdt1jFjtVnVS/LPPmr0BU2jWzXlrf6BVMeODtdLewB3j8j3WjNiB+V+giw==",
+            "version": "2.7.9",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.9.tgz",
+            "integrity": "sha512-NPJxt6OjVlzmkixYg0SdIN2Lw/rMryQskObY89uAMcM9flS/HrmLK5LaN1ReBTuhBgnYuagZZEkSS6FESATQUQ==",
             "devOptional": true,
             "dependencies": {
                 "de-indent": "^1.0.2",
@@ -27447,6 +27573,16 @@
             },
             "peerDependencies": {
                 "vue": "^2.0.0"
+            }
+        },
+        "node_modules/vue/node_modules/@vue/compiler-sfc": {
+            "version": "2.7.9",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.9.tgz",
+            "integrity": "sha512-TD2FvT0fPUezw5RVP4tfwTZnKHP0QjeEUb39y7tORvOJQTjbOuHJEk4GPHUPsRaTeQ8rjuKjntyrYcEIx+ODxg==",
+            "dependencies": {
+                "@babel/parser": "^7.18.4",
+                "postcss": "^8.4.14",
+                "source-map": "^0.6.1"
             }
         },
         "node_modules/vuedraggable": {
@@ -30614,6 +30750,15 @@
                 "postcss-selector-parser": "^6.0.10"
             }
         },
+        "@csstools/postcss-nested-calc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-1.0.0.tgz",
+            "integrity": "sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            }
+        },
         "@csstools/postcss-normalize-display-values": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.1.tgz",
@@ -30646,6 +30791,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-1.0.1.tgz",
             "integrity": "sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            }
+        },
+        "@csstools/postcss-text-decoration-shorthand": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-1.0.0.tgz",
+            "integrity": "sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
@@ -31432,9 +31586,9 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-            "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+            "version": "0.3.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+            "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -31506,9 +31660,9 @@
             }
         },
         "@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
         },
         "@rollup/plugin-babel": {
             "version": "5.3.1",
@@ -32016,9 +32170,9 @@
             }
         },
         "@types/eslint": {
-            "version": "8.4.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-            "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+            "version": "8.4.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+            "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -32121,9 +32275,9 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
         },
         "@types/lodash": {
-            "version": "4.14.182",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
-            "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
+            "version": "4.14.184",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+            "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q=="
         },
         "@types/mdast": {
             "version": "3.0.10",
@@ -32149,9 +32303,9 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
         },
         "@types/node": {
-            "version": "18.6.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-            "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw=="
+            "version": "18.7.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.9.tgz",
+            "integrity": "sha512-0N5Y1XAdcl865nDdjbO0m3T6FdmQ4ijE89/urOHLREyTXbpMWbSafx9y7XIsgWGtwUP2iYTinLyyW3FatAxBLQ=="
         },
         "@types/normalize-package-data": {
             "version": "2.4.1",
@@ -32273,9 +32427,9 @@
             "dev": true
         },
         "@types/uglify-js": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.16.0.tgz",
-            "integrity": "sha512-0yeUr92L3r0GLRnBOvtYK1v2SjqMIqQDHMl7GLb+l2L8+6LSFWEEWEIgVsPdMn5ImLM8qzWT8xFPtQYpp8co0g==",
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.0.tgz",
+            "integrity": "sha512-3HO6rm0y+/cqvOyA8xcYLweF0TKXlAxmQASjbOi49Co51A1N4nR4bEwBgRoD9kNM+rqFGArjKr654SLp2CoGmQ==",
             "requires": {
                 "source-map": "^0.6.1"
             }
@@ -33516,14 +33670,76 @@
                 "strip-ansi": "^6.0.0"
             }
         },
-        "@vue/compiler-sfc": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.8.tgz",
-            "integrity": "sha512-2DK4YWKfgLnW9VDR9gnju1gcYRk3flKj8UNsms7fsRmFcg35slVTZEkqwBtX+wJBXaamFfn6NxSsZh3h12Ix/Q==",
+        "@vue/compiler-core": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.37.tgz",
+            "integrity": "sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==",
+            "optional": true,
+            "peer": true,
             "requires": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "estree-walker": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+                    "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+                    "optional": true,
+                    "peer": true
+                }
+            }
+        },
+        "@vue/compiler-dom": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
+            "integrity": "sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==",
+            "optional": true,
+            "peer": true,
+            "requires": {
+                "@vue/compiler-core": "3.2.37",
+                "@vue/shared": "3.2.37"
+            }
+        },
+        "@vue/compiler-sfc": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz",
+            "integrity": "sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==",
+            "optional": true,
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.37",
+                "@vue/compiler-dom": "3.2.37",
+                "@vue/compiler-ssr": "3.2.37",
+                "@vue/reactivity-transform": "3.2.37",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7",
+                "postcss": "^8.1.10",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "estree-walker": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+                    "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+                    "optional": true,
+                    "peer": true
+                }
+            }
+        },
+        "@vue/compiler-ssr": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.37.tgz",
+            "integrity": "sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==",
+            "optional": true,
+            "peer": true,
+            "requires": {
+                "@vue/compiler-dom": "3.2.37",
+                "@vue/shared": "3.2.37"
             }
         },
         "@vue/component-compiler-utils": {
@@ -33577,6 +33793,36 @@
             "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz",
             "integrity": "sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==",
             "requires": {}
+        },
+        "@vue/reactivity-transform": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.37.tgz",
+            "integrity": "sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==",
+            "optional": true,
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.37",
+                "@vue/shared": "3.2.37",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7"
+            },
+            "dependencies": {
+                "estree-walker": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+                    "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+                    "optional": true,
+                    "peer": true
+                }
+            }
+        },
+        "@vue/shared": {
+            "version": "3.2.37",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
+            "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==",
+            "optional": true,
+            "peer": true
         },
         "@vue/test-utils": {
             "version": "1.3.0",
@@ -35293,9 +35539,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001375",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
-            "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw=="
+            "version": "1.0.30001381",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+            "integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w=="
         },
         "capture-exit": {
             "version": "2.0.0",
@@ -35732,9 +35978,9 @@
             }
         },
         "codemirror": {
-            "version": "5.65.7",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.7.tgz",
-            "integrity": "sha512-zb67cXzgugIQmb6tfD4G11ILjYoMfTjwcjn+cWsa4GewlI2adhR/h3kolkoCQTm1msD/1BuqVTKuO09ELsS++A=="
+            "version": "5.65.8",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.8.tgz",
+            "integrity": "sha512-TNGkSkkoAsmZSf6W6g35LMVQJBHKasc2CKwhr/fTxSYun7cn6J+CbtyNjV/MYlFVkNTsqZoviegyCZimWhoMMA=="
         },
         "codemirror-spell-checker": {
             "version": "1.1.2",
@@ -36434,9 +36680,9 @@
                     }
                 },
                 "cssnano": {
-                    "version": "5.1.12",
-                    "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.12.tgz",
-                    "integrity": "sha512-TgvArbEZu0lk/dvg2ja+B7kYoD7BBCmn3+k58xD0qjrGHsFzXY/wKTo9M5egcUCabPol05e/PVoIu79s2JN4WQ==",
+                    "version": "5.1.13",
+                    "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.13.tgz",
+                    "integrity": "sha512-S2SL2ekdEz6w6a2epXn4CmMKU4K3KpcyXLKfAYc9UQQqJRkD/2eLUG0vJ3Db/9OvO5GuAdgXw3pFbR6abqghDQ==",
                     "dev": true,
                     "requires": {
                         "cssnano-preset-default": "^5.2.12",
@@ -36872,9 +37118,9 @@
             "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
         },
         "cssdb": {
-            "version": "6.6.3",
-            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.6.3.tgz",
-            "integrity": "sha512-7GDvDSmE+20+WcSMhP17Q1EVWUrLlbxxpMDqG731n8P99JhnQZHR9YvtjPvEHfjFUjvQJvdpKCjlKOX+xe4UVA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.0.0.tgz",
+            "integrity": "sha512-HmRYATZ4Gf8naf6sZmwKEyf7MXAC0ZxjsamtNNgmuWpQgoO973zsE/1JMIohEYsSi5e3n7vQauCLv7TWSrOlrw==",
             "dev": true
         },
         "cssesc": {
@@ -37105,9 +37351,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.18.23",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.23.tgz",
-                    "integrity": "sha512-MhbCWN18R4GhO8ewQWAFK4TGQdBpXWByukz7cWyJmXhvRuCIaM/oWytGPqVmDzgEnnaIc9ss6HbU5mUi+vyZPA==",
+                    "version": "14.18.25",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.25.tgz",
+                    "integrity": "sha512-9pLfceRSrKIsv/MISN6RoFWTIzka36Uk2Uuf5a8cHyDYhEgl5Hm5dXoe621KULeBjt+cFsY18mILsWWtJeG80w==",
                     "dev": true
                 },
                 "ansi-styles": {
@@ -37312,9 +37558,9 @@
             }
         },
         "dayjs": {
-            "version": "1.11.4",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-            "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
+            "version": "1.11.5",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
+            "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
             "dev": true
         },
         "de-indent": {
@@ -37854,9 +38100,9 @@
             "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
         },
         "electron-to-chromium": {
-            "version": "1.4.213",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.213.tgz",
-            "integrity": "sha512-+3DbGHGOCHTVB/Ms63bGqbyC1b8y7Fk86+7ltssB8NQrZtSCvZG6eooSl9U2Q0yw++fL2DpHKOdTU0NVEkFObg=="
+            "version": "1.4.225",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+            "integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw=="
         },
         "elliptic": {
             "version": "6.5.4",
@@ -39709,9 +39955,9 @@
             "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
         },
         "hotkeys-js": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.4.tgz",
-            "integrity": "sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q=="
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.5.tgz",
+            "integrity": "sha512-T0G8CUZ6Q1IOgPnLK1hDXR8DqgKF/VWEsHvZgi6CM7Ub9oOAzvWuJ3Qhc/9nFQaR26MfFOZSwULHrtCnsUX7zA=="
         },
         "hpack.js": {
             "version": "2.1.6",
@@ -42459,9 +42705,9 @@
             "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
         },
         "js-beautify": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.5.tgz",
-            "integrity": "sha512-P2BfZBhXchh10uZ87qMKpM2tfcDXLA+jDiWU/OV864yWdTGzLUGNAdp9Y1ID5ubpNVGls3cZ1UMcO8myUB+UyA==",
+            "version": "1.14.6",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.6.tgz",
+            "integrity": "sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==",
             "dev": true,
             "requires": {
                 "config-chain": "^1.1.13",
@@ -42684,9 +42930,9 @@
             "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw=="
         },
         "launch-editor": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.5.0.tgz",
-            "integrity": "sha512-coRiIMBJ3JF7yX8nZE4Fr+xxUy+3WTRsDSwIzHghU28gjXwkAWsvac3BpZrL/jHtbiqQ4TiRAyTJmsgErNk1jQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+            "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
             "requires": {
                 "picocolors": "^1.0.0",
                 "shell-quote": "^1.7.3"
@@ -42700,11 +42946,11 @@
             }
         },
         "launch-editor-middleware": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.5.0.tgz",
-            "integrity": "sha512-kv9MMO81pbYjznk9j/DBu0uBGxIpT6uYhGajq6fxdGEPb+DCRBoS96jGkhe3MJumdY3zZFkuS8CFPTZI9DaBNw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/launch-editor-middleware/-/launch-editor-middleware-2.6.0.tgz",
+            "integrity": "sha512-K2yxgljj5TdCeRN1lBtO3/J26+AIDDDw+04y6VAiZbWcTdBwsYN6RrZBnW5DN/QiSIdKNjKdATLUUluWWFYTIA==",
             "requires": {
-                "launch-editor": "^2.5.0"
+                "launch-editor": "^2.6.0"
             }
         },
         "lazy-ass": {
@@ -43070,7 +43316,7 @@
             "version": "0.25.9",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
             "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "sourcemap-codec": "^1.4.8"
             }
@@ -43111,9 +43357,9 @@
             }
         },
         "marked": {
-            "version": "4.0.18",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-            "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw=="
+            "version": "4.0.19",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+            "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ=="
         },
         "mathml-tag-names": {
             "version": "2.1.3",
@@ -43938,9 +44184,9 @@
             }
         },
         "object.assign": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
-            "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+            "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -44762,9 +45008,9 @@
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
         },
         "portfinder": {
-            "version": "1.0.29",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.29.tgz",
-            "integrity": "sha512-Z5+DarHWCKlufshB9Z1pN95oLtANoY5Wn9X3JGELGyQ6VhEcBfT2t+1fGUBq7MwUant6g/mqowH+4HifByPbiQ==",
+            "version": "1.0.32",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+            "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
             "requires": {
                 "async": "^2.6.4",
                 "debug": "^3.2.7",
@@ -45836,57 +46082,59 @@
             }
         },
         "postcss-preset-env": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.7.2.tgz",
-            "integrity": "sha512-1q0ih7EDsZmCb/FMDRvosna7Gsbdx8CvYO5hYT120hcp2ZAuOHpSzibujZ4JpIUcAC02PG6b+eftxqjTFh5BNA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.0.tgz",
+            "integrity": "sha512-leqiqLOellpLKfbHkD06E04P6d9ZQ24mat6hu4NSqun7WG0UhspHR5Myiv/510qouCjoo4+YJtNOqg5xHaFnCA==",
             "dev": true,
             "requires": {
-                "@csstools/postcss-cascade-layers": "^1.0.4",
-                "@csstools/postcss-color-function": "^1.1.0",
-                "@csstools/postcss-font-format-keywords": "^1.0.0",
-                "@csstools/postcss-hwb-function": "^1.0.1",
-                "@csstools/postcss-ic-unit": "^1.0.0",
-                "@csstools/postcss-is-pseudo-class": "^2.0.6",
-                "@csstools/postcss-normalize-display-values": "^1.0.0",
-                "@csstools/postcss-oklab-function": "^1.1.0",
+                "@csstools/postcss-cascade-layers": "^1.0.5",
+                "@csstools/postcss-color-function": "^1.1.1",
+                "@csstools/postcss-font-format-keywords": "^1.0.1",
+                "@csstools/postcss-hwb-function": "^1.0.2",
+                "@csstools/postcss-ic-unit": "^1.0.1",
+                "@csstools/postcss-is-pseudo-class": "^2.0.7",
+                "@csstools/postcss-nested-calc": "^1.0.0",
+                "@csstools/postcss-normalize-display-values": "^1.0.1",
+                "@csstools/postcss-oklab-function": "^1.1.1",
                 "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-                "@csstools/postcss-stepped-value-functions": "^1.0.0",
-                "@csstools/postcss-trigonometric-functions": "^1.0.1",
-                "@csstools/postcss-unset-value": "^1.0.1",
-                "autoprefixer": "^10.4.7",
-                "browserslist": "^4.21.0",
+                "@csstools/postcss-stepped-value-functions": "^1.0.1",
+                "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
+                "@csstools/postcss-trigonometric-functions": "^1.0.2",
+                "@csstools/postcss-unset-value": "^1.0.2",
+                "autoprefixer": "^10.4.8",
+                "browserslist": "^4.21.3",
                 "css-blank-pseudo": "^3.0.3",
                 "css-has-pseudo": "^3.0.4",
                 "css-prefers-color-scheme": "^6.0.3",
-                "cssdb": "^6.6.3",
-                "postcss-attribute-case-insensitive": "^5.0.1",
+                "cssdb": "^7.0.0",
+                "postcss-attribute-case-insensitive": "^5.0.2",
                 "postcss-clamp": "^4.1.0",
-                "postcss-color-functional-notation": "^4.2.3",
+                "postcss-color-functional-notation": "^4.2.4",
                 "postcss-color-hex-alpha": "^8.0.4",
-                "postcss-color-rebeccapurple": "^7.1.0",
+                "postcss-color-rebeccapurple": "^7.1.1",
                 "postcss-custom-media": "^8.0.2",
                 "postcss-custom-properties": "^12.1.8",
                 "postcss-custom-selectors": "^6.0.3",
-                "postcss-dir-pseudo-class": "^6.0.4",
-                "postcss-double-position-gradients": "^3.1.1",
+                "postcss-dir-pseudo-class": "^6.0.5",
+                "postcss-double-position-gradients": "^3.1.2",
                 "postcss-env-function": "^4.0.6",
                 "postcss-focus-visible": "^6.0.4",
                 "postcss-focus-within": "^5.0.4",
                 "postcss-font-variant": "^5.0.0",
-                "postcss-gap-properties": "^3.0.3",
-                "postcss-image-set-function": "^4.0.6",
+                "postcss-gap-properties": "^3.0.5",
+                "postcss-image-set-function": "^4.0.7",
                 "postcss-initial": "^4.0.1",
-                "postcss-lab-function": "^4.2.0",
+                "postcss-lab-function": "^4.2.1",
                 "postcss-logical": "^5.0.4",
                 "postcss-media-minmax": "^5.0.0",
-                "postcss-nesting": "^10.1.9",
+                "postcss-nesting": "^10.1.10",
                 "postcss-opacity-percentage": "^1.1.2",
-                "postcss-overflow-shorthand": "^3.0.3",
+                "postcss-overflow-shorthand": "^3.0.4",
                 "postcss-page-break": "^3.0.4",
-                "postcss-place": "^7.0.4",
-                "postcss-pseudo-class-any-link": "^7.1.5",
+                "postcss-place": "^7.0.5",
+                "postcss-pseudo-class-any-link": "^7.1.6",
                 "postcss-replace-overflow-wrap": "^4.0.0",
-                "postcss-selector-not": "^6.0.0",
+                "postcss-selector-not": "^6.0.1",
                 "postcss-value-parser": "^4.2.0"
             },
             "dependencies": {
@@ -47200,9 +47448,9 @@
             }
         },
         "rollup": {
-            "version": "2.77.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-            "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+            "version": "2.78.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+            "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -47450,9 +47698,9 @@
             }
         },
         "sass": {
-            "version": "1.54.4",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.4.tgz",
-            "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
+            "version": "1.54.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.5.tgz",
+            "integrity": "sha512-p7DTOzxkUPa/63FU0R3KApkRHwcVZYC0PLnLm5iyZACyp15qSi32x7zVUhRdABAATmkALqgGrjCJAcWvobmhHw==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -48093,7 +48341,7 @@
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
             "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-            "dev": true
+            "devOptional": true
         },
         "spdx-correct": {
             "version": "3.1.1",
@@ -48727,9 +48975,9 @@
                     }
                 },
                 "flatted": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-                    "integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ=="
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+                    "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
                 },
                 "get-stdin": {
                     "version": "8.0.0",
@@ -49186,15 +49434,15 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-            "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.5.tgz",
+            "integrity": "sha512-AOEDLDxD2zylUGf/wxHxklEkOe2/r+seuyOWujejFrIxHf11brA1/dWQNIgXa1c6/Wkxgu7zvv0JhOWfc2ELEA==",
             "requires": {
-                "@jridgewell/trace-mapping": "^0.3.7",
+                "@jridgewell/trace-mapping": "^0.3.14",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
-                "terser": "^5.7.2"
+                "terser": "^5.14.1"
             },
             "dependencies": {
                 "commander": {
@@ -49460,9 +49708,9 @@
             "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
         },
         "trumbowyg": {
-            "version": "2.25.1",
-            "resolved": "https://registry.npmjs.org/trumbowyg/-/trumbowyg-2.25.1.tgz",
-            "integrity": "sha512-bmmV1qC+fTLfyVpLE5iZjCzHG5DfAwM7p8K2fdq6L1kOi+IrVJk/qGFVEEmYyJ0Ofd1z3g2vavfABpmkVLzV6A==",
+            "version": "2.25.2",
+            "resolved": "https://registry.npmjs.org/trumbowyg/-/trumbowyg-2.25.2.tgz",
+            "integrity": "sha512-wpWZzvmYgDHBiDBEWZ+YrYfeWmWdwAwudb1mNquRX7VpVqbzetNfrM307E1qgq36v+Gviu4r1V9ITFD8zZvmhg==",
             "requires": {}
         },
         "tryer": {
@@ -49998,12 +50246,24 @@
             "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
         },
         "vue": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.8.tgz",
-            "integrity": "sha512-ncwlZx5qOcn754bCu5/tS/IWPhXHopfit79cx+uIlLMyt3vCMGcXai5yCG5y+I6cDmEj4ukRYyZail9FTQh7lQ==",
+            "version": "2.7.9",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.9.tgz",
+            "integrity": "sha512-GeWCvAUkjzD5q4A3vgi8ka5r9bM6g8fmNmx/9VnHDKCaEzBcoVw+7UcQktZHrJ2jhlI+Zv8L57pMCIwM4h4MWg==",
             "requires": {
-                "@vue/compiler-sfc": "2.7.8",
+                "@vue/compiler-sfc": "2.7.9",
                 "csstype": "^3.1.0"
+            },
+            "dependencies": {
+                "@vue/compiler-sfc": {
+                    "version": "2.7.9",
+                    "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.9.tgz",
+                    "integrity": "sha512-TD2FvT0fPUezw5RVP4tfwTZnKHP0QjeEUb39y7tORvOJQTjbOuHJEk4GPHUPsRaTeQ8rjuKjntyrYcEIx+ODxg==",
+                    "requires": {
+                        "@babel/parser": "^7.18.4",
+                        "postcss": "^8.4.14",
+                        "source-map": "^0.6.1"
+                    }
+                }
             }
         },
         "vue-eslint-parser": {
@@ -50222,9 +50482,9 @@
             }
         },
         "vue-template-compiler": {
-            "version": "2.7.8",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.8.tgz",
-            "integrity": "sha512-eQqdcUpJKJpBRPDdxCNsqUoT0edNvdt1jFjtVnVS/LPPmr0BU2jWzXlrf6BVMeODtdLewB3j8j3WjNiB+V+giw==",
+            "version": "2.7.9",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.9.tgz",
+            "integrity": "sha512-NPJxt6OjVlzmkixYg0SdIN2Lw/rMryQskObY89uAMcM9flS/HrmLK5LaN1ReBTuhBgnYuagZZEkSS6FESATQUQ==",
             "devOptional": true,
             "requires": {
                 "de-indent": "^1.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ Encore.addPlugin(
     .cleanupOutputBeforeBuild()
     .disableSingleRuntimeChunk()
     .enableSourceMaps(!Encore.isProduction())
-    .enableVersioning(true)
+    .enableVersioning(false)
 
     .addEntry('bolt', './assets/js/bolt.js')
     .addEntry('zxcvbn', './assets/js/zxcvbn.js')


### PR DESCRIPTION
Fixes #3289 

Turns out versioning breaks clearing the cache. (I assume a race condition). Let's disable it for now. 