### PR TITLE
Add doctrine/lexer v3 compatibility

### DIFF
--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -52,7 +52,7 @@ class Cast extends FunctionNode
         $this->first = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_AS);
         $parser->match(Lexer::T_IDENTIFIER);
-        $this->second = $parser->getLexer()->token['value'];
+        $this->second = $parser->getLexer()->token->value;
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }


### PR DESCRIPTION
Using the token as Token object is compatible with both v2 and v3 of doctrine/lexer