### PR TITLE
Fix language switcher failing to set a default "type" value

### DIFF
--- a/templates/helpers/_languageselect.html.twig
+++ b/templates/helpers/_languageselect.html.twig
@@ -13,8 +13,8 @@ The current locale is in the Request object, which is an instance of `Symfony\Co
 
 #}
 
-{# Make sure type is either 'list' or 'select' #}
-{% if type|default('list') != 'list' %}{% set type = 'select' %}{% endif %}
+{# Make sure type is either 'list' or 'select'. Default to 'select' if not defined. #}
+{% if type|default('') != 'list' %}{% set type = 'select' %}{% endif %}
 
 {# Set `class` and `style` variables #}
 {% set class = 'class="languageselect_' ~ type ~ (class is defined ? ' ' ~ class) ~ '"' %}


### PR DESCRIPTION
According to the documentation https://docs.boltcms.io/5.0/twig-components/languageselect the language switcher should be usable without type: 

```twig
{% include 'helpers/_languageselect.html.twig' %}
```

However, not setting the type like below will throw an error:

```stacktrace
Twig\Error\RuntimeError:
Variable "type" does not exist.

  at vendor/bolt/core/templates/helpers/_languageselect.html.twig:22
  at __TwigTemplate_2281140af09e6102e86e7eafa527bafd11b91df66b58316afb745dd4e298e615->{closure}()
     (var/cache/dev/twig/58/58f807167b332d30faaf3f3777118f147f078e150977e0ac1d19f218da238901.php:57)
  at __TwigTemplate_2281140af09e6102e86e7eafa527bafd11b91df66b58316afb745dd4e298e615->doDisplay()
     (vendor/twig/twig/src/Template.php:394)
  at Twig\Template->displayWithErrorHandling()
     (vendor/twig/twig/src/Template.php:367)
  at Twig\Template->display()
     (var/cache/dev/twig/76/76263a4899b607054c1ebab37cf0df25d321cbe7d8454b62618cfa4dc60f9bea.php:59)
  at __TwigTemplate_9c77d5d01dfc5069d0e8a8163a940d579b40fac679cd19e28eb85116b3803fc4->doDisplay()
     (vendor/twig/twig/src/Template.php:394)
  at Twig\Template->displayWithErrorHandling()
     (vendor/twig/twig/src/Template.php:367)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:379)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:40)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Extension/CoreExtension.php:1347)
  at twig_include()
     (var/cache/dev/twig/3e/3e59e8963c4e0446a75941277df1d2c648227756b652d1addfe7cd55b505c39f.php:83)
  at __TwigTemplate_b180803ae46d1e67d24682057fc081a4292738d4544049c2a96ae9c3af589735->doDisplay()
     (vendor/twig/twig/src/Template.php:394)
  at Twig\Template->displayWithErrorHandling()
     (vendor/twig/twig/src/Template.php:367)
  at Twig\Template->display()
     (var/cache/dev/twig/e2/e23a21ca2ea7286990f1a4f2779899976336ce425b0105f0231edf72d9fcee84.php:48)
  at __TwigTemplate_df5b8db26974698fca99c605d6d80c345786e5b4bdd0db6acac991406e9a1905->doDisplay()
     (vendor/twig/twig/src/Template.php:394)
  at Twig\Template->displayWithErrorHandling()
     (vendor/twig/twig/src/Template.php:367)
  at Twig\Template->display()
     (vendor/twig/twig/src/Template.php:379)
  at Twig\Template->render()
     (vendor/twig/twig/src/TemplateWrapper.php:40)
  at Twig\TemplateWrapper->render()
     (vendor/twig/twig/src/Environment.php:280)
  at Twig\Environment->render()
     (vendor/bolt/core/src/Controller/TwigAwareController.php:231)
  at Bolt\Controller\TwigAwareController->renderTemplate()
     (vendor/bolt/core/src/Controller/TwigAwareController.php:90)
  at Bolt\Controller\TwigAwareController->render()
     (vendor/bolt/core/src/Controller/TwigAwareController.php:140)
  at Bolt\Controller\TwigAwareController->renderSingle()
     (vendor/bolt/core/src/Controller/Frontend/DetailController.php:64)
  at Bolt\Controller\Frontend\DetailController->record()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/framework-bundle/Controller/AbstractController.php:156)
  at Symfony\Bundle\FrameworkBundle\Controller\AbstractController->forward()
     (src/Controller/BrowserController.php:32)
  at App\Controller\BrowserController->redirectToUpdatePage()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:37)     
```

Only this form works:

```twig
{% include 'helpers/_languageselect.html.twig' with {'type': 'select'} %}
```

This is due to the helper template not using `type|default('list')` at each call and only setting the value to `'select'` if `type|default('list')` is different from `'list'`.
So, if no value if provided for `type`, the condition never applies as the default value (`'list'`) is not different from `'list'` and `type` remains undefined elsewhere in the template.