### PR TITLE
Fix `excerpt` when content would be too short _after_ trimming

### DIFF
--- a/src/Utils/Excerpt.php
+++ b/src/Utils/Excerpt.php
@@ -109,6 +109,7 @@ class Excerpt
         // if we are going to snip too much...
         if ($textlength - $startPos < $relLength) {
             $startPos -= (int) round(($textlength - $startPos) / 2);
+            $startPos = max(0, $startPos);
         }
 
         $relText = mb_substr($fulltext, $startPos, $relLength);


### PR DESCRIPTION
but would be long enough _before_ trimming in order to skip returning the `fulltext` instead.

The issue lies in a piece of small text that would be longer than the excerpt length `relLength`, but when trimmed at https://github.com/bolt/core/blob/master/src/Utils/Excerpt.php#L110-L112 would overflow resulting in a negative starting position. This gives an undesired result (and potenttially no highlight).