### PR TITLE
:heavy_minus_sign: Remove Loco adapter for translation

### DIFF
--- a/.env
+++ b/.env
@@ -57,7 +57,3 @@ MAILER_DSN=smtp://localhost
 # for Docker:
 # MAILER_DSN=smtp://mailcatcher:1025
 ###< symfony/mailer ###
-
-###> php-translation/loco-adapter ###
-LOCO_PROJECT_API_KEY=
-###< php-translation/loco-adapter ###

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,6 @@
         "php-http/discovery": "^1.14",
         "php-http/httplug-bundle": "^1.19",
         "php-http/message": "^1.12",
-        "php-translation/loco-adapter": "^0.11",
         "phpstan/phpstan": "^1.2.0",
         "phpstan/phpstan-doctrine": "^1.0",
         "phpstan/phpstan-symfony": "^1.0.1",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -21,6 +21,5 @@ return [
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
     Translation\Bundle\TranslationBundle::class => ['all' => true],
-    Translation\PlatformAdapter\Loco\Bridge\Symfony\TranslationAdapterLocoBundle::class => ['dev' => true, 'local' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
 ];

--- a/config/packages/dev/translation.yaml
+++ b/config/packages/dev/translation.yaml
@@ -2,14 +2,3 @@
 translation:
     symfony_profiler:
         enabled: true
-    configs:
-        bolt:
-            remote_storage: ["php_translation.adapter.loco"]
-
-# php_translation_adapter_loco_adapter
-translation_adapter_loco:
-    index_parameter: 'id' # 'text' or 'name'. Leave blank for "auto"  See https://localise.biz/api/docs/export/exportlocale
-    projects:
-        bolt:
-            api_key: '%env(LOCO_PROJECT_API_KEY)%'
-            domains: ['messages']

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,11 +22,6 @@
         <!-- ###+ nelmio/cors-bundle ### -->
         <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
         <!-- ###- nelmio/cors-bundle ### -->
-
-        <!-- ###+ php-translation/loco-adapter ### -->
-        <env name="LOCO_PROJECT_API_KEY" value=""/>
-        <!-- ###- php-translation/loco-adapter ### -->
-
         <!-- ###+ symfony/mailer ### -->
         <!-- MAILER_DSN=smtp://localhost -->
         <!-- ###- symfony/mailer ### -->

--- a/symfony.lock
+++ b/symfony.lock
@@ -194,9 +194,6 @@
     "fakerphp/faker": {
         "version": "v1.10.1"
     },
-    "friendsofapi/localise.biz": {
-        "version": "1.0.1"
-    },
     "friendsofphp/proxy-manager-lts": {
         "version": "v1.0.3"
     },
@@ -332,9 +329,6 @@
     "php-http/message-factory": {
         "version": "v1.0.2"
     },
-    "php-http/multipart-stream-builder": {
-        "version": "1.1.0"
-    },
     "php-http/promise": {
         "version": "v1.0.0"
     },
@@ -346,18 +340,6 @@
     },
     "php-translation/extractor": {
         "version": "2.0.1"
-    },
-    "php-translation/loco-adapter": {
-        "version": "0.8",
-        "recipe": {
-            "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
-            "version": "0.8",
-            "ref": "c97545d1c229338606d881294eceeb4cdc993777"
-        },
-        "files": [
-            "config/packages/php_translation_loco_adapter.yaml"
-        ]
     },
     "php-translation/symfony-bundle": {
         "version": "0.10",


### PR DESCRIPTION
Remove loco dependency because it's not compatible with PHP 8.4 and Symfony 7.

Nobody has access to the used account. You have account access, contact us on slack: https://slack.bolt.cm/