### PR TITLE
Fixed thumbnail sizes

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -140,7 +140,7 @@ class ImageController
 
     private function parseParameters(string $paramString): void
     {
-        $raw = explode('×', preg_replace('/([0-9])(x)([0-9])/', '\1×\3', $paramString));
+        $raw = explode('×', preg_replace('/([0-9])(x)([0-9a-z])/i', '\1×\3', $paramString));
 
         $this->parameters = [
             'w' => is_numeric($raw[0]) ? (int) $raw[0] : 400,


### PR DESCRIPTION
 which did not fit the size because of a incomplete regex replace.

Further reference: 
https://boltcms.slack.com/archives/C094GL7ME/p1675776303978339?thread_ts=1675769854.480089&cid=C094GL7ME