### PR TITLE
fix: IterableFieldTrait:current() should be compatible with Iterator:…

### DIFF
--- a/src/Entity/IterableFieldTrait.php
+++ b/src/Entity/IterableFieldTrait.php
@@ -4,59 +4,14 @@ declare(strict_types=1);
 
 namespace Bolt\Entity;
 
-trait IterableFieldTrait
-{
-    private $iteratorCursor = 0;
-
-    /** @var array Field */
-    private $fields = [];
-
-    /**
-     * Makes ListFieldInterface fields |length filter
-     * return the number of elements in the field
-     */
-    public function count(): int
+if (PHP_MAJOR_VERSION >= 8) {
+    trait IterableFieldTrait
     {
-        return count($this->getValue());
+        use IterableFieldTraitPhp8;
     }
-
-    /**
-     * Makes ListFieldInterface fields .length attribute
-     * return the number of elements in the field
-     */
-    public function length(): int
+} else {
+    trait IterableFieldTrait
     {
-        return $this->count();
-    }
-
-    /**
-     * @return Field|string
-     */
-    public function current()
-    {
-        return $this->fields[$this->iteratorCursor];
-    }
-
-    public function next(): void
-    {
-        ++$this->iteratorCursor;
-    }
-
-    public function key(): int
-    {
-        return $this->iteratorCursor;
-    }
-
-    public function valid(): bool
-    {
-        return isset($this->fields[$this->iteratorCursor]);
-    }
-
-    public function rewind(): void
-    {
-        // Ensure $this->fields is initialised
-        $this->fields = $this->getValue();
-
-        $this->iteratorCursor = 0;
+        use IterableFieldTraitPhp7;
     }
 }

--- a/src/Entity/IterableFieldTraitPhp7.php
+++ b/src/Entity/IterableFieldTraitPhp7.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Entity;
+
+trait IterableFieldTraitPhp7
+{
+    private $iteratorCursor = 0;
+
+    /** @var array Field */
+    private $fields = [];
+
+    /**
+     * Makes ListFieldInterface fields |length filter
+     * return the number of elements in the field
+     */
+    public function count(): int
+    {
+        return count($this->getValue());
+    }
+
+    /**
+     * Makes ListFieldInterface fields .length attribute
+     * return the number of elements in the field
+     */
+    public function length(): int
+    {
+        return $this->count();
+    }
+
+    /**
+     * @return Field|string
+     */
+    public function current()
+    {
+        return $this->fields[$this->iteratorCursor];
+    }
+
+    public function next(): void
+    {
+        ++$this->iteratorCursor;
+    }
+
+    public function key(): int
+    {
+        return $this->iteratorCursor;
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->fields[$this->iteratorCursor]);
+    }
+
+    public function rewind(): void
+    {
+        // Ensure $this->fields is initialised
+        $this->fields = $this->getValue();
+
+        $this->iteratorCursor = 0;
+    }
+}

--- a/src/Entity/IterableFieldTraitPhp8.php
+++ b/src/Entity/IterableFieldTraitPhp8.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Entity;
+
+trait IterableFieldTraitPhp8
+{
+    use IterableFieldTraitPhp7 {
+        IterableFieldTraitPhp7::current as private parentCurrent;
+    }
+
+    /**
+     * @return Field|string
+     * @noinspection PhpMixedReturnTypeCanBeReducedInspection
+     */
+    public function current(): mixed
+    {
+        return $this->parentCurrent();
+    }
+}


### PR DESCRIPTION
…:current()

As of PHP 8.1 methods return types should be compatible with their parent/interface. I.e. deprecration as of 8.1 enforced as of 9.0. IterableFieldTrait::current() should therefore return mixed, the same as Iterator::current(). However this is not possible to do without dropping support for PHP < 8.0, as mixed was introduced then.

We fix this by creating different versions of IterableFieldTrait based on the PHP version; defining current() with(out) a return type based on the (major) version of PHP and/or the availability of mixed.

phpstan: flip logic so that phpstan loads correct trait.

---
This fix is not a nice fix, nor is it elegant. However, it is a fix.. and that's something.

It aims to fix the issue first raised in #3395 by @enrise-mbraam. TLDR; Anything implementing the Iterator interface should have `mixed` as the return type of `current()`. However, adding that return type, would break the code for PHP < 8, as this is when `mixed` was first introduced. 

Unfortunately this PR is the only viable solution that I see, short of dropping support for PHP < 8.

This work around should be removed when minimum PHP version is bumped to 8.0. Which should/will be done in bolt/bolt#7969 (couldn't find the moved issue).

**Marking this as WIP, as we should discuss/explore more elegant solutions.**