### PR TITLE
Allow image/files modals to be populated from dynamic backend URLs

### DIFF
--- a/assets/js/app/editor/Components/File.vue
+++ b/assets/js/app/editor/Components/File.vue
@@ -217,8 +217,8 @@ export default {
         },
         generateModalContent(inputOptions) {
             let filePath = '';
-            let baseAsyncUrl = `/bolt/async/list_files?location=files/${filePath}&type=files`;
             let folderPath = inputOptions[0].value;
+            let baseAsyncPath = inputOptions[0].base_url_path;
             let fileIcons = {
                 jpg: 'fa-file-image',
                 jpeg: 'fa-file-image',
@@ -251,7 +251,7 @@ export default {
                 pathChunks.pop();
                 pathChunks.pop();
                 filePath = pathChunks.join('/');
-                baseAsyncUrl = `/bolt/async/list_files?location=${filePath}&type=files`;
+                let baseAsyncUrl = `${baseAsyncPath}?location=${filePath}&type=files`;
                 if (filePath != '') {
                     modalContent += `
                     <div class="col">
@@ -277,7 +277,7 @@ export default {
                     .toLowerCase();
                 if (element.group == 'directories') {
                     filePath = element.value;
-                    baseAsyncUrl = `/bolt/async/list_files?location=${filePath}&type=files`;
+                    let baseAsyncUrl = `${baseAsyncPath}?location=${filePath}&type=files`;
                     modalContent += `
                         <div class="col">
                             <div class="card h-100">

--- a/assets/js/app/editor/Components/Image.vue
+++ b/assets/js/app/editor/Components/Image.vue
@@ -280,8 +280,8 @@ export default {
         },
         generateModalContent(inputOptions) {
             let filePath = '';
-            let baseAsyncUrl = `/bolt/async/list_files?location=${filePath}&type=images`;
             let folderPath = inputOptions[0].value;
+            let baseAsyncPath = inputOptions[0].base_url_path;
             let modalContent = '<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-2">';
             // If we are deep in the directory, add an arrow to navigate back to previous folder
             if (folderPath.includes('/')) {
@@ -289,7 +289,7 @@ export default {
                 pathChunks.pop();
                 pathChunks.pop();
                 filePath = pathChunks.join('/');
-                baseAsyncUrl = `/bolt/async/list_files?location=${filePath}&type=images`;
+                let baseAsyncUrl = `${baseAsyncPath}?location=${filePath}&type=images`;
 
                 if (filePath != '') {
                     modalContent += `
@@ -312,7 +312,7 @@ export default {
             inputOptions.forEach((element, key) => {
                 if (element.group == 'directories') {
                     filePath = element.value;
-                    baseAsyncUrl = `/bolt/async/list_files?location=${filePath}&type=images`;
+                    let baseAsyncUrl = `${baseAsyncPath}?location=${filePath}&type=images`;
                     // let directoryPath = '/bolt/async/list_files?location=files/' + element.value + '&type=images';
                     modalContent += `
                     <div class="col">

--- a/src/Cache/FilesIndexCacher.php
+++ b/src/Cache/FilesIndexCacher.php
@@ -11,11 +11,11 @@ class FilesIndexCacher extends FilesIndex implements CachingInterface
 
     public const CACHE_CONFIG_KEY = 'files_index';
 
-    public function get(string $path, string $type, string $basePath): Collection
+    public function get(string $path, string $type, string $baseUrlPath, string $baseFilePath): Collection
     {
         $this->setCacheTags(['fileslisting']);
         $this->setCacheKey([$path, $type]);
 
-        return $this->execute([parent::class, __FUNCTION__], [$path, $type, $basePath]);
+        return $this->execute([parent::class, __FUNCTION__], [$path, $type, $baseUrlPath, $baseFilePath]);
     }
 }

--- a/src/Controller/Backend/Async/FileListingController.php
+++ b/src/Controller/Backend/Async/FileListingController.php
@@ -61,10 +61,10 @@ class FileListingController implements AsyncZoneInterface
 
         // Do not allow any path outside of the public directory.
         $path = PathCanonicalize::canonicalize($this->publicPath, $relativeLocation);
-        $basePath = PathCanonicalize::canonicalize($this->publicPath, $relativeTopLocation);
+        $baseFilePath = PathCanonicalize::canonicalize($this->publicPath, $relativeTopLocation);
         $relativePath = Path::makeRelative($path, $this->publicPath);
 
-        $files = $this->filesIndex->get($relativePath, $type, $basePath);
+        $files = $this->filesIndex->get($relativePath, $type, $baseFilePath);
 
         return new JsonResponse($files);
     }

--- a/src/Controller/Backend/Async/FileListingController.php
+++ b/src/Controller/Backend/Async/FileListingController.php
@@ -62,9 +62,10 @@ class FileListingController implements AsyncZoneInterface
         // Do not allow any path outside of the public directory.
         $path = PathCanonicalize::canonicalize($this->publicPath, $relativeLocation);
         $baseFilePath = PathCanonicalize::canonicalize($this->publicPath, $relativeTopLocation);
+        $baseUrlPath = $this->request->server->get('PATH_INFO');
         $relativePath = Path::makeRelative($path, $this->publicPath);
 
-        $files = $this->filesIndex->get($relativePath, $type, $baseFilePath);
+        $files = $this->filesIndex->get($relativePath, $type, $baseUrlPath, $baseFilePath);
 
         return new JsonResponse($files);
     }

--- a/src/Utils/FilesIndex.php
+++ b/src/Utils/FilesIndex.php
@@ -17,7 +17,7 @@ class FilesIndex
         $this->config = $config;
     }
 
-    public function get(string $path, string $type, string $baseFilePath): Collection
+    public function get(string $path, string $type, string $baseUrlPath, string $baseFilePath): Collection
     {
         if ($type === 'images') {
             $glob = sprintf('*.{%s}', $this->config->getMediaTypes()->implode(','));
@@ -32,6 +32,7 @@ class FilesIndex
                 'group' => 'directories',
                 'value' => $dir->getPathname(),
                 'text' => $dir->getFilename(),
+                'base_url_path' => $baseUrlPath
             ];
         }
 
@@ -40,6 +41,7 @@ class FilesIndex
                 'group' => basename($baseFilePath),
                 'value' => $path . '/' . $file->getRelativePathname(),
                 'text' => $file->getFilename(),
+                'base_url_path' => $baseUrlPath
             ];
         }
 

--- a/src/Utils/FilesIndex.php
+++ b/src/Utils/FilesIndex.php
@@ -17,7 +17,7 @@ class FilesIndex
         $this->config = $config;
     }
 
-    public function get(string $path, string $type, string $basePath): Collection
+    public function get(string $path, string $type, string $baseFilePath): Collection
     {
         if ($type === 'images') {
             $glob = sprintf('*.{%s}', $this->config->getMediaTypes()->implode(','));
@@ -37,7 +37,7 @@ class FilesIndex
 
         foreach (self::findFiles($path, $glob) as $file) {
             $files[] = [
-                'group' => basename($basePath),
+                'group' => basename($baseFilePath),
                 'value' => $path . '/' . $file->getRelativePathname(),
                 'text' => $file->getFilename(),
             ];

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -2115,7 +2115,7 @@
     <unit id="JpJFIFq" name="collection.confirm_delete">
       <segment>
         <source>collection.confirm_delete</source>
-        <target>Weet u zeker dat je dit collectie item wilt verwijderen?</target>
+        <target>Weet je zeker dat je dit collectie item wilt verwijderen?</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -2115,7 +2115,7 @@
     <unit id="JpJFIFq" name="collection.confirm_delete">
       <segment>
         <source>collection.confirm_delete</source>
-        <target>collection.confirm_delete</target>
+        <target>Weet u zeker dat je dit collectie item wilt verwijderen?</target>
       </segment>
     </unit>
   </file>


### PR DESCRIPTION
This PR fixes #3288.

This PR uses the base backend URL set in `bolt.backend_url` in `services.yaml` to populate the image/files modals and it adds a missing Dutch translation for `collection.confirm_delete`