### PR TITLE
Don't blindly pre-select the first option in a filter.

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -135,10 +135,6 @@ export default {
             })
             .filter(item => undefined !== item);
 
-        if (filterSelectedItems.length === 0) {
-            filterSelectedItems = [_options[0]];
-        }
-
         this.selected = filterSelectedItems;
     },
     methods: {

--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -94,6 +94,7 @@ export default {
         classname: String,
         autocomplete: Boolean,
         errormessage: String | Boolean, //string if errormessage is set, and false otherwise
+        required: String | Boolean,
     },
     data: () => {
         return {
@@ -134,6 +135,10 @@ export default {
                 }
             })
             .filter(item => undefined !== item);
+
+        if (!!this._props.required && filterSelectedItems.length === 0) {
+            filterSelectedItems = [_options[0]];
+        }
 
         this.selected = filterSelectedItems;
     },

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -42,5 +42,6 @@
         :autocomplete="{{ autocomplete }}"
         :readonly="{{ readonly|json_encode }}"
         :errormessage='{{ errormessage|json_encode }}'
+        :required='{{ required|json_encode }}'
     ></editor-select>
 {% endblock %}


### PR DESCRIPTION
This eventually caused Relations selects for new content to have the first Related option pre-selected. Not entirely sure where this change came from and what the thought behind it was, so I cannot in full confidence say that this one won't break anything. I'd like @bobdenotter and @I-Valchev (and possibly @nestordedios ?) to weigh in.

Fixes #3370
