### PR TITLE
Made the is current filter remove the current locale 

### DIFF
--- a/src/Twig/FrontendMenuExtension.php
+++ b/src/Twig/FrontendMenuExtension.php
@@ -58,8 +58,11 @@ class FrontendMenuExtension extends AbstractExtension
 
     public function isCurrent($item): bool
     {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        $currentLocale = $currentRequest->getLocale();
         $uri = $item['uri'] ?? '';
+        $currentUrl = str_replace('/' . $currentLocale, '', $currentRequest->getPathInfo());
 
-        return $uri === $this->requestStack->getCurrentRequest()->getPathInfo();
+        return $uri === $currentUrl;
     }
 }

--- a/src/Twig/FrontendMenuExtension.php
+++ b/src/Twig/FrontendMenuExtension.php
@@ -61,7 +61,7 @@ class FrontendMenuExtension extends AbstractExtension
         $currentRequest = $this->requestStack->getCurrentRequest();
         $currentLocale = $currentRequest->getLocale();
         $uri = $item['uri'] ?? '';
-        $currentUrl = str_replace('/' . $currentLocale, '', $currentRequest->getPathInfo());
+        $currentUrl = str_replace('/' . $currentLocale . '/', '/', $currentRequest->getPathInfo());
 
         return $uri === $currentUrl;
     }


### PR DESCRIPTION
before comparing, to the current route to get continuous results across all languages.

/en/products becomes /products, which we then compare to the path info.