### PR TITLE
3115-thumbnails-parameters

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -166,9 +166,6 @@ records_per_page: 8
 # Default settings for thumbnails.
 #
 # quality:       Quality should be between 0 (horrible, small file) and 100 (best, huge file).
-# fit:           One of either none, crop (= crop-center), crop-top-left, crop-top, crop-top-right, crop-left, crop-right, crop-bottom-left, crop-bottom or crop-bottom-right.
-# allow_upscale: Determines whether small images will be enlarged to fit
-#                the requested dimensions.
 # save_files:    Save files in the thumbs/ folder, so subsequent requests will serve file directly. Great for performance
 #
 # Note: If you change these values, you might need to clear the cache before
@@ -177,9 +174,7 @@ thumbnails:
     default_thumbnail: [ 320, 240 ]
     default_image: [ 1000, 750 ]
     quality: 80
-    cropping: crop
     save_files: true
-    allow_upscale: false
 
 # File permissions for read/write/execute to set on folders and files that are
 # created. The exact permissions you should be setting depends on the system

--- a/src/Configuration/Parser/GeneralParser.php
+++ b/src/Configuration/Parser/GeneralParser.php
@@ -84,7 +84,7 @@ class GeneralParser extends BaseParser
             'thumbnails' => [
                 'default_thumbnail' => [160, 120],
                 'default_image' => [1000, 750],
-                'quality' => 75,
+                'quality' => 80,
                 'cropping' => 'crop',
                 'notfound_image' => 'bolt_assets://img/default_notfound.png',
                 'error_image' => 'bolt_assets://img/default_error.png',

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -147,18 +147,19 @@ class ImageController
             'h' => is_numeric($raw[1]) ? (int) $raw[1] : 300,
             'fit' => 'default',
             'location' => 'files',
+            'q' => (is_numeric($raw[2]) && 0 <= $raw[2] && $raw[2] <= 100) ? (int) $raw[2] : 80
         ];
 
-        if (isset($raw[3])) {
-            $this->parameters['fit'] = $this->parseFit($raw[2]);
-            $this->parameters['location'] = $raw[3];
-        } elseif (isset($raw[2])) {
-            $posible_fit = $this->parseFit($raw[2]);
+        if (isset($raw[4])) {
+            $this->parameters['fit'] = $this->parseFit($raw[3]);
+            $this->parameters['location'] = $raw[4];
+        } elseif (isset($raw[3])) {
+            $posible_fit = $this->parseFit($raw[3]);
 
             if ($this->testFit($posible_fit)) {
                 $this->parameters['fit'] = $posible_fit;
             } else {
-                $this->parameters['location'] = $raw[2];
+                $this->parameters['location'] = $raw[3];
             }
         }
     }

--- a/src/Twig/ImageExtension.php
+++ b/src/Twig/ImageExtension.php
@@ -121,11 +121,11 @@ class ImageExtension extends AbstractExtension
     /**
      * @param ImageField|array|string $image
      */
-    public function thumbnail($image, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null)
+    public function thumbnail($image, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null, ?int $quality = null)
     {
         $filename = $this->getFilename($image, true);
 
-        return $this->thumbnailHelper->path($filename, $width, $height, $location, $path, $fit);
+        return $this->thumbnailHelper->path($filename, $width, $height, $location, $path, $fit, $quality);
     }
 
     /**

--- a/src/Utils/ThumbnailHelper.php
+++ b/src/Utils/ThumbnailHelper.php
@@ -17,7 +17,7 @@ class ThumbnailHelper
         $this->config = $config;
     }
 
-    private function parameters(?int $width = null, ?int $height = null, ?string $fit = null, ?string $location = null): string
+    private function parameters(?int $width = null, ?int $height = null, ?string $fit = null, ?string $location = null, ?int $quality = null): string
     {
         if (! $width && ! $height) {
             $width = $this->config->get('general/thumbnails/default_thumbnail/0', 320);
@@ -34,10 +34,14 @@ class ThumbnailHelper
             $location = null;
         }
 
-        return implode('×', array_filter([$width, $height, $fit, $location]));
+        if (! $quality) {
+            $quality = (int) $this->config->get('general/thumbnails/quality');
+        }
+
+    return implode('×', array_filter([$width, $height, $quality, $fit, $location]));
     }
 
-    public function path(?string $filename = null, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null): string
+    public function path(?string $filename = null, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null, ?int $quality = null): string
     {
         if (! $filename) {
             return '/assets/images/placeholder.png';
@@ -47,7 +51,7 @@ class ThumbnailHelper
             $filename = $path . '/' . $filename;
         }
 
-        $paramString = $this->parameters($width, $height, $fit, $location);
+        $paramString = $this->parameters($width, $height, $fit, $location, $quality);
         $filename = Str::ensureStartsWith($filename, '/');
 
         return sprintf('/thumbs/%s%s', $paramString, $filename);

--- a/src/Utils/ThumbnailHelper.php
+++ b/src/Utils/ThumbnailHelper.php
@@ -38,7 +38,7 @@ class ThumbnailHelper
             $quality = (int) $this->config->get('general/thumbnails/quality');
         }
 
-    return implode('×', array_filter([$width, $height, $quality, $fit, $location]));
+        return implode('×', array_filter([$width, $height, $quality, $fit, $location]));
     }
 
     public function path(?string $filename = null, ?int $width = null, ?int $height = null, ?string $location = null, ?string $path = null, ?string $fit = null, ?int $quality = null): string


### PR DESCRIPTION
The thumbnail quality setting works now. I have also added a `$quality` parameter as the last parameter of the `thumbnail` filter. I have also brought the quality setting in `GeneralParser`'s default config in line with the default in `config.yaml`. As a result of my changes, quality is now the 3rd element of generated thumbnail paths. 

I have removed superfluous settings from `config.yaml` (`cropping` and `allow_upscale` – both seem to be superseded by the `$fit` parameter of the `thumbnail` filter).

I have tried to make my changes as undisruptive as possible, but I still recommend giving them a good look over.