### PR TITLE
Handle incorrect parameters gracefully

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -143,7 +143,7 @@ class ImageController
         $raw = explode('×', preg_replace('/([0-9])(x)([0-9a-z])/i', '\1×\3', $paramString));
 
         $this->parameters = [
-            'w' => (isset($raw[0] && is_numeric($raw[0])) ? (int) $raw[0] : 400,
+            'w' => (isset($raw[0]) && is_numeric($raw[0])) ? (int) $raw[0] : 400,
             'h' => (isset($raw[1]) && is_numeric($raw[1])) ? (int) $raw[1] : 300,
             'fit' => isset($raw[2]) ? $raw[2] : $this->config->get('general/thumbnails/default_cropping', 'default'),
             'location' => 'files',

--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -143,8 +143,8 @@ class ImageController
         $raw = explode('×', preg_replace('/([0-9])(x)([0-9a-z])/i', '\1×\3', $paramString));
 
         $this->parameters = [
-            'w' => is_numeric($raw[0]) ? (int) $raw[0] : 400,
-            'h' => is_numeric($raw[1]) ? (int) $raw[1] : 300,
+            'w' => (isset($raw[0] && is_numeric($raw[0])) ? (int) $raw[0] : 400,
+            'h' => (isset($raw[1]) && is_numeric($raw[1])) ? (int) $raw[1] : 300,
             'fit' => isset($raw[2]) ? $raw[2] : $this->config->get('general/thumbnails/default_cropping', 'default'),
             'location' => 'files',
             'q' => (!empty($raw[2]) && 0 <= $raw[2] && $raw[2] <= 100) ? (int) $raw[2] : 80


### PR DESCRIPTION
Solves a `Warning: Undefined array key 1` notice.

Some clients do not understand how to use UTF-8, and execute a request to for example `/thumbs/400%C3%83%C2%97400%C3%83%C2%97contain/news`, which contains `Ã` instead of the expected `×`. I do not know why `%83%C2` is inserted in the URL (it is some sort of Python based external scanner...), but I do believe this code should be robust enough to not throw a warning when this happens. With this change the raw parameters are checked for existence before being used, allowing for a sane fallback.

I do not believe the CI failures are related to this change.