### PR TITLE
Characters escaped when displaying the title bloc in templates

### DIFF
--- a/templates/_base/layout.html.twig
+++ b/templates/_base/layout.html.twig
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ block('title')|striptags }}</title>
+    <title>{{ block('title')|striptags|raw }}</title>
     {% block stylesheets %}
     {% set theme = 'theme-' ~ app.user.backendTheme|default('default') %}
     {{ encore_entry_link_tags('bolt') }}

--- a/templates/_base/layout_blank.html.twig
+++ b/templates/_base/layout_blank.html.twig
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ block('title')|striptags }}</title>
+    <title>{{ block('title')|striptags|raw }}</title>
     {% block stylesheets %}
     {{ encore_entry_link_tags('bolt') }}
     {% endblock %}


### PR DESCRIPTION
Hello,

Just noticed that the title in `layout*.html.twig` files is a little bit too much escaped.

There's a `|striptags` filter which is indeed useful because subsequent title blocks may have html elements in it. But the function does too much escaping.

For example, the title of the login page in french is "S'identifier" which is then displayed as : 
![wrong-title-escaping](https://user-images.githubusercontent.com/3305030/190481588-c32597bb-9fe1-4b4d-b780-794d16d5ec06.png)

As the content is already stripped from tags, we can just display a `raw` value.