### PR TITLE
Stop Symfony from overwriting the localefrom the query string when set_locale_from_accept_language is true

### DIFF
--- a/src/Event/Subscriber/LocaleSubscriber.php
+++ b/src/Event/Subscriber/LocaleSubscriber.php
@@ -31,6 +31,14 @@ class LocaleSubscriber implements EventSubscriberInterface
             $locale = $request->query->get('_locale');
             $request->getSession()->set('_locale', $locale);
             $request->setLocale($locale);
+
+            // Symfony does not take this query parameter into account in its own subscriber.
+            // Symfony's listener has a lower priority and will thus be called later.
+            // It will not check that the locale was set already and in case useAcceptLanguageHeader
+            // (see https://symfony.com/doc/5.4/reference/configuration/framework.html#set-locale-from-accept-language) is set, it will
+            // overwrite the locale that was just set.
+            // @see https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php#L71
+            $request->attributes->set('_locale', $locale);
         } elseif ($request->attributes->get('zone', false) === 'backend' && $request->getSession()->has('_backend_locale')) {
             $request->setLocale($request->getSession()->get('_backend_locale'));
         } else {


### PR DESCRIPTION
Hi!

# Context

A bit of context to begin with: I am using Bolt with 3 languages, each page being translated in each of this language.
Some of the visitors do not speak the default language and won't take the time use the language switcher.

I want the pages do be displayed in the language the user chose in its browser configuration.
That's what symfony provides through https://symfony.com/doc/current/reference/configuration/framework.html#set-locale-from-accept-language.

However I'd still like to be able to change the locale, through the language switcher, which simply appends `?_locale=XX` to the query string.

# Issue

When `framework.set_locale_from_accept_language: true` is set (with `framework.enabled_locales: ['en', 'fr', 'it']) the preferred language overwrites (Symfony's subscriber is called after Bolt's subscriber) the language set in the query string: symfony only checks the attributes, not the query string.

# Solution

When the `_locale` parameter from the query string is set, also set it in the attributes, which Symfony will check.

# :warning Warning

I do not know what that might imply (besides fixing my issue). This pull request is kind of here for discussions if that is not the way things should be done (I might not know Symfony well enough).

See https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php#L71
