### PR TITLE
Fix: null author locale when saving new content

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1148,12 +1148,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Controller/Backend/ContentEditController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot call method getLocale\\(\\) on Bolt\\\\Entity\\\\User\\|null\\.$#',
-	'identifier' => 'method.nonObject',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controller/Backend/ContentEditController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Bolt\\\\Controller\\\\Backend\\\\ContentEditController\\:\\:getFieldToUpdate\\(\\) has parameter \\$fieldDefinition with no type specified\\.$#',
 	'identifier' => 'missingType.parameter',
 	'count' => 1,

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -181,10 +181,9 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $event = new ContentEvent($content);
         $this->dispatcher->dispatch($event, ContentEvent::POST_SAVE);
 
-        $locale = $originalAuthor ? $originalAuthor->getLocale() : $request->getLocale();
-
         // If we're "Saving Ajaxy"
         if ($request->isXmlHttpRequest()) {
+            $locale = $originalAuthor ? $originalAuthor->getLocale() : $request->getLocale();
             $modified = sprintf(
                 '(%s: %s)',
                 $this->translator->trans('field.modifiedAt', [], null, $locale),

--- a/src/Controller/Backend/ContentEditController.php
+++ b/src/Controller/Backend/ContentEditController.php
@@ -181,7 +181,7 @@ class ContentEditController extends TwigAwareController implements BackendZoneIn
         $event = new ContentEvent($content);
         $this->dispatcher->dispatch($event, ContentEvent::POST_SAVE);
 
-        $locale = $originalAuthor->getLocale();
+        $locale = $originalAuthor ? $originalAuthor->getLocale() : $request->getLocale();
 
         // If we're "Saving Ajaxy"
         if ($request->isXmlHttpRequest()) {


### PR DESCRIPTION
## Summary

- Fix fatal error `Call to a member function getLocale() on null` when saving a **new** content record in the backend
- When `$originalContent` is null (new record), `$originalAuthor` is null — falls back to `$request->getLocale()` instead of crashing

Fixes #3696

## Test plan

- [ ] Create a new content record of any content type
- [ ] Fill in required fields and click Save
- [ ] Verify it saves without 500 error
- [ ] Verify editing an existing record still works correctly