### PR TITLE
Mysql - Fix field trait item types

### DIFF
--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -35,7 +35,7 @@ class Cast extends FunctionNode
             }
         }
 
-        if ($platform instanceof SQLitePlatform && $this->second === 'TEXT') {
+        if ($platform instanceof AbstractMySQLPlatform && $this->second === 'TEXT') {
             $this->second = 'CHAR';
         }
 

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Bolt\Doctrine\Query;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;

--- a/src/Doctrine/Query/Cast.php
+++ b/src/Doctrine/Query/Cast.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bolt\Doctrine\Query;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\ORM\Query\AST\Functions\FunctionNode;
 use Doctrine\ORM\Query\AST\Node;
 use Doctrine\ORM\Query\Parser;

--- a/src/Entity/FieldParentTrait.php
+++ b/src/Entity/FieldParentTrait.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
  */
 trait FieldParentTrait
 {
-    /** @var array<Field|string> */
+    /** @var array<Field|string|int> */
     private array $fields = [];
 
     abstract public function getContent(): ?Content;

--- a/src/Entity/IterableFieldTrait.php
+++ b/src/Entity/IterableFieldTrait.php
@@ -8,7 +8,7 @@ trait IterableFieldTrait
 {
     private int $iteratorCursor = 0;
 
-    /** @var array<Field|string> */
+    /** @var array<Field|string|int> */
     private array $fields = [];
 
     /**
@@ -29,7 +29,7 @@ trait IterableFieldTrait
         return $this->count();
     }
 
-    public function current(): Field|string
+    public function current(): Field|string|int
     {
         return $this->fields[$this->iteratorCursor];
     }


### PR DESCRIPTION
 Iterating over a select field on MySQL throws a fatal error

On SQLite, JSON is decoded as strings → current() returns string → no error.                                                                                                                                                                   
On MySQL, JSON integers are decoded as PHP int → current() returns int 
   → type error against the declared Field|string return type.                                                                                                           

### To reproduce    
**Content type**
````
homepage:
    name: Homepage
    singular_name: Homepage
    fields:
        related_entry:
            type: select
            values: entries/{title}
````    
**Twig**  
{{dump(record.related_entry)}}

**Error**
An exception has been thrown during the rendering of a template ("Bolt\Entity\Field\SelectField::current(): Return value must be of type Bolt\Entity\Field|string, int returned") in index.twig at line 10.