### PR TITLE
Since we call it using `self::runPHP`, we don't need the shebang

### DIFF
--- a/bin/fix-bundles.php
+++ b/bin/fix-bundles.php
@@ -1,4 +1,3 @@
-#!/usr/bin/env php
 <?php
 
 use Symfony\Component\VarExporter\VarExporter;


### PR DESCRIPTION
This prevents the confusing messsages like this from showing up: 

```
sh: 1: exec: vendor/bolt/core/bin/fix-bundles: not found
Processed 0 files. Updated: 0, deleted: 0, skipped: 0.
```

