### PR TITLE
Only attempt to get a link to content with a slug for the locale.

### DIFF
--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -110,7 +110,7 @@ class LocaleHelper
                 $routeParams['slugOrId'] = $slug;
             }
 
-            if ($route && (!isset($content) || isset($routeParams['slugOrId']))) {
+            if ($route && (stripos($route, "bolt_") === 0 || (!isset($content) || isset($routeParams['slugOrId'])))) {
                 $locale->put('link', $this->getLink($route, $routeParams, $locale));
             } else {
                 // For edge-cases like '404', the `_route` is null.

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -110,10 +110,11 @@ class LocaleHelper
                 $routeParams['slugOrId'] = $slug;
             }
 
-            if ($route) {
+            if ($route && (!isset($content) || isset($routeParams['slugOrId']))) {
                 $locale->put('link', $this->getLink($route, $routeParams, $locale));
             } else {
                 // For edge-cases like '404', the `_route` is null.
+                // Also, there's no link to content that does not have a slug in the given locale.
                 $locale->put('link', '');
             }
 


### PR DESCRIPTION
This prevents us from attempting to create a route without a slugOrId, which would only make the Router sad.

Fixes #3442