### PR TITLE
Fix CAST query function for MariaDB platform

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -4070,12 +4070,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Storage/SelectQuery.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Possibly invalid array key type int\\|string\\|null\\.$#',
-	'identifier' => 'array.invalidKey',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Storage/SelectQuery.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Bolt\\\\Storage\\\\SelectQuery\\:\\:\\$coreDateFields type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
@@ -4558,12 +4552,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^PHPDoc tag @var for variable \\$definition contains generic class Illuminate\\\\Support\\\\Collection but does not specify its types\\: TKey, TValue$#',
 	'identifier' => 'missingType.generics',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Twig/FieldExtension.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Possibly invalid array key type int\\|null\\.$#',
-	'identifier' => 'offsetAccess.invalidOffset',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Twig/FieldExtension.php',
 ];
@@ -5312,12 +5300,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Utils/TranslationsManager.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Possibly invalid array key type int\\|null\\.$#',
-	'identifier' => 'offsetAccess.invalidOffset',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Utils/TranslationsManager.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Property Bolt\\\\Utils\\\\TranslationsManager\\:\\:\\$translations type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
@@ -5363,12 +5345,6 @@ $ignoreErrors[] = [
 	'message' => '#^Method Bolt\\\\Validator\\\\ContentValidator\\:\\:relationsToMap\\(\\) return type has no value type specified in iterable type list\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
-	'path' => __DIR__ . '/src/Validator/ContentValidator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Possibly invalid array key type string\\|null\\.$#',
-	'identifier' => 'offsetAccess.invalidOffset',
-	'count' => 3,
 	'path' => __DIR__ . '/src/Validator/ContentValidator.php',
 ];
 $ignoreErrors[] = [

--- a/src/Controller/Backend/Async/EmbedController.php
+++ b/src/Controller/Backend/Async/EmbedController.php
@@ -9,7 +9,6 @@ use Embed\Embed as EmbedFactory;
 use Psr\Http\Client\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
@@ -19,13 +18,6 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class EmbedController implements AsyncZoneInterface
 {
     use CsrfTrait;
-
-    private ?Request $request;
-
-    public function __construct(RequestStack $requestStack)
-    {
-        $this->request = $requestStack->getCurrentRequest();
-    }
 
     #[Route(path: '/embed', name: 'bolt_async_embed', methods: [Request::METHOD_POST])]
     public function fetchEmbed(Request $request): JsonResponse
@@ -41,7 +33,7 @@ class EmbedController implements AsyncZoneInterface
         }
 
         try {
-            $url = $this->request?->request->getString('url') ?? '';
+            $url = $request->request->getString('url') ?? '';
             $info = (new EmbedFactory())->get($url);
             $oembed = $info->getOEmbed();
 

--- a/src/Controller/Backend/Async/FileListingController.php
+++ b/src/Controller/Backend/Async/FileListingController.php
@@ -11,32 +11,28 @@ use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 class FileListingController implements AsyncZoneInterface
 {
-    private readonly ?Request $request;
     private readonly string $publicPath;
 
     public function __construct(
         private readonly Config $config,
-        RequestStack $requestStack,
         private readonly Security $security,
         string $projectDir,
         string $publicFolder,
         private readonly FilesIndex $filesIndex
     ) {
-        $this->request = $requestStack->getCurrentRequest();
         $this->publicPath = $projectDir . DIRECTORY_SEPARATOR . $publicFolder;
     }
 
     #[Route(path: '/list_files', name: 'bolt_async_filelisting', methods: [Request::METHOD_GET])]
-    public function index(): JsonResponse
+    public function index(Request $request): JsonResponse
     {
-        $locationName = $this->request?->query->getString('location', 'files') ?? 'files';
-        $type = $this->request?->query->getString('type') ?? '';
+        $locationName = $request->query->getString('location', 'files') ?? 'files';
+        $type = $request->query->getString('type') ?? '';
         $locationTopLevel = explode('/', Path::canonicalize($locationName))[0];
 
         if (! $this->security->isGranted('list_files:' . $locationTopLevel)) {
@@ -51,7 +47,7 @@ class FileListingController implements AsyncZoneInterface
         // Do not allow any path outside of the public directory.
         $path = PathCanonicalize::canonicalize($this->publicPath, $relativeLocation);
         $baseFilePath = PathCanonicalize::canonicalize($this->publicPath, $relativeTopLocation);
-        $baseUrlPath = $this->request?->getPathInfo() ?? '';
+        $baseUrlPath = $request->getPathInfo();
         $relativePath = Path::makeRelative($path, $this->publicPath);
 
         $files = $this->filesIndex->get($relativePath, $type, $baseUrlPath, $baseFilePath);

--- a/src/Controller/Backend/Async/UploadController.php
+++ b/src/Controller/Backend/Async/UploadController.php
@@ -15,12 +15,10 @@ use Sirius\Upload\Handler;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
-use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\FileBag;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
@@ -35,18 +33,14 @@ class UploadController extends AbstractController implements AsyncZoneInterface
 {
     use CsrfTrait;
 
-    private ?Request $request;
-
     public function __construct(
         private MediaFactory $mediaFactory,
         private EntityManagerInterface $em,
         private Config $config,
         private TextExtension $textExtension,
-        RequestStack $requestStack,
         private Filesystem $filesystem,
         private TagAwareCacheInterface $cache
     ) {
-        $this->request = $requestStack->getCurrentRequest();
     }
 
     #[Route(path: '/upload-url', name: 'bolt_async_upload_url', methods: [Request::METHOD_POST])]
@@ -116,8 +110,8 @@ class UploadController extends AbstractController implements AsyncZoneInterface
             ], Response::HTTP_FORBIDDEN);
         }
 
-        $locationName = $this->request?->query->getString('location') ?? '';
-        $path = $this->request?->query->getString('path') ?? '';
+        $locationName = $request->query->getString('location') ?? '';
+        $path = $request->query->getString('path') ?? '';
 
         $basepath = $this->config->getPath($locationName);
         $target = $this->config->getPath($locationName, true, $path);

--- a/src/Controller/Backend/BulkOperationsController.php
+++ b/src/Controller/Backend/BulkOperationsController.php
@@ -12,7 +12,6 @@ use Doctrine\Persistence\ObjectManager;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -25,14 +24,11 @@ class BulkOperationsController extends AbstractController implements BackendZone
     use CsrfTrait;
 
     private ?ObjectManager $em = null;
-    private ?Request $request;
 
     public function __construct(
-        RequestStack $requestStack,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly ManagerRegistry $managerRegistry
     ) {
-        $this->request = $requestStack->getCurrentRequest();
     }
 
     public function em(): ObjectManager
@@ -44,7 +40,7 @@ class BulkOperationsController extends AbstractController implements BackendZone
     public function status(Request $request, string $status): Response
     {
         $this->validateCsrf($request, 'batch');
-        $formData = $this->request?->request->getString('records') ?? '';
+        $formData = $request->request->getString('records') ?? '';
         $recordIds = array_map(intval(...), explode(',', $formData));
 
         $records = $this->findRecordsFromIds($recordIds);
@@ -57,7 +53,7 @@ class BulkOperationsController extends AbstractController implements BackendZone
         $this->em()->flush();
 
         $this->addFlash('success', 'content.status_changed_successfully');
-        $url = $this->request?->headers->get('referer') ?? $this->generateUrl('bolt_dashboard');
+        $url = $request->headers->get('referer') ?? $this->generateUrl('bolt_dashboard');
 
         return new RedirectResponse($url);
     }
@@ -66,7 +62,7 @@ class BulkOperationsController extends AbstractController implements BackendZone
     public function delete(Request $request): Response
     {
         $this->validateCsrf($request, 'batch');
-        $formData = $this->request?->request->getString('records') ?? '';
+        $formData = $request->request->getString('records') ?? '';
         $recordIds = array_map(intval(...), explode(',', $formData));
 
         $record = null;
@@ -84,7 +80,7 @@ class BulkOperationsController extends AbstractController implements BackendZone
         $this->em()->flush();
 
         $this->addFlash('success', 'content.deleted_successfully');
-        $url = $this->request?->headers->get('referer') ?? $this->generateUrl('bolt_dashboard');
+        $url = $request->headers->get('referer') ?? $this->generateUrl('bolt_dashboard');
 
         return new RedirectResponse($url);
     }

--- a/src/Controller/Backend/FilemanagerController.php
+++ b/src/Controller/Backend/FilemanagerController.php
@@ -19,7 +19,6 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
@@ -33,7 +32,6 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
     public function __construct(
         private FileLocations $fileLocations,
         private MediaRepository $mediaRepository,
-        protected RequestStack $requestStack,
         private Filesystem $filesystem
     ) {
     }
@@ -41,7 +39,7 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
     #[Route(path: '/filemanager/{location}', name: 'bolt_filemanager', methods: [Request::METHOD_GET])]
     public function filemanager(Request $request, string $location): Response
     {
-        $session = $this->requestStack->getSession();
+        $session = $request->getSession();
 
         $this->denyAccessUnlessGranted('managefiles:' . $location);
 

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Doctrine\Query;
 
-use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
@@ -23,7 +23,7 @@ class Cast extends FunctionNode
         $platform = $sqlWalker->getConnection()->getDatabasePlatform();
 
         // test if we are using MySQL
-        if ($platform instanceof MySQLPlatform) {
+        if ($platform instanceof AbstractMySQLPlatform) {
             // YES we are using MySQL
             // how do we know what type $this->first is? For now hardcoding
             // type(t.value) = JSON for MySQL. JSONB for others.


### PR DESCRIPTION
Was changed from 

```
if (mb_strpos($backend_driver, 'mysql') !== false) {
```

to an instance of, but the one used did not include MariaDB. With this change it does.