### PR TITLE
Do not allow erusev/parsedown to fix failing cypress tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/orm": "^3.5",
         "drupol/composer-packages": "^2.0",
         "embed/embed": "^4.4",
-        "erusev/parsedown": "^1.7",
+        "erusev/parsedown": "<1.8.0",
         "erusev/parsedown-extra": "^0.8.1",
         "fakerphp/faker": "^1.16",
         "illuminate/collections": "^12.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/orm": "^3.5",
         "drupol/composer-packages": "^2.0",
         "embed/embed": "^4.4",
-        "erusev/parsedown": "<1.8.0",
+        "erusev/parsedown": "^1.7,<1.8.0",
         "erusev/parsedown-extra": "^0.8.1",
         "fakerphp/faker": "^1.16",
         "illuminate/collections": "^12.0",


### PR DESCRIPTION
The latest version is not compatible with `erusev/parsedown-extra`, causing internal server errors during the cypress tests.

The newest version will be made available later.