### PR TITLE
Set limit per relation and select field option

### DIFF
--- a/templates/_partials/fields/select.html.twig
+++ b/templates/_partials/fields/select.html.twig
@@ -33,8 +33,9 @@
 	{% set autocomplete = field.definition.get('autocomplete')|default ? 'true' : 'false' %}
 {% endif %}
 
-{% if limit is not defined %}
-	{% set limit = field.definition.get('limit')|default(2000) %}
+{% set limit = config.get('general/maximum_listing_select', 2000) %}
+{% if field.definition.get('limit') is defined and field.definition.get('limit') is not empty %}
+    {% set limit = field.definition.get('limit') %}
 {% endif %}
 
 {% block field %}

--- a/templates/content/_relationships.html.twig
+++ b/templates/content/_relationships.html.twig
@@ -6,9 +6,10 @@
 
     {% set options = related_options(fromContentType, toContentTypeSlug, relation.order|default(), relation.format|default(), relation.required, relation.allow_empty, relation.link_to_record|default(false), ) %}
     {% set value = record|related_values(toContentTypeSlug) %}
+    {% set limit = config.get('general/maximum_listing_select', 2000) %}
 
-    {% if limit is not defined %}
-        {% set limit = relation.get('limit')|default(2000) %}
+    {% if relation.get('limit') is defined and relation.get('limit') is not empty %}
+        {% set limit = relation.get('limit') %}
     {% endif %}
 
     <div class="mb-4">
@@ -26,14 +27,14 @@
 
         <div>
             <editor-select
-                    :value="{{ value }}"
-                    :name="'relationship[{{ toContentTypeSlug }}]'"
-                    :id="'relationship-{{ toContentTypeSlug }}'"
-                    :options="{{ options }}"
-                    :optionslimit="{{ limit }}"
-                    :multiple="{{ relation.multiple ? 'true' : 'false' }}"
-                    :taggable=false
-                    :autocomplete=true
+                :value="{{ value }}"
+                :name="'relationship[{{ toContentTypeSlug }}]'"
+                :id="'relationship-{{ toContentTypeSlug }}'"
+                :options="{{ options }}"
+                :optionslimit="{{ limit }}"
+                :multiple="{{ relation.multiple ? 'true' : 'false' }}"
+                :taggable=false
+                :autocomplete=true
             ></editor-select>
         </div>
 


### PR DESCRIPTION
This PR adds a fix for a bug introduced on PR #3477(Allow setting a limit for the options displayed in relationships selects)

The limit option is now set to the general config option `maximum_listing_select` or 2000 by default.

If a relation or select field has the `limit` option defined, the limit will be set to the value of that option.
