### PR TITLE
Make guesstimateAuthor return type nullable

### DIFF
--- a/src/Event/Listener/ContentFillListener.php
+++ b/src/Event/Listener/ContentFillListener.php
@@ -99,7 +99,7 @@ class ContentFillListener
         $entity->setContentExtension($this->contentExtension);
     }
 
-    private function guesstimateAuthor(): User
+    private function guesstimateAuthor(): ?User
     {
         return $this->users->getFirstAdminUser();
     }


### PR DESCRIPTION
As seen with @bobdenotter, author can be `null` sometimes, especially on ContentType creation from forms with `bolt/forms`.