### PR TITLE
:arrow_up: remove unused coduo/php-matcher dependency - issue #3551

### DIFF
--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -40,12 +40,15 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Install composer dependencies
               run: composer install --prefer-dist --no-progress
+            - name: Initialise folders
+              run: sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
+            - name: create the database
+              run: ./bin/console doctrine:database:create
+              if: ${{ startsWith('sqlite', matrix.database) }}
             - name: Initialise the database
-              run: |
-                  sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
-                  ./bin/console doctrine:database:create
-                  ./bin/console doctrine:schema:create
-                  symfony server:start --no-tls --port=8088 -d
+              run: ./bin/console doctrine:schema:create
+            - name: Starting server
+              run: symfony server:start --no-tls --port=8088 -d
             - name: create api user
               run: php bin/console bolt:add-user apiuser apiuser%1 api@example.org API --roles=ROLE_WEBSERVICE
             - name: check API user gets content

--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -37,3 +37,9 @@ jobs:
               run: curl -fkI -u apiuser:apiuser%1 http://localhost:8088/api/fields
             - name: check API user gets relations
               run: curl -fkI -u apiuser:apiuser%1 http://localhost:8088/api/relations
+            - uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                 name: logs
+                 path: var/log
+

--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -28,6 +28,7 @@ jobs:
                   sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
                   ./bin/console doctrine:database:create
                   ./bin/console doctrine:schema:create
+                  ./bin/console doctrine:fixtures:load -n
                   symfony server:start --no-tls --port=8088 -d
             - name: create api user
               run: php bin/console bolt:add-user apiuser apiuser%1 api@example.org API --roles=ROLE_WEBSERVICE

--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -8,8 +8,25 @@ jobs:
         strategy:
             matrix:
                 php-version: [ '8.1', '8.2', '8.3', '8.4' ]
+                database:
+                    - 'sqlite:///%kernel.project_dir%/var/data/bolt.sqlite'
+                    - 'mysql://bolt:bolt@127.0.0.1/bolt?serverVersion=5.7&charset=utf8mb4'
         name: curl tests
+        services:
+            mysql:
+                image: mysql:5.7
+                ports:
+                    - "3306:3306"
+                env:
+                    MYSQL_DATABASE: bolt
+                    MYSQL_USER: bolt
+                    MYSQL_PASSWORD: bolt
+                    MYSQL_ROOT_PASSWORD: bolt
+                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+                
         runs-on: ubuntu-latest
+        env:
+            DATABASE_URL: ${{matrix.database}}
         steps:
             - uses: actions/checkout@v4
             - uses: shivammathur/setup-php@v2

--- a/.github/workflows/api_tests.yaml
+++ b/.github/workflows/api_tests.yaml
@@ -28,7 +28,6 @@ jobs:
                   sudo chmod -R 777 config/ public/files/ public/theme/ public/thumbs/ var/
                   ./bin/console doctrine:database:create
                   ./bin/console doctrine:schema:create
-                  ./bin/console doctrine:fixtures:load -n
                   symfony server:start --no-tls --port=8088 -d
             - name: create api user
               run: php bin/console bolt:add-user apiuser apiuser%1 api@example.org API --roles=ROLE_WEBSERVICE
@@ -38,9 +37,3 @@ jobs:
               run: curl -fkI -u apiuser:apiuser%1 http://localhost:8088/api/fields
             - name: check API user gets relations
               run: curl -fkI -u apiuser:apiuser%1 http://localhost:8088/api/relations
-            - uses: actions/upload-artifact@v4
-              if: failure()
-              with:
-                 name: logs
-                 path: var/log
-

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
         "bobdenotter/configuration-notices": "^1.2",
         "bobdenotter/weatherwidget": "^1.1",
         "bolt/newswidget": "^1.3",
-        "coduo/php-matcher": "^5.0",
         "dama/doctrine-test-bundle": "^6.6.0",
         "nyholm/psr7": "^1.4",
         "ondram/ci-detector": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "doctrine/doctrine-migrations-bundle": "^3.2",
+        "doctrine/lexer": "^2 || ^3",
         "doctrine/orm": "^2.10",
         "drupol/composer-packages": "^2.0",
         "embed/embed": "^3.4",

--- a/src/Api/Extensions/ContentExtension.php
+++ b/src/Api/Extensions/ContentExtension.php
@@ -34,8 +34,12 @@ final class ContentExtension implements QueryCollectionExtensionInterface, Query
         })->values();
     }
 
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?string $operationName = null): void
-    {
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?string $operationName = null
+    ): void {
         /*
          * Note: We're not distinguishing between `viewless` and `viewless_listing` here. In the
          * context of the API it makes no sense to say "You can get a list, but not the details"
@@ -51,8 +55,14 @@ final class ContentExtension implements QueryCollectionExtensionInterface, Query
         }
     }
 
-    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, ?string $operationName = null, array $context = []): void
-    {
+    public function applyToItem(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        array $identifiers,
+        ?string $operationName = null,
+        array $context = []
+    ): void {
         if ($resourceClass === Content::class) {
             $this->filterUnpublishedViewlessContent($queryBuilder);
         }
@@ -78,7 +88,10 @@ final class ContentExtension implements QueryCollectionExtensionInterface, Query
     private function filterUnpublishedViewlessFields(QueryBuilder $queryBuilder): void
     {
         $rootAlias = $queryBuilder->getRootAliases()[0];
-        $queryBuilder->join($rootAlias . '.content', 'c', Join::WITH, 'c.status = :status');
+
+        $queryBuilder->join($rootAlias . '.content', 'c');
+        $queryBuilder->andWhere('c.status = :status');
+
         $queryBuilder->setParameter('status', Statuses::PUBLISHED);
 
         //todo: Fix this when https://github.com/doctrine/orm/issues/3835 closed.

--- a/src/Doctrine/Functions/Rand.php
+++ b/src/Doctrine/Functions/Rand.php
@@ -33,7 +33,7 @@ class Rand extends FunctionNode
         $parser->match(Lexer::T_IDENTIFIER);
         $parser->match(Lexer::T_OPEN_PARENTHESIS);
 
-        if ($lexer->lookahead['type'] !== Lexer::T_CLOSE_PARENTHESIS) {
+        if ($lexer->lookahead->type !== Lexer::T_CLOSE_PARENTHESIS) {
             $this->expression = $parser->SimpleArithmeticExpression();
         }
 

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -30,19 +30,19 @@ class Cast extends FunctionNode
             // alternatively, test if true: $this->first->dispatch($sqlWalker)==='b2_.value',
             // b4_.value for /bolt/new/showcases
             if ($this->first->dispatch($sqlWalker) === 'b2_.value' ||
-                 $this->first->dispatch($sqlWalker) === 'b4_.value') {
+                $this->first->dispatch($sqlWalker) === 'b4_.value') {
                 return $this->first->dispatch($sqlWalker);
             }
         }
 
-        if (! mb_strpos($backend_driver, 'sqlite') && $this->second === 'TEXT') {
+        if (!mb_strpos($backend_driver, 'sqlite') && $this->second === 'TEXT') {
             $this->second = 'CHAR';
         }
 
         return sprintf('CAST(%s AS %s)',
             $this->first->dispatch($sqlWalker),
             $this->second
-            );
+        );
     }
 
     public function parse(Parser $parser): void
@@ -52,7 +52,7 @@ class Cast extends FunctionNode
         $this->first = $parser->ArithmeticPrimary();
         $parser->match(Lexer::T_AS);
         $parser->match(Lexer::T_IDENTIFIER);
-        $this->second = $parser->getLexer()->token['value'];
+        $this->second = $parser->getLexer()->token->value;
         $parser->match(Lexer::T_CLOSE_PARENTHESIS);
     }
 }

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -80,7 +80,7 @@ class Field implements FieldInterface, TranslatableInterface
     private $version;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields", fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields")
      * @ORM\JoinColumn(nullable=false)
      * @Groups("api_write")
      */

--- a/src/Entity/Field.php
+++ b/src/Entity/Field.php
@@ -80,7 +80,7 @@ class Field implements FieldInterface, TranslatableInterface
     private $version;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields")
+     * @ORM\ManyToOne(targetEntity="Bolt\Entity\Content", inversedBy="fields", fetch="EAGER")
      * @ORM\JoinColumn(nullable=false)
      * @Groups("api_write")
      */

--- a/symfony.lock
+++ b/symfony.lock
@@ -46,12 +46,6 @@
     "cocur/slugify": {
         "version": "v4.0.0"
     },
-    "coduo/php-matcher": {
-        "version": "4.0.0"
-    },
-    "coduo/php-to-string": {
-        "version": "3.0.0"
-    },
     "composer/ca-bundle": {
         "version": "1.2.6"
     },

--- a/templates/pages/about.html.twig
+++ b/templates/pages/about.html.twig
@@ -80,7 +80,6 @@
         <li><a href="https://phpunit.de/" target="_blank">PHPUnit</a>.</li>
         <li><a href="http://www.phpspec.net/en/stable/" target="_blank">phpspec</a>.</li>
         <li><a href="https://www.cypress.io/" target="_blank">Cypress</a>.</li>
-        <li><a href="https://github.com/coduo/php-matcher" target="_blank">PHP Matcher</a>.</li>
         <li><a href="https://github.com/phpstan/phpstan" target="_blank">PHP Stan</a>.</li>
         <li><a href="https://github.com/Symplify/EasyCodingStandard" target="_blank">Easy Coding Standard</a>.</li>
         <li><a href="https://blackfire.io/" target="_blank">Blackfire</a>.</li>


### PR DESCRIPTION
The development dependency `coduo/php-matcher` is not used in code and lock the `doctrine/orm` update.

See issue #3551 