### PR TITLE
Remove abs() deprecation warnings when compiling assets

### DIFF
--- a/assets/scss/init/_variables.scss
+++ b/assets/scss/init/_variables.scss
@@ -71,7 +71,6 @@ $headings-font-weight:          600;
 
 // Links
 $link-color:                $primary;
-$link-hover-color:          var(--primary-600);
 
 //buttons
 $btn-disabled-opacity:                  0.75;

--- a/assets/scss/init/_variables.scss
+++ b/assets/scss/init/_variables.scss
@@ -19,7 +19,10 @@ $bolt-blue: #255687; // Nice and bright, pretty light
 $bolt-bluegray: #2f3e4d; // Nice dark and desaturated
 $bolt-saturated: #003e7c; // Very saturated. Use with care
 
+$gray-200: #e9ecef; // Use default Bootstrap value for now
+
 $body-bg: $background;
+$body-secondary-bg:         $gray-200; // Use default Bootstrap value for now
 
 $theme-colors: (
   "primary":   $primary,
@@ -67,7 +70,7 @@ $font-weight-bold:              700;
 $headings-font-weight:          600;
 
 // Links
-$link-color:                var(--primary);
+$link-color:                $primary;
 $link-hover-color:          var(--primary-600);
 
 //buttons
@@ -139,6 +142,7 @@ $min-contrast-ratio:  4.5;
 
 $popover-header-padding-y:          0.5rem;
 $popover-header-padding-x:          0.75rem;
+$popover-header-bg:                 $body-secondary-bg;
 
 $popover-body-padding-y:            0.5rem;
 $popover-body-padding-x:            0.75rem;

--- a/assets/scss/vendor/bootstrap/bootstrap.scss
+++ b/assets/scss/vendor/bootstrap/bootstrap.scss
@@ -1,7 +1,7 @@
 //** Bootstrap
 @import "~bootstrap/scss/functions";
 @import "~bootstrap/scss/variables";
-//@import "~bootstrap/scss/variables-dark";
+@import "~bootstrap/scss/variables-dark";
 @import "~bootstrap/scss/maps";
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/root";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@vue/cli-service": "^4.5.19",
                 "axios": "^0.27.2",
                 "baguettebox.js": "^1.11.1",
-                "bootstrap": "5.2.*",
+                "bootstrap": "5.3.*",
                 "browserslist": "^4.21.4",
                 "clipboard": "^2.0.11",
                 "codemirror": "^5.65.9",
@@ -3877,9 +3877,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.38",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.38.tgz",
-            "integrity": "sha512-hXOtc0tuDHZPFwwhuBJXPbjemWtXnJjbvuuyNH2Y5Z6in+iXc63c4eXYDc7GGGqHy+iwYqAJMdaItqdnbcBKmg==",
+            "version": "4.17.39",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+            "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -5758,85 +5758,14 @@
                 "strip-ansi": "^6.0.0"
             }
         },
-        "node_modules/@vue/compiler-core": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.21.3",
-                "@vue/shared": "3.3.4",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.0.2"
-            }
-        },
-        "node_modules/@vue/compiler-core/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@vue/compiler-dom": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4"
-            }
-        },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-            "optional": true,
-            "peer": true,
+            "version": "2.7.14",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
+            "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
             "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/compiler-ssr": "3.3.4",
-                "@vue/reactivity-transform": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0",
-                "postcss": "^8.1.10",
-                "source-map-js": "^1.0.2"
-            }
-        },
-        "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
-            "version": "0.30.5",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-            "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@vue/compiler-ssr": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@vue/compiler-dom": "3.3.4",
-                "@vue/shared": "3.3.4"
+                "@babel/parser": "^7.18.4",
+                "postcss": "^8.4.14",
+                "source-map": "^0.6.1"
             }
         },
         "node_modules/@vue/component-compiler-utils": {
@@ -5908,47 +5837,6 @@
                 "html-webpack-plugin": ">=2.26.0",
                 "webpack": ">=4.0.0"
             }
-        },
-        "node_modules/@vue/reactivity-transform": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@vue/compiler-core": "3.3.4",
-                "@vue/shared": "3.3.4",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.0"
-            }
-        },
-        "node_modules/@vue/reactivity-transform/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@vue/reactivity-transform/node_modules/magic-string": {
-            "version": "0.30.5",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
-            "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@vue/test-utils": {
             "version": "1.3.6",
@@ -7659,9 +7547,9 @@
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
         },
         "node_modules/bootstrap": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
-            "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
             "funding": [
                 {
                     "type": "github",
@@ -7673,7 +7561,7 @@
                 }
             ],
             "peerDependencies": {
-                "@popperjs/core": "^2.11.6"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/brace-expansion": {
@@ -7986,12 +7874,13 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9211,9 +9100,9 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.0.tgz",
-            "integrity": "sha512-HoZr92+ZjFEKar5HS6MC776gYslNOKHt75mEBKWKnPeFDpZ6nH5OeF3S6HFT1mUAUZKrzkez05VboaX8myjSuw==",
+            "version": "3.33.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
+            "integrity": "sha512-qVSq3s+d4+GsqN0teRCJtM6tdEEXyWxjzbhVrCHmBS5ZTM0FS2MOS0D13dUXAWDUN6a+lHI/N1hF9Ytz6iLl9Q==",
             "dev": true,
             "hasInstallScript": true,
             "funding": {
@@ -9222,9 +9111,9 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.0.tgz",
-            "integrity": "sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==",
+            "version": "3.33.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.1.tgz",
+            "integrity": "sha512-6pYKNOgD/j/bkC5xS5IIg6bncid3rfrI42oBH1SQJbsmYPKF7rhzcFzYCcxYMmNQQ0rCEB8WqpW7QHndOggaeQ==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.22.1"
@@ -9235,9 +9124,9 @@
             }
         },
         "node_modules/core-js-pure": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.0.tgz",
-            "integrity": "sha512-FKSIDtJnds/YFIEaZ4HszRX7hkxGpNKM7FC9aJ9WLJbSd3lD4vOltFuVIBLR8asSx9frkTSqL0dw90SKQxgKrg==",
+            "version": "3.33.1",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.33.1.tgz",
+            "integrity": "sha512-wCXGbLjnsP10PlK/thHSQlOLlLKNEkaWbTzVvHHZ79fZNeN1gUmw2gBlpItxPv/pvqldevEXFh/d5stdNvl6EQ==",
             "dev": true,
             "hasInstallScript": true,
             "funding": {
@@ -11613,9 +11502,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.559",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.559.tgz",
-            "integrity": "sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug=="
+            "version": "1.4.561",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.561.tgz",
+            "integrity": "sha512-eS5t4ulWOBfVHdq9SW2dxEaFarj1lPjvJ8PaYMOjY0DecBaj/t4ARziL2IPpDr4atyWwjLFGQ2vo/VCgQFezVQ=="
         },
         "node_modules/elliptic": {
             "version": "6.5.4",
@@ -19635,9 +19524,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.0.tgz",
-            "integrity": "sha512-HQ4J+ic8hKrgIt3mqk6cVOVrW2ozL4KdvHlqpBv9vDYWx9ysAgENAdvy4FoGF+KFdhR7nQTNm5J0ctAeOwn+3g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -24981,6 +24870,20 @@
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
         },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/set-function-name": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
@@ -25567,9 +25470,9 @@
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
         "node_modules/sshpk": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
-            "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
             "dependencies": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -28441,16 +28344,6 @@
                 "vue": "^2.0.0"
             }
         },
-        "node_modules/vue/node_modules/@vue/compiler-sfc": {
-            "version": "2.7.14",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-            "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
-            "dependencies": {
-                "@babel/parser": "^7.18.4",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
-            }
-        },
         "node_modules/vuedraggable": {
             "version": "2.24.3",
             "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
@@ -29745,12 +29638,12 @@
             "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-tostringtag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@vue/cli-service": "^4.5.19",
         "axios": "^0.27.2",
         "baguettebox.js": "^1.11.1",
-        "bootstrap": "5.2.*",
+        "bootstrap": "5.3.*",
         "browserslist": "^4.21.4",
         "clipboard": "^2.0.11",
         "codemirror": "^5.65.9",


### PR DESCRIPTION
This PR adds the following changes: 

- Updates Bootstrap to v5.3.2 which fixes compilation warnings as stated in their tag release https://github.com/twbs/bootstrap/releases/tag/v5.3.2
- Adds some new variables with Bootstrap default values (This is necessary to prevent Node Sass to compile using CSS variables, which is impossible and breaks the compilation)
- Remove unused variables
