### PR TITLE
:arrow_up: Add dependencies replace - issue #3551

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,6 +146,17 @@
             "spec\\Bolt\\": "tests/spec/Bolt/"
         }
     },
+    "replace": {
+        "symfony/polyfill-php81": "*",
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php74": "*",
+        "symfony/polyfill-php73": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php55": "*",
+        "symfony/polyfill-php54": "*"
+    },
     "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {

--- a/symfony.lock
+++ b/symfony.lock
@@ -723,18 +723,6 @@
     "symfony/polyfill-mbstring": {
         "version": "v1.14.0"
     },
-    "symfony/polyfill-php72": {
-        "version": "v1.14.0"
-    },
-    "symfony/polyfill-php73": {
-        "version": "v1.14.0"
-    },
-    "symfony/polyfill-php80": {
-        "version": "v1.17.0"
-    },
-    "symfony/polyfill-php81": {
-        "version": "v1.23.0"
-    },
     "symfony/process": {
         "version": "v4.4.4"
     },


### PR DESCRIPTION
The replace section allows the removal of unnecessary dependencies like polyfill.

All polyfill for PHP before the current PHP minimal version must be added in the `replace` section.

See issue #3551