### PR TITLE
 Fix MySQL CAST AS TEXT regression

### DIFF
--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -34,7 +34,7 @@ class Cast extends FunctionNode
             }
         }
 
-        if ($platform instanceof AbstractMySQLPlatform && $this->second === 'TEXT') {
+        if (! $platform instanceof SQLitePlatform && $this->second === 'TEXT') {
             $this->second = 'CHAR';
         }
 

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -35,7 +35,7 @@ class Cast extends FunctionNode
             }
         }
 
-        if ($platform instanceof SQLitePlatform && $this->second === 'TEXT') {
+        if ($platform instanceof AbstractMySQLPlatform && $this->second === 'TEXT') {
             $this->second = 'CHAR';
         }
 

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Bolt\Doctrine\Query;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Doctrine\Query;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;


### PR DESCRIPTION
With MySQL/MariaDB orderby failed.

### A test have been replaced for bolt 6 :
```php        
  // Before (Bolt 5 / pre-DBAL v4) — correct:
  // TEXT→CHAR for everything EXCEPT SQLite → MySQL gets CHAR ✓                                                                                 
  if (! mb_strpos($backend_driver, 'sqlite') && $this->second === 'TEXT') {
      $this->second = 'CHAR';                                                                                                                   
  }                                                                                                                                           
                                                                                                                                                
  // After (Bolt 6.1.x) — regression:                                                                                                         
  // TEXT→CHAR ONLY for SQLite → MySQL gets TEXT ✗
  if ($platform instanceof SQLitePlatform && $this->second === 'TEXT') {                                                                        
      $this->second = 'CHAR';
  }                                                                                                                                             
  ```        

### to reproduce the bug:
**Create the content type**
```yaml   
  products:
      name: Products                                                                                                                            
      singular_name: Product
      title_format: "{title}-{subtitle}"                                                                                                        
      fields:                                                                                                                                 
          title:
              type: text
          subtitle:                                                                                                                             
              type: text
  ```                 

**in a twig file** 
 ```twig                                                                                                                                       
  {% setcontent allProducts = 'products' limit 200 orderby 'title' %}                                                                         
  {{ allProducts|length }}                                                                                                                      
  ```

**you should have the error** 
Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TEXT)), LOWER(value_21) FROM (SELECT b0_.id AS id_0, b0_.content_type AS content' at line 1") 