### PR TITLE
allow_twig : prevent saving error

### DIFF
--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -285,7 +285,7 @@ class Field implements FieldInterface, TranslatableInterface
                     'record' => $this->getContent(),
                 ]);
             } catch (LoaderError|SyntaxError $e) {
-                //prevent saving error (translations getting cleared if Twig code contains errors)
+                // Prevent saving error (translations getting cleared if Twig code contains errors)
                 $value = $valueBeforeRenderingAsTwig;
             }
         }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -18,6 +18,8 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Tightenco\Collect\Support\Collection;
 use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\SyntaxError;
 use Twig\Markup;
 
 /**
@@ -274,12 +276,18 @@ class Field implements FieldInterface, TranslatableInterface
         $value = is_string($value) ? FieldFillListener::trimZeroWidthWhitespace($value) : $value;
 
         if ($this->shouldBeRenderedAsTwig($value)) {
-            $template = self::getTwig()->createTemplate($value);
-            $value = $template->render([
-                // Edge case, if we try to generate a title or excerpt for a field that allows Twig
-                // and references {{ record }}
-                'record' => $this->getContent(),
-            ]);
+            $valueBeforeRenderingAsTwig = $value;
+            try {
+                $template = self::getTwig()->createTemplate($value);
+                $value    = $template->render([
+                    // Edge case, if we try to generate a title or excerpt for a field that allows Twig
+                    // and references {{ record }}
+                    'record' => $this->getContent(),
+                ]);
+            } catch (LoaderError|SyntaxError $e) {
+                //prevent saving error (translations getting cleared if Twig code contains errors)
+                $value = $valueBeforeRenderingAsTwig;
+            }
         }
 
         if (is_string($value) && $this->getDefinition()->get('allow_html')) {


### PR DESCRIPTION
allow_twig : prevent saving error (translations getting cleared if Twig code contains errors)

When inserting twig code (for example in an Article field), if the code contains one or more error, the content is saved in the current locale... but others translations are cleared.