### PR TITLE
Allow `lazy` as an option for select fields using contenttype-queries

### DIFF
--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -153,19 +153,28 @@ export default {
          */
         if (this.fetchurl) {
             window.selectCache = window.selectCache || {};
+            window.requestCache = window.requestCache || {};
+
             if (window.selectCache[this.fetchurl]) {
                 this.options = window.selectCache[this.fetchurl];
                 fixSelectedItems.call(this);
+            } else if (window.requestCache[this.fetchurl]) {
+                window.requestCache[this.fetchurl].then(response => {
+                    this.options = response;
+                    fixSelectedItems.call(this);
+                });
             } else {
                 this.isLoading = true;
 
-                $.ajax({ url: this.fetchurl, dataType: 'json', cache: true }).then(response => {
-                    this.options = response;
-                    window.selectCache[this.fetchurl] = response;
-                    this.isLoading = false;
-
-                    fixSelectedItems.call(this);
-                });
+                window.requestCache[this.fetchurl] = $.ajax({ url: this.fetchurl, dataType: 'json', cache: true });
+                window.requestCache[this.fetchurl].then(
+                    response => {
+                        this.options = response;
+                        window.selectCache[this.fetchurl] = response;
+                        this.isLoading = false;
+                        fixSelectedItems.call(this);
+                    },
+                );
             }
         } else {
             fixSelectedItems.call(this);

--- a/assets/js/app/editor/Components/Select.vue
+++ b/assets/js/app/editor/Components/Select.vue
@@ -78,7 +78,6 @@
 <script>
 import Multiselect from 'vue-multiselect';
 import $ from 'jquery';
-//import axios from 'axios';
 
 export default {
     name: 'EditorSelect',

--- a/src/Controller/Backend/Async/SelectOptionsController.php
+++ b/src/Controller/Backend/Async/SelectOptionsController.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Controller\Backend\Async;
+
+use Bolt\Configuration\Config;
+use Bolt\Twig\FieldExtension;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Annotation\Route;
+use Tightenco\Collect\Support\Collection;
+use Bolt\Cache\SelectOptionsCacher;
+
+/**
+ * @Security("is_granted('upload')")
+ */
+class SelectOptionsController extends AbstractController implements AsyncZoneInterface
+{
+    // use CsrfTrait;
+
+    /** @var Config */
+    private $config;
+
+    /** @var Request */
+    private $request;
+
+    /** @var FieldExtension */
+    private $fieldExtension;
+
+
+    public function __construct(Config              $config,
+                                RequestStack        $requestStack,
+                                SelectOptionsCacher $selectOptionsCacher)
+    {
+        $this->config = $config;
+        $this->request = $requestStack->getCurrentRequest();
+        $this->fieldExtension = $selectOptionsCacher;
+    }
+
+    /**
+     * Based on Bolt\Twig\FieldExtension.
+     *
+     * @Route("/select-options", name="bolt_async_select_options", methods={"GET"})
+     */
+    public function handleSelectOptions(Request $request): JsonResponse
+    {
+        // TODO: Need to get a field definition somewhere ...
+
+        [ $contentTypeSlug, $format ] = explode('/', $request->get('values'));
+
+        if (empty($maxAmount = $request->get('limit'))) {
+            $maxAmount = $this->config->get('general/maximum_listing_select', 200);
+        }
+
+        $order = $request->get('order');
+
+        $options = [];
+
+        // We need to add this as a 'dummy' option for when the user is allowed
+        // not to pick an option. This is needed, because otherwise the `select`
+        // would default to the one.
+        /*
+        if ($field->allowEmpty()) {
+            $options[] = [
+                'key' => '',
+                'value' => '',
+                'selected' => false,
+            ];
+        }
+        */
+
+        $params = [
+            'limit' => $maxAmount,
+            'order' => $order,
+        ];
+
+        $field = $this->fieldExtension->fieldFactory($request->get('name'));
+
+        $options = array_merge($options, $this->fieldExtension->selectOptionsHelper($contentTypeSlug, $params, $field, $format)); // is this part cached?
+
+        $response = new JsonResponse(new Collection($options));
+        /* -- This does NOT seem to work, we want to store responses so we won't DDOS ourselves.
+        $response->setCache([
+            'must_revalidate' => false,
+            'no_cache' => false,
+            'max_age'  => 36000,
+        ]);
+        */
+
+        return $response;
+    }
+
+
+}

--- a/src/Twig/FieldExtension.php
+++ b/src/Twig/FieldExtension.php
@@ -218,7 +218,6 @@ class FieldExtension extends AbstractExtension
             'values' => $field->getDefinition()->get('values'),
             'limit'  => $field->getDefinition()->get('limit', ''),
             'order'  => $field->getDefinition()->get('order', ''),
-
         ]);
     }
 
@@ -315,7 +314,6 @@ class FieldExtension extends AbstractExtension
         // If we use `cache/list_format`, delegate it to that Helper
         if ($this->config->get('general/caching/list_format')) {
             $options = $this->listFormatHelper->getSelect($contentTypeSlug, $params);
-//            dump($options);
             return $options;
         }
 
@@ -338,8 +336,6 @@ class FieldExtension extends AbstractExtension
                 $options[$key]["link_to_record_url"] = $this->router->generate('bolt_content_edit', ['id' => $record->getId()]);
             }
         }
-
-//        dump($options);
 
         return $options;
     }

--- a/src/Twig/FieldExtension.php
+++ b/src/Twig/FieldExtension.php
@@ -85,6 +85,7 @@ class FieldExtension extends AbstractExtension
             new TwigFunction('field_factory', [$this, 'fieldFactory']),
             new TwigFunction('list_templates', [$this, 'getListTemplates']),
             new TwigFunction('select_options', [$this, 'selectOptions']),
+            new TwigFunction('select_options_url', [$this, 'selectOptionsUrl']),
         ];
     }
 
@@ -208,6 +209,17 @@ class FieldExtension extends AbstractExtension
         }
 
         return new Collection($options);
+    }
+
+    public function selectOptionsUrl(Field\SelectField $field): String
+    {
+        return $this->router->generate('bolt_async_select_options', [
+            'name'   => $field->getDefinition()->get('name', ''),
+            'values' => $field->getDefinition()->get('values'),
+            'limit'  => $field->getDefinition()->get('limit', ''),
+            'order'  => $field->getDefinition()->get('order', ''),
+
+        ]);
     }
 
     public function selectOptions(Field $field): Collection

--- a/templates/_partials/fields/_base.html.twig
+++ b/templates/_partials/fields/_base.html.twig
@@ -160,4 +160,3 @@
 
 {{ separator|raw }}
 </div>
-

--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -13,6 +13,14 @@
     {% endif %}
 {% endblock %}
 
+{% set fetchUrl = '' %}
+{% if field is defined
+    and field.definition.get('values') is not iterable
+    and field.definition.get('lazy')|default(false) %}
+    {% set options = [] %}
+    {% set fetchUrl = select_options_url(field) %}
+{% endif %}
+
 {% if options is not defined %}
     {% set options = select_options(field) %}
 {% endif %}
@@ -43,5 +51,6 @@
         :readonly="{{ readonly|json_encode }}"
         :errormessage='{{ errormessage|json_encode }}'
         :required='{{ required|json_encode }}'
+        :fetchurl='{{ fetchUrl|json_encode }}'
     ></editor-select>
 {% endblock %}


### PR DESCRIPTION
### What this does

Allows the use of `lazy: true` for contenttype-queries on select fields. __Potentially__ useful on sites that have a lot of records that need to be processed before rendering the template/response. This is a proof-of-concept for now. I've chosen an opt-in method since this will be very niche, and we will have to see whether we get the gains, or not.

```diff
selected_pages:
    type: select
    label: "Select Pages"
    values: "pages/{contenttype} Nº{id}: {title} - {status}"
    autocomplete: true
    multiple: true
    limit: 1000
    variant: inline
+   lazy: true
```

### Issues

When components get initialized (mounted), they will each query the server for the list of options. This is to ensure that the selected values are properly selected and shown in the UI. The problem stems that they will do so simultaneously. After that the response will be stored in the cache.

- How to remake a proper Field instance from a bunch of strings?
- How to cache both client-side and server-side?
- What is the proper permission for the Async route?