### PR TITLE
Add setId() function in User Entity

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -123,6 +123,11 @@ class User implements UserInterface, \Serializable, PasswordAuthenticatedUserInt
     public function __construct()
     {
     }
+    
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
 
     public function getId(): int
     {


### PR DESCRIPTION
To improve import functionality of the Conimex extension this function is necessary to allow the importer to set the ID of the user to whatever the id is in the exported users file. See https://github.com/bobdenotter/conimex/pull/62