### PR TITLE
Fix phpstan errors

### DIFF
--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class CollectionField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, \Iterator, RawPersistable
+class CollectionField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable
 {
     use FieldParentTrait;
     use IterableFieldTrait;

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class FilelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable, \Iterator
+class FilelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class ImagelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable, \Iterator
+class ImagelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/SelectField.php
+++ b/src/Entity/Field/SelectField.php
@@ -14,7 +14,7 @@ use Tightenco\Collect\Support\Collection;
 /**
  * @ORM\Entity
  */
-class SelectField extends Field implements FieldInterface, RawPersistable, \Iterator
+class SelectField extends Field implements FieldInterface, RawPersistable
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -18,7 +18,7 @@ use Tightenco\Collect\Support\Collection;
 /**
  * @ORM\Entity
  */
-class SetField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, \Iterator, RawPersistable
+class SetField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable
 {
     use FieldParentTrait;
     use IterableFieldTrait;

--- a/src/Security/AuthenticationEntryPointRedirector.php
+++ b/src/Security/AuthenticationEntryPointRedirector.php
@@ -8,6 +8,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 class AuthenticationEntryPointRedirector implements AuthenticationEntryPointInterface
 {
@@ -21,10 +22,12 @@ class AuthenticationEntryPointRedirector implements AuthenticationEntryPointInte
         $this->urlGenerator = $urlGenerator;
     }
 
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null): RedirectResponse
     {
         // add a custom flash message and redirect to the login page
-        $request->getSession()->getFlashBag()->add('warning', $this->translator->trans('You have to login in order to access this page.', [], 'security'));
+        /** @var Session $session */
+        $session = $request->getSession();
+        $session->getFlashBag()->add('warning', $this->translator->trans('You have to login in order to access this page.', [], 'security'));
 
         return new RedirectResponse($this->urlGenerator->generate('bolt_login'));
     }


### PR DESCRIPTION
Fix deprecation errors that appear when using Bolt on PHP 8.1 (and I guess 8.2)

Implementing `\Iterator` is not needed, I believe.

Also fixed another error Phpstan reported in the same way it was dealt with in `src/Controller/ErrorController.php`

See image for errors that were occurring. 

![deprecation notices bolt](https://user-images.githubusercontent.com/118975804/214266328-7ff61012-9197-4ed5-b8b3-77894b79cb61.png)

