### PR TITLE
Update messages.ru.xlf

### DIFF
--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="ru" trgLang="ru" translator="Павел Бид | Paul Bid (https://paul.bid) paulbid@protonmail.com">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="ru" trgLang="ru">
   <file id="messages.ru">
     <unit id="tbB2gib" name="not_available">
       <notes>


### PR DESCRIPTION
Sorry, @hide-me , Symfony doesn't allow the `attribute 'translator'` in the XLF. 

```
  Invalid resource provided: "/xxx/vendor/bolt/core/translations/messages.ru.xlf"; Errors: [ERROR 1867] Element '{urn:oasis:names:tc:xliff:document:2.0}xliff', attribute 'translator': The attribute 'translator' is not allowed. (in /Users/bob/Sites/327_oneplanet/ - line 2, column 0)
```