### PR TITLE
Bump minimum twig version to 3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ Make sure to check the [upgrade notes](https://github.com/bolt/core/blob/main/UP
 - `doctrine/data-fixtures` now requires `^2.0`. A version constraint was not specified in a earlier version of Bolt, but we were only compatible with v1.
 - Support for `doctrine/lexer` `^2` has been dropped.
 - `doctrine/dbal` now required `^4.0`.
-- `doctrine/orm` now requires `^3.5`
+- `doctrine/orm` now requires `^3.5`.
 - `doctrine/doctrine-fixtures-bundle` now requires `^4.3`.
-- Support for `symfony/flex` v1 was dropped
+- Support for `symfony/flex` v1 was dropped.
+- `twig/twig` now requires `^3.21`.
 
 ### Other noteworthy updates
 - We've enabled login throttling by default.

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
         "twig/extra-bundle": "^3.3",
         "twig/html-extra": "^3.3",
         "twig/intl-extra": "^3.3",
-        "twig/twig": "^3.3",
+        "twig/twig": "^3.21",
         "ua-parser/uap-php": "^3.9",
         "webimpress/safe-writer": "^2.1",
         "webonyx/graphql-php": "^15.0",


### PR DESCRIPTION
With 3bbb001900d06abc223322d76623eeac79b0d557 we updated the code to no longer use deprecated calls, but the update requires at least twig 3.21.