### PR TITLE
Register controller services

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2708,12 +2708,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Event/Subscriber/AuthSubscriber.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Property Bolt\\\\Event\\\\Subscriber\\\\ExtensionSubscriber\\:\\:\\$objects type has no value type specified in iterable type array\\.$#',
-	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Event/Subscriber/ExtensionSubscriber.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Call to an undefined method object\\:\\:executeUpdate\\(\\)\\.$#',
 	'identifier' => 'method.notFound',
 	'count' => 2,

--- a/src/Event/Subscriber/ExtensionSubscriber.php
+++ b/src/Event/Subscriber/ExtensionSubscriber.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Bolt\Event\Subscriber;
 
+use Bolt\Extension\ExtensionController;
 use Bolt\Extension\ExtensionRegistry;
 use Bolt\Storage\Query;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -18,35 +18,49 @@ class ExtensionSubscriber implements EventSubscriberInterface
 {
     public const PRIORITY = 0;
 
-    private array $objects = [];
-
     public function __construct(
-        ContainerInterface $container,
+        private readonly ContainerInterface $container,
         private readonly ExtensionRegistry $extensionRegistry,
-        EntityManagerInterface $objectManager,
-        Query $query
+        private readonly EntityManagerInterface $objectManager,
+        private readonly Query $query
     ) {
-        $this->objects = [
-            'manager' => $objectManager,
-            'container' => $container,
-            'query' => $query,
-        ];
     }
 
     /**
      * Kernel response listener callback.
      */
-    public function onKernelResponse(ControllerEvent $event): void
+    public function onKernelController(ControllerEvent $event): void
     {
-        $this->extensionRegistry->initializeAll($this->objects);
+        $this->extensionRegistry->initializeAll([
+            'manager' => $this->objectManager,
+            'container' => $this->container,
+            'query' => $this->query,
+        ]);
+
+        $controller = $event->getController();
+        if (is_array($controller)) {
+            // method access
+            $controller = $controller[0];
+        }
+
+        if ($controller instanceof ExtensionController) {
+            $controller->injectObjects([
+                'manager' => $this->objectManager,
+                'query' => $this->query,
+            ]);
+        }
     }
 
     /**
      * Command response listener callback.
      */
-    public function onConsoleResponse(ConsoleCommandEvent $event): void
+    public function onConsoleCommand(): void
     {
-        $this->extensionRegistry->initializeAll($this->objects, true);
+        $this->extensionRegistry->initializeAll([
+            'manager' => $this->objectManager,
+            'container' => $this->container,
+            'query' => $this->query,
+        ], true);
     }
 
     /**
@@ -55,8 +69,8 @@ class ExtensionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::CONTROLLER => [['onKernelResponse', self::PRIORITY]],
-            ConsoleEvents::COMMAND => [['onConsoleResponse', self::PRIORITY]],
+            KernelEvents::CONTROLLER => [['onKernelController', self::PRIORITY]],
+            ConsoleEvents::COMMAND => [['onConsoleCommand', self::PRIORITY]],
         ];
     }
 }

--- a/src/Extension/ServicesTrait.php
+++ b/src/Extension/ServicesTrait.php
@@ -43,8 +43,11 @@ trait ServicesTrait
     public function injectObjects(array $objects): void
     {
         $this->entityManager = $objects['manager'];
-        $this->container = $objects['container'];
         $this->query = $objects['query'];
+
+        if (! $this->container && $container = $objects['container'] ?? null) {
+            $this->container = $container;
+        }
     }
 
     /**


### PR DESCRIPTION
Extension controller should use the `ExtensionController` base class, which uses the `ServicesTrait`. However, those services were not populated correctly. This PR fixes that.