### PR TITLE
Check for empty request before using it

### DIFF
--- a/src/Widget/Injector/RequestZone.php
+++ b/src/Widget/Injector/RequestZone.php
@@ -67,6 +67,10 @@ class RequestZone
      */
     public static function getFromRequest(?Request $request): string
     {
+        if (!$request) {
+            return static::NOWHERE;
+        }
+        
         return $request->attributes->get(static::KEY) ?: static::NOWHERE;
     }
 


### PR DESCRIPTION
Crashed today in one of my production environments:

![image](https://user-images.githubusercontent.com/1835343/194830765-a2bf27cb-02a9-4a74-9831-b550f49cc8b0.png)

Unfortunately I couldn't use the null-safe operator here :(