### PR TITLE
Prevent user to create/delete folder/files anywhere

### DIFF
--- a/src/Controller/Backend/FilemanagerController.php
+++ b/src/Controller/Backend/FilemanagerController.php
@@ -96,11 +96,15 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
         $path = $this->getFromRequest($request, 'path');
         $location = $this->getFromRequest($request, 'location');
 
+        if (! is_string($path)) {
+            throw new \RuntimeException('Invalid filename');
+        }
+
         $this->denyAccessUnlessGranted('managefiles:' . $location);
 
         $location = $this->fileLocations->get($location);
 
-        $folder = Path::canonicalize($location->getBasepath() . '/' . $path);
+        $folder = PathCanonicalize::canonicalize($location->getBasepath(), $path);
 
         if (! $this->filesystem->exists($folder)) {
             $this->addFlash('warning', 'filemanager.delete_folder_missing');
@@ -139,7 +143,7 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
 
         $location = $this->fileLocations->get($location);
 
-        $folder = Path::canonicalize($location->getBasepath() . '/' . $path);
+        $folder = PathCanonicalize::canonicalize($location->getBasepath(), $path);
 
         if ($this->filesystem->exists($folder)) {
             $this->addFlash('warning', 'filemanager.create_folder_already_exists');

--- a/src/Controller/Backend/FilemanagerController.php
+++ b/src/Controller/Backend/FilemanagerController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bolt\Controller\Backend;
 
+use RuntimeException;
 use Bolt\Common\Str;
 use Bolt\Configuration\FileLocations;
 use Bolt\Controller\CsrfTrait;
@@ -97,7 +98,7 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
         $location = $this->getFromRequest($request, 'location');
 
         if (! is_string($path)) {
-            throw new \RuntimeException('Invalid filename');
+            throw new RuntimeException('Invalid filename');
         }
 
         $this->denyAccessUnlessGranted('managefiles:' . $location);

--- a/src/Controller/Backend/FilemanagerController.php
+++ b/src/Controller/Backend/FilemanagerController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Bolt\Controller\Backend;
 
-use RuntimeException;
 use Bolt\Common\Str;
 use Bolt\Configuration\FileLocations;
 use Bolt\Controller\CsrfTrait;
@@ -21,6 +20,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 
@@ -98,7 +98,7 @@ class FilemanagerController extends TwigAwareController implements BackendZoneIn
         $location = $this->getFromRequest($request, 'location');
 
         if (! is_string($path)) {
-            throw new RuntimeException('Invalid filename');
+            throw new BadRequestHttpException('Invalid filename');
         }
 
         $this->denyAccessUnlessGranted('managefiles:' . $location);


### PR DESCRIPTION
 An authenticated user with managefiles permission could supply a path parameter (e.g.    
  /../../src) to delete a directories anywhere on the filesystem that the web process can write to.
  
 - Replace Path::canonicalize() with the project's own PathCanonicalize::canonicalize() in the delete() and create() methods of FilemanagerController