### PR TITLE
Keep relation direction when updating content.

### DIFF
--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -568,20 +568,41 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         }
     }
 
-    private function updateRelation(Content $content, $newRelations): array
+    private function updateRelation(Content $content, string $relationType, $newRelations): void
     {
         $newRelations = (new Collection(Json::findArray($newRelations)))->filter();
-        $currentRelations = $this->relationRepository->findRelations($content, null, null, false);
-        $relationsResult = [];
+        $currentRelations = $this->relationRepository->findRelations($content, $relationType, null, false);
+        $currentRelationIds = \array_unique(
+            \array_map(
+                fn(Relation $relation) => $relation->getFromContent() === $content
+                    ? $relation->getToContent()->getId()
+                    : $relation->getFromContent()->getId(),
+                $currentRelations
+            )
+        );
 
-        // Remove old ones
+        // Remove old, no longer used relations.
         foreach ($currentRelations as $currentRelation) {
+            if (
+                $newRelations->contains($currentRelation->getToContent()->getId())
+                || $newRelations->contains($currentRelation->getFromContent()->getId())
+            ) {
+                // This relation currently exists, and continues to exist.
+                continue;
+            }
+
             // unlink content from relation - needed for code using relations from the content
             // side later (e.g. validation)
-            if ($currentRelation->getToContent()) {
+            if (
+                $currentRelation->getToContent()
+                && $newRelations->doesntContain($currentRelation->getToContent()->getId())
+            ) {
                 $currentRelation->getToContent()->removeRelationsToThisContent($currentRelation);
             }
-            if ($currentRelation->getFromContent()) {
+            if (
+                $currentRelation->getFromContent()
+                && $newRelations->doesntContain($currentRelation->getFromContent()->getId())
+            ) {
                 $currentRelation->getFromContent()->removeRelationsFromThisContent($currentRelation);
             }
             $this->em->remove($currentRelation);
@@ -589,20 +610,20 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
 
         // Then (re-) add selected ones
         foreach ($newRelations as $id) {
-            $contentTo = $this->contentRepository->findOneBy(['id' => $id]);
+            if (\in_array($id, $currentRelationIds)) {
+                // If this relation already exists, don't add it a second time.
+                continue;
+            }
 
+            $contentTo = $this->contentRepository->findOneBy(['id' => $id]);
             if ($contentTo === null) {
                 // Don't add relations to things that have gone missing
                 continue;
             }
 
             $relation = new Relation($content, $contentTo);
-
             $this->em->persist($relation);
-            $relationsResult[] = $id;
         }
-
-        return $relationsResult;
     }
 
     private function getEditLocale(Content $content): string

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -574,9 +574,11 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $currentRelations = $this->relationRepository->findRelations($content, $relationType, null, false);
         $currentRelationIds = \array_unique(
             \array_map(
-                fn(Relation $relation) => $relation->getFromContent() === $content
-                    ? $relation->getToContent()->getId()
-                    : $relation->getFromContent()->getId(),
+                static function (Relation $relation) use ($content) {
+                    return $relation->getFromContent() === $content
+                        ? $relation->getToContent()->getId()
+                        : $relation->getFromContent()->getId();
+                },
                 $currentRelations
             )
         );

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -388,8 +388,8 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         }
 
         if (isset($formData['relationship'])) {
-            foreach ($formData['relationship'] as $relation) {
-                $this->updateRelation($content, $relation);
+            foreach ($formData['relationship'] as $relationType => $relation) {
+                $this->updateRelation($content, $relationType, $relation);
             }
         }
 

--- a/src/Repository/RelationRepository.php
+++ b/src/Repository/RelationRepository.php
@@ -51,9 +51,7 @@ class RelationRepository extends ServiceEntityRepository
             ->select('r, cfrom, cto')
             ->join('r.fromContent', 'cfrom')
             ->join('r.toContent', 'cto')
-            ->orderBy('r.position', 'DESC');
-
-        $qb->andWhere('r.fromContent = :from OR r.toContent = :from');
+            ->orderBy('r.position', 'ASC');
 
         if ($publishedOnly === true) {
             $qb->andWhere('cto.status = :status')
@@ -62,8 +60,10 @@ class RelationRepository extends ServiceEntityRepository
         }
 
         if ($name !== null) {
-            $qb->andWhere('cto.contentType = :name OR cfrom.contentType = :name')
+            $qb->andWhere("(cfrom.contentType = :name AND r.toContent = :from) OR (cto.contentType = :name AND r.fromContent = :from)")
                 ->setParameter('name', $name, \PDO::PARAM_STR);
+        } else {
+            $qb->andWhere('r.fromContent = :from OR r.toContent = :from');
         }
 
         $qb->setParameter(':from', $from);


### PR DESCRIPTION
_This scratches my personal itch, where I want to nudge my Bolt-powered blog slightly more towards a knowledge-base thingy, where I can keep track of posts linking to other posts. To do this properly, I want to distinguish between incoming and outgoing links for a post._

Currently, a Content can have Relations To and From itself. In the edit interface, they're all thrown onto one pile, and when saving such an entry, all the relations will be, from that point on, From that content (even if they were in fact To it, before). This change fixes that, by more carefully storing and removing Relations. 

- Only remove existing Relations if they are actually no longer used
- Only add new Relations if they weren't already present
- Keep and fetch Relations in the correct order, default to sorting by `position`

In addition:

- Don't return anything (and change the method signature) from `updateRelation()`, since the output was never actually used.

Tested with content that had one or more relations to and from other contents of the same and of different contenttypes. In my testing, it all seems to work. I can't think of any BC breaks in this. The `position` being used to actually sort on is new, but not breaking (might be worth a warning, though, not sure if people actually used the default sorting since IMO it was kinda useless, but you never know).