### PR TITLE
Delete duplicated unit in messages.en.xlf

### DIFF
--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -937,12 +937,6 @@
         <target>Search</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
       <segment>
         <source>contenttypes.generic.overview</source>


### PR DESCRIPTION
The unit tag with the name "9fb3e6e" completely repeats in meaning and content the unit tag with the name "general.purpose.built-with-bolt". I'm talking about the messages.en.xlf file. I suggest deleting this unit tag with the name "9fb3e6e".