### PR TITLE
Partial reverse of #3395, we really need those `\Iterator`s

### DIFF
--- a/src/Entity/Field/CollectionField.php
+++ b/src/Entity/Field/CollectionField.php
@@ -17,7 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class CollectionField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable
+class CollectionField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable, \Iterator
 {
     use FieldParentTrait;
     use IterableFieldTrait;

--- a/src/Entity/Field/FilelistField.php
+++ b/src/Entity/Field/FilelistField.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class FilelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable
+class FilelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable, \Iterator
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/ImagelistField.php
+++ b/src/Entity/Field/ImagelistField.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-class ImagelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable
+class ImagelistField extends Field implements FieldInterface, ListFieldInterface, RawPersistable, \Iterator
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/SelectField.php
+++ b/src/Entity/Field/SelectField.php
@@ -14,7 +14,7 @@ use Tightenco\Collect\Support\Collection;
 /**
  * @ORM\Entity
  */
-class SelectField extends Field implements FieldInterface, RawPersistable
+class SelectField extends Field implements FieldInterface, RawPersistable, \Iterator
 {
     use IterableFieldTrait;
 

--- a/src/Entity/Field/SetField.php
+++ b/src/Entity/Field/SetField.php
@@ -18,7 +18,7 @@ use Tightenco\Collect\Support\Collection;
 /**
  * @ORM\Entity
  */
-class SetField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable
+class SetField extends Field implements Excerptable, FieldInterface, FieldParentInterface, ListFieldInterface, RawPersistable, \Iterator
 {
     use FieldParentTrait;
     use IterableFieldTrait;

--- a/src/Security/AuthenticationEntryPointRedirector.php
+++ b/src/Security/AuthenticationEntryPointRedirector.php
@@ -9,7 +9,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
 
 class AuthenticationEntryPointRedirector implements AuthenticationEntryPointInterface
 {


### PR DESCRIPTION
Pinging @enrise-mbraam , I had to partially revert your recent PR, because the removal of `Iterator` causes things like this to stop functioning: 

```
{% for image in record.gallery %}
    {{ image|popup() }}
{% endfor %}
```

Could you take another look at what was breaking on your end, and if we can do an alternative fix for that? :-)