### PR TITLE
Insert meta snippets on main request only

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -68,6 +68,9 @@ canonical: https://example.org
 # If you want to override the canonical template, from the theme:
 #canonical_template: 'partials/_canonical.html.twig'
 
+# If you want to add canonical link in your own way, set this to true
+omit_canonical_link: false
+
 # By setting this to true, you will get a relative canonical path passed to the template.
 #relative_canonical_url: true
 

--- a/src/Configuration/Parser/GeneralParser.php
+++ b/src/Configuration/Parser/GeneralParser.php
@@ -114,6 +114,7 @@ class GeneralParser extends BaseParser
             ],
             'omit_backgrounds' => false,
             'omit_meta_generator_tag' => false,
+            'omit_canonical_link' => false,
             'user_avatar' => [
                 'upload_path' => 'avatars',
                 'extensions_allowed' => ['png', 'jpeg', 'jpg', 'gif'],

--- a/src/Event/Subscriber/ProcessWidgetsQueueSubscriber.php
+++ b/src/Event/Subscriber/ProcessWidgetsQueueSubscriber.php
@@ -26,6 +26,10 @@ class ProcessWidgetsQueueSubscriber implements EventSubscriberInterface
      */
     public function onKernelResponse(ResponseEvent $event): void
     {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
         $response = $event->getResponse();
 
         $this->widgets->processQueue($response);

--- a/src/Event/Subscriber/WidgetSubscriber.php
+++ b/src/Event/Subscriber/WidgetSubscriber.php
@@ -48,13 +48,19 @@ class WidgetSubscriber implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event): void
     {
-        $canonicalLinkWidget = new CanonicalLinkWidget(
-            $this->canonical,
-            $this->config,
-            $this->twig
-        );
+        if (!$event->isMainRequest()) {
+            return;
+        }
 
-        $this->widgets->registerWidget($canonicalLinkWidget);
+        if (! $this->config->get('general/omit_canonical_link')) {
+            $canonicalLinkWidget = new CanonicalLinkWidget(
+                $this->canonical,
+                $this->config,
+                $this->twig
+            );
+
+            $this->widgets->registerWidget($canonicalLinkWidget);
+        }
 
         if (! $this->config->get('general/headers/allow_floc')) {
             $this->widgets->registerWidget(new FlocOptOutHeader());


### PR DESCRIPTION
Fix issue #1975 where meta snippets are inserted multiple times, via sub-requests for example.

I added an option in config to give the ability to deactivate default canonical insertion.