### PR TITLE
Fix ImageController filename

### DIFF
--- a/src/Controller/ImageController.php
+++ b/src/Controller/ImageController.php
@@ -35,7 +35,7 @@ class ImageController
         }
 
         try {
-            $filename = PathCanonicalize::canonicalize($this->getPath($request), $filename);
+            PathCanonicalize::canonicalize($this->getPath($request), $filename);
         } catch (Exception) {
             return $this->sendErrorImage();
         }


### PR DESCRIPTION
The filename here does not need to be updated as it will be the full path filename, instead of the relative path filename.

For more information, this bug was explained on Bolt's Slack.