### PR TITLE
Set explicit doctrine/lexer version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "doctrine/doctrine-migrations-bundle": "^3.2",
+        "doctrine/lexer": "^2",
         "doctrine/orm": "^2.10",
         "drupol/composer-packages": "^2.0",
         "embed/embed": "^3.4",


### PR DESCRIPTION
Bolt v5 is not compatible with `doctrine/lexer` v3 which introduces a breaking change: the `token` is now an object of class `Doctrine\Common\Lexer\Token` and not an array anymore. A normal `composer update` in a Bolt CMS based project may now generate an error: `Cannot use object of type Doctrine\Common\Lexer\Token as array`. The error goes away if `doctrine/lexer` v2 is explicitly required.

On a separate PR I will propose an actual fix. This is about setting the dependency in Bolt CMS own `composer.json`.
