### PR TITLE
:bug: Does not redirect ot login if url start by /bolt...

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -58,5 +58,5 @@ security:
         - { path: '^/(%app_locales%)%bolt.backend_url%/api', roles: ADMIN_API_ACCESS } # handled by voter
         - { path: '^%bolt.backend_url%/_trans', roles: ADMIN_TRANSLATE_ACCESS } # handled by voter
         - { path: '^/(%app_locales%)%bolt.backend_url%/_trans', roles: ADMIN_TRANSLATE_ACCESS } # handled by voter
-        - { path: '^%bolt.backend_url%', roles: IS_AUTHENTICATED_REMEMBERED }
-        - { path: '^/(%app_locales%)%bolt.backend_url%', roles: IS_AUTHENTICATED_REMEMBERED }
+        - { path: '^%bolt.backend_url%($|/)', roles: IS_AUTHENTICATED_REMEMBERED }
+        - { path: '^/(%app_locales%)%bolt.backend_url%($|/)', roles: IS_AUTHENTICATED_REMEMBERED }


### PR DESCRIPTION
Issue #3504 Fix the security side effect on URL start with `/bolt`.

* `/bolt$` is secured and redirect on login if need. :lock:
* `/bolt/new/page` is secured and redirect on login if need. :lock: 
* `/bolt-and-nuts` Not secured. :unlock: 
