### PR TITLE
Propagate current locale to custom 404/403/500 error pages

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1424,12 +1424,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Controller/Frontend/ListingController.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method Bolt\\\\Controller\\\\Frontend\\\\ListingController\\:\\:listing\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\Response but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\|null\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controller/Frontend/ListingController.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Bolt\\\\Controller\\\\Frontend\\\\ListingController\\:\\:parseQueryParams\\(\\) return type has no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,
@@ -1510,12 +1504,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method Bolt\\\\Controller\\\\TwigAwareController\\:\\:renderSingle\\(\\) has parameter \\$templates with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/src/Controller/TwigAwareController.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method Bolt\\\\Controller\\\\TwigAwareController\\:\\:renderSingle\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\Response but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\|null\\.$#',
-	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/src/Controller/TwigAwareController.php',
 ];

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -21,6 +21,8 @@ use Symfony\Component\HttpKernel\Controller\ErrorController as SymfonyErrorContr
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
 use Twig\Environment;
 use Twig\Error\LoaderError;
@@ -37,9 +39,16 @@ class ErrorController extends SymfonyErrorController implements ErrorZoneInterfa
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly Security $security,
         private readonly RequestStack $requestStack,
+        private readonly TranslatorInterface $translator,
+        string $locales,
     ) {
         parent::__construct($httpKernel, $this->templateController, $errorRenderer);
+
+        $this->localeCodes = explode('|', $locales);
     }
+
+    /** @var list<string> */
+    private readonly array $localeCodes;
 
     /**
      * Show an exception. Mainly used for custom 404 pages, otherwise falls back
@@ -61,6 +70,11 @@ class ErrorController extends SymfonyErrorController implements ErrorZoneInterfa
 
         // We need the parent request here, but fall back to current if not found
         if ($request = $this->requestStack->getParentRequest() ?? $this->requestStack->getCurrentRequest()) {
+            // On a 404/403, no route matched, so Symfony's LocaleListener never set
+            // the locale from the URL. Recover it from the path so localized error
+            // pages (and their records) render in the right language.
+            $this->setLocaleFromPath($request);
+
             if ($code === Response::HTTP_SERVICE_UNAVAILABLE || $this->isMaintenanceEnabled($code)) {
                 $twig->addGlobal('exception', $exception);
 
@@ -156,6 +170,41 @@ class ErrorController extends SymfonyErrorController implements ErrorZoneInterfa
         return filter_var($this->config->get('general/maintenance_mode', false), FILTER_VALIDATE_BOOLEAN);
     }
 
+    /**
+     * Sets the locale based on the first segment of the path, if it matches one
+     * of the configured locales (e.g. `/de/...` => `de`).
+     *
+     * The locale is applied to both the given request (used when rendering a
+     * record) and the current request (which Twig's `app.request` resolves to,
+     * and is a sub-request when an error page is being rendered). It's also set on
+     * the translator, so `{% trans %}` strings in the error template are localized
+     * too - normally Symfony's `LocaleListener`/`LocaleAwareListener` does this,
+     * but neither runs when no route matched.
+     */
+    private function setLocaleFromPath(Request $request): void
+    {
+        // Cast: on PHP 8.4 `mb_trim()` is analysed as `string|false`, but `getPathInfo()`
+        // always yields a string, so the result is effectively always a string here.
+        $segment = explode('/', (string) mb_trim($request->getPathInfo(), '/'))[0];
+
+        if ($segment === '' || ! in_array($segment, $this->localeCodes, true)) {
+            return;
+        }
+
+        $request->setLocale($segment);
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        if ($currentRequest instanceof Request && $currentRequest !== $request) {
+            $currentRequest->setLocale($segment);
+        }
+
+        // The concrete translator is locale-aware; the contracts interface we depend
+        // on isn't, so guard the call to keep the dependency narrow.
+        if ($this->translator instanceof LocaleAwareInterface) {
+            $this->translator->setLocale($segment);
+        }
+    }
+
     private function attemptToRender(Request $request, string $item): ?Response
     {
         // First, see if it's a contenttype/slug pair:
@@ -165,7 +214,9 @@ class ErrorController extends SymfonyErrorController implements ErrorZoneInterfa
             // We wrap it in a try/catch, because we wouldn't want to
             // trigger a 404 within a 404 now, would we?
             try {
-                return $this->detailController->record($request, $slug, $contentType, false, null);
+                // Pass the request's locale explicitly, so `DetailController` keeps
+                // it instead of falling back to the default locale.
+                return $this->detailController->record($request, $slug, $contentType, false, $request->getLocale());
             } catch (NotFoundHttpException) {
                 // Just continue to the next one.
             }

--- a/src/Controller/ErrorController.php
+++ b/src/Controller/ErrorController.php
@@ -187,21 +187,21 @@ class ErrorController extends SymfonyErrorController implements ErrorZoneInterfa
         // always yields a string, so the result is effectively always a string here.
         $segment = explode('/', (string) mb_trim($request->getPathInfo(), '/'))[0];
 
-        if ($segment === '' || ! in_array($segment, $this->localeCodes, true)) {
-            return;
-        }
+        if ($segment !== '' && in_array($segment, $this->localeCodes, true)) {
+            $request->setLocale($segment);
 
-        $request->setLocale($segment);
-
-        $currentRequest = $this->requestStack->getCurrentRequest();
-        if ($currentRequest instanceof Request && $currentRequest !== $request) {
-            $currentRequest->setLocale($segment);
+            $currentRequest = $this->requestStack->getCurrentRequest();
+            if ($currentRequest instanceof Request && $currentRequest !== $request) {
+                $currentRequest->setLocale($segment);
+            }
         }
 
         // The concrete translator is locale-aware; the contracts interface we depend
-        // on isn't, so guard the call to keep the dependency narrow.
+        // on isn't, so guard the call to keep the dependency narrow. Always sync it to
+        // the (possibly default) request locale so a previous request's locale can't
+        // leak into a default-locale error page in long-running runtimes.
         if ($this->translator instanceof LocaleAwareInterface) {
-            $this->translator->setLocale($segment);
+            $this->translator->setLocale($request->getLocale());
         }
     }
 

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -44,9 +44,12 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
             throw new NotFoundHttpException('Content is not viewable');
         }
 
-        // If the locale is the wrong locale
-        if (! $this->validLocaleForContentType($request, $contentType)) {
-            return $this->redirectToDefaultLocale($request);
+        // If the locale is the wrong locale, redirect to the default locale, or -
+        // when that's not possible (e.g. a forwarded request without a matched
+        // route) - render the listing in the default locale.
+        if (! $this->validLocaleForContentType($request, $contentType)
+            && ($redirect = $this->redirectToDefaultLocaleOrFallback($request)) instanceof Response) {
+            return $redirect;
         }
 
         $page = (int) $this->getFromRequest($request, 'page', '1');

--- a/src/Controller/TwigAwareController.php
+++ b/src/Controller/TwigAwareController.php
@@ -113,9 +113,11 @@ class TwigAwareController extends AbstractController
             throw new NotFoundHttpException('Content is not viewable');
         }
 
-        // If the locale is the wrong locale
-        if (! $this->validLocaleForContentType($request, $recordDefinition)) {
-            return $this->redirectToDefaultLocale($request);
+        // If the locale is the wrong locale, redirect to the default locale, or -
+        // when that's not possible - render the record in the default locale.
+        if (! $this->validLocaleForContentType($request, $recordDefinition)
+            && ($redirect = $this->redirectToDefaultLocaleOrFallback($request)) instanceof Response) {
+            return $redirect;
         }
 
         $singularSlug = $record->getContentTypeSingularSlug();
@@ -145,8 +147,41 @@ class TwigAwareController extends AbstractController
         return $request->getLocale() === $this->defaultLocale;
     }
 
+    /**
+     * Either redirect to the same route in the default locale, or - when there's
+     * no route to redirect to (e.g. a forwarded request, or an error page where
+     * routing never matched) - reset the request to the default locale and return
+     * `null`, so the caller can render in the default locale instead.
+     *
+     * Note: this resets the locale on the _given_ request only. When rendering an
+     * error page, Twig's `app.request` is a sub-request whose locale was set
+     * separately (see ErrorController::setLocaleFromPath()), so the `<html lang>`
+     * may still reflect the URL locale while the - non-localizable - record content
+     * is rendered in the default locale. That's harmless: such content is identical
+     * across locales.
+     */
+    protected function redirectToDefaultLocaleOrFallback(Request $request): ?Response
+    {
+        $redirect = $this->redirectToDefaultLocale($request);
+
+        if ($redirect instanceof Response) {
+            return $redirect;
+        }
+
+        $request->setLocale($this->defaultLocale);
+
+        return null;
+    }
+
     protected function redirectToDefaultLocale(Request $request): ?Response
     {
+        // No route was matched (e.g. on an error page): there's nothing to
+        // redirect to, so let the caller decide how to handle this.
+        $route = $request->attributes->get('_route');
+        if (! $route) {
+            return null;
+        }
+
         $request->getSession()->set('_locale', $this->defaultLocale);
 
         $params = $request->attributes->get('_route_params');
@@ -155,7 +190,7 @@ class TwigAwareController extends AbstractController
             $params['_locale'] = $this->defaultLocale;
         }
 
-        return $this->redirectToRoute($request->get('_route'), $params);
+        return $this->redirectToRoute($route, $params);
     }
 
     private function setTwigLoader(): void

--- a/tests/php/Controller/Frontend/ErrorControllerTest.php
+++ b/tests/php/Controller/Frontend/ErrorControllerTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Controller\Frontend;
+
+use Bolt\Configuration\Config;
+use Bolt\Controller\ErrorController;
+use Bolt\Entity\Content;
+use Bolt\Enum\Statuses;
+use Bolt\Tests\DbAwareTestCase;
+use Bolt\Widget\Injector\RequestZone;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Throwable;
+use Twig\Environment;
+
+class ErrorControllerTest extends DbAwareTestCase
+{
+    private const HEADING_EN = 'Not-found-heading-in-English';
+    private const HEADING_NL = 'Niet-gevonden-kop-in-het-Nederlands';
+
+    protected function setUp(): void
+    {
+        // The test environment has no `canonical` configured, which makes the
+        // CanonicalSubscriber choke on frontend requests. Provide a value so we
+        // can exercise the full frontend request/response cycle.
+        putenv('BOLT_CANONICAL=http://localhost');
+        $_SERVER['BOLT_CANONICAL'] = 'http://localhost';
+        $_ENV['BOLT_CANONICAL'] = 'http://localhost';
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('BOLT_CANONICAL');
+        unset($_SERVER['BOLT_CANONICAL'], $_ENV['BOLT_CANONICAL']);
+
+        parent::tearDown();
+    }
+
+    public function testNotFoundRecordRendersLocalizedFieldInRequestedLocale(): void
+    {
+        $this->seedLocalizedNotFoundPage();
+
+        $this->client->request('GET', '/nl/this-page-does-not-exist');
+        $response = $this->client->getResponse();
+        $body = (string) $response->getContent();
+
+        self::assertSame(404, $response->getStatusCode());
+        // `htmllang()` (rendered as `<html lang="...">`) reflects the current locale.
+        self::assertStringContainsString('<html lang="nl"', $body);
+        // The localized `heading` field is rendered in Dutch, not English.
+        self::assertStringContainsString(self::HEADING_NL, $body);
+        self::assertStringNotContainsString(self::HEADING_EN, $body);
+    }
+
+    public function testNotFoundRecordRendersLocalizedFieldInDefaultLocale(): void
+    {
+        $this->seedLocalizedNotFoundPage();
+
+        $this->client->request('GET', '/this-page-does-not-exist');
+        $response = $this->client->getResponse();
+        $body = (string) $response->getContent();
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('<html lang="en"', $body);
+        self::assertStringContainsString(self::HEADING_EN, $body);
+        self::assertStringNotContainsString(self::HEADING_NL, $body);
+    }
+
+    public function testForbiddenRecordRendersLocalizedFieldInRequestedLocale(): void
+    {
+        $page = $this->seedLocalizedPage();
+        $this->setGeneralConfig('forbidden', ['page/' . $page->getId()]);
+
+        // A frontend 403 doesn't arise from a routed request in the test app (all
+        // `access_control` rules are backend, and the backend 403 path redirects to
+        // the dashboard rather than rendering the custom page). So we drive the
+        // configured `error_controller` directly, exactly as Symfony's error
+        // handling does, with the URL whose locale should be recovered. A 403
+        // `AccessDeniedHttpException` routes to `showForbidden()`, which renders the
+        // configured `general/forbidden` page (set above to our localized record).
+        //
+        // Note: `showAction()` returns the rendered page as a plain 200; promoting
+        // the status to the exception's 403 is the kernel's job (see
+        // HttpKernel::handleThrowable()), which we bypass here. So we assert the
+        // locale handling that *is* this controller's responsibility, not the code.
+        $response = $this->renderError(new AccessDeniedHttpException(), '/nl/this-page-is-forbidden');
+        $body = (string) $response->getContent();
+
+        // `htmllang()` (rendered as `<html lang="...">`) reflects the current locale.
+        self::assertStringContainsString('<html lang="nl"', $body);
+        // The localized `heading` field is rendered in Dutch, not English. (Its mere
+        // presence also proves the *forbidden* page rendered: only `general/forbidden`
+        // points at this record - the default `notfound` renders a different block.)
+        self::assertStringContainsString(self::HEADING_NL, $body);
+        self::assertStringNotContainsString(self::HEADING_EN, $body);
+    }
+
+    public function testErrorPageRecoversTranslatorLocaleFromPath(): void
+    {
+        // When no route matches, Symfony's LocaleListener/LocaleAwareListener never
+        // run, so the translator keeps its default locale and `{% trans %}` strings
+        // in the error page render in the wrong language. The error controller must
+        // recover the locale from the path onto the (shared) translator too.
+        $page = $this->seedLocalizedPage();
+        $this->setGeneralConfig('notfound', ['page/' . $page->getId()]);
+
+        $this->renderError(new NotFoundHttpException(), '/nl/this-page-does-not-exist');
+
+        /** @var TranslatorInterface $translator */
+        $translator = self::getContainer()->get('translator');
+        self::assertSame('nl', $translator->getLocale());
+    }
+
+    public function testNotFoundPageWithNonLocalizedContentTypeDoesNotError(): void
+    {
+        // The default `notfound` points at `blocks/404-not-found`. The `blocks`
+        // ContentType is *not* localized, so the requested `nl` locale can't be
+        // honored for the record. This must not error (regression: it used to
+        // attempt an invalid redirect, throwing a TypeError); instead it renders
+        // the not-found record.
+        $this->client->request('GET', '/nl/this-page-does-not-exist');
+        $response = $this->client->getResponse();
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('404 Page not found', (string) $response->getContent());
+    }
+
+    /**
+     * Point the 404 page at a published, localized `pages` record with distinct
+     * `heading` values per locale.
+     */
+    private function seedLocalizedNotFoundPage(): void
+    {
+        $page = $this->seedLocalizedPage();
+
+        $this->setGeneralConfig('notfound', ['page/' . $page->getId()]);
+    }
+
+    /**
+     * Give a published `pages` record distinct `heading` values per locale.
+     */
+    private function seedLocalizedPage(): Content
+    {
+        $page = $this->getPublishedPage();
+
+        $page->setFieldValue('heading', self::HEADING_EN, 'en');
+        $page->setFieldValue('heading', self::HEADING_NL, 'nl');
+        $page->getField('heading')->mergeNewTranslations();
+        $this->getEm()->flush();
+
+        return $page;
+    }
+
+    /**
+     * Invoke the configured `error_controller` directly, the way Symfony's error
+     * handling does, with a frontend request for the given path on the stack so
+     * the locale can be recovered from it.
+     */
+    private function renderError(Throwable $exception, string $path): Response
+    {
+        $request = Request::create('http://localhost' . $path);
+        RequestZone::setToRequest($request, RequestZone::FRONTEND);
+
+        /** @var RequestStack $requestStack */
+        $requestStack = self::getContainer()->get(RequestStack::class);
+        $requestStack->push($request);
+
+        /** @var ErrorController $errorController */
+        $errorController = self::getContainer()->get(ErrorController::class);
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        return $errorController->showAction($twig, $exception);
+    }
+
+    private function getPublishedPage(): Content
+    {
+        $page = $this->getEm()->getRepository(Content::class)
+            ->findOneBy(['contentType' => 'pages', 'status' => Statuses::PUBLISHED]);
+
+        self::assertInstanceOf(Content::class, $page, 'Expected a published "pages" record in the fixtures.');
+
+        return $page;
+    }
+
+    /**
+     * Override a `general/*` configuration value at runtime.
+     *
+     * @param array<string> $value
+     */
+    private function setGeneralConfig(string $key, array $value): void
+    {
+        $config = self::getContainer()->get(Config::class);
+
+        // Mutate only the `general` collection in place; rebuilding the whole data
+        // tree would turn `contenttypes` into plain collections and break typing.
+        $property = new \ReflectionProperty(Config::class, 'data');
+        $property->getValue($config)->get('general')->put($key, $value);
+    }
+}

--- a/tests/php/Controller/Frontend/ErrorControllerTest.php
+++ b/tests/php/Controller/Frontend/ErrorControllerTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Throwable;
 use Twig\Environment;
+use Twig\Loader\ChainLoader;
+use Twig\Loader\FilesystemLoader;
 
 class ErrorControllerTest extends DbAwareTestCase
 {
@@ -119,6 +121,34 @@ class ErrorControllerTest extends DbAwareTestCase
         self::assertSame('nl', $translator->getLocale());
     }
 
+    public function testErrorPageTranslatesUnderscoreFunctionInRequestedLocale(): void
+    {
+        // End-to-end: a `{{ __('...') }}` string in the rendered error page must be
+        // translated in the locale recovered from the URL. `http_error.name` is
+        // "Error %status_code%" (en) / "Fout %status_code%" (nl).
+        $this->registerFixtureTemplatePath();
+        $this->setGeneralConfig('notfound', ['locale_probe.html.twig']);
+
+        $body = (string) $this->renderError(new NotFoundHttpException(), '/nl/this-page-does-not-exist')->getContent();
+
+        self::assertStringContainsString('LOCALE_PROBE:Fout 404', $body);
+        self::assertStringNotContainsString('Error 404', $body);
+    }
+
+    public function testErrorPageTranslatesUnderscoreFunctionInDefaultLocale(): void
+    {
+        // The counterpart of the test above: with no locale segment in the URL, the
+        // same `__()` string must fall back to the default locale (en) - and must not
+        // leak a previous request's locale onto the shared translator.
+        $this->registerFixtureTemplatePath();
+        $this->setGeneralConfig('notfound', ['locale_probe.html.twig']);
+
+        $body = (string) $this->renderError(new NotFoundHttpException(), '/this-page-does-not-exist')->getContent();
+
+        self::assertStringContainsString('LOCALE_PROBE:Error 404', $body);
+        self::assertStringNotContainsString('Fout 404', $body);
+    }
+
     public function testNotFoundPageWithNonLocalizedContentTypeDoesNotError(): void
     {
         // The default `notfound` points at `blocks/404-not-found`. The `blocks`
@@ -183,6 +213,31 @@ class ErrorControllerTest extends DbAwareTestCase
         } finally {
             $requestStack->pop();
         }
+    }
+
+    /**
+     * Make the `Fixtures/` directory resolvable by name, so a fixture template can be
+     * pointed at via the `notfound` config. Mirrors how Bolt prepends paths to the
+     * existing filesystem loader (see TwigAwareController::setTwigLoader()) rather than
+     * replacing it, so the added path survives rendering.
+     */
+    private function registerFixtureTemplatePath(): void
+    {
+        /** @var Environment $twig */
+        $twig = self::getContainer()->get('twig');
+
+        $loader = $twig->getLoader();
+        $loaders = $loader instanceof ChainLoader ? $loader->getLoaders() : [$loader];
+
+        foreach ($loaders as $candidate) {
+            if ($candidate instanceof FilesystemLoader) {
+                $candidate->addPath(__DIR__ . '/Fixtures');
+
+                return;
+            }
+        }
+
+        self::fail('Could not find a FilesystemLoader to register the fixture template path on.');
     }
 
     private function getPublishedPage(): Content

--- a/tests/php/Controller/Frontend/ErrorControllerTest.php
+++ b/tests/php/Controller/Frontend/ErrorControllerTest.php
@@ -173,12 +173,16 @@ class ErrorControllerTest extends DbAwareTestCase
         $requestStack = self::getContainer()->get(RequestStack::class);
         $requestStack->push($request);
 
-        /** @var ErrorController $errorController */
-        $errorController = self::getContainer()->get(ErrorController::class);
-        /** @var Environment $twig */
-        $twig = self::getContainer()->get('twig');
+        try {
+            /** @var ErrorController $errorController */
+            $errorController = self::getContainer()->get(ErrorController::class);
+            /** @var Environment $twig */
+            $twig = self::getContainer()->get('twig');
 
-        return $errorController->showAction($twig, $exception);
+            return $errorController->showAction($twig, $exception);
+        } finally {
+            $requestStack->pop();
+        }
     }
 
     private function getPublishedPage(): Content

--- a/tests/php/Controller/Frontend/Fixtures/locale_probe.html.twig
+++ b/tests/php/Controller/Frontend/Fixtures/locale_probe.html.twig
@@ -1,0 +1,4 @@
+{# Test fixture for ErrorControllerTest: renders a `__()` string so the test can
+   assert error pages translate via the translator locale recovered from the URL.
+   `http_error.name` is "Error %status_code%" (en) / "Fout %status_code%" (nl). #}
+LOCALE_PROBE:{{ __('http_error.name', {'%status_code%': 404}) }}

--- a/tests/php/Controller/Frontend/ListingControllerTest.php
+++ b/tests/php/Controller/Frontend/ListingControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Controller\Frontend;
+
+use Bolt\Configuration\Config;
+use Bolt\Tests\DbAwareTestCase;
+
+class ListingControllerTest extends DbAwareTestCase
+{
+    protected function setUp(): void
+    {
+        // The test environment has no `canonical` configured, which makes the
+        // CanonicalSubscriber choke on frontend requests. Provide a value so we
+        // can exercise the full frontend request/response cycle.
+        putenv('BOLT_CANONICAL=http://localhost');
+        $_SERVER['BOLT_CANONICAL'] = 'http://localhost';
+        $_ENV['BOLT_CANONICAL'] = 'http://localhost';
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('BOLT_CANONICAL');
+        unset($_SERVER['BOLT_CANONICAL'], $_ENV['BOLT_CANONICAL']);
+
+        parent::tearDown();
+    }
+
+    /**
+     * When a listing is reached via a matched route but with a locale that the
+     * ContentType doesn't support, it redirects to the default locale.
+     * (The `if ($redirect instanceof Response) { return $redirect; }` branch.)
+     */
+    public function testListingRedirectsToDefaultLocaleWhenLocaleNotSupported(): void
+    {
+        // `pages` is localized to en/nl/ja/nb, so `fr` is a valid app-locale but
+        // not valid for this ContentType.
+        $this->client->request('GET', '/fr/pages');
+        $response = $this->client->getResponse();
+
+        self::assertSame(302, $response->getStatusCode());
+        self::assertStringContainsString('/en/pages', (string) $response->headers->get('Location'));
+    }
+
+    /**
+     * When a listing is reached *without* a matched route (a forwarded request,
+     * e.g. the homepage rendered as a listing) and the locale isn't supported,
+     * there's no route to redirect to — so it must fall back to rendering in the
+     * default locale instead of erroring. (The fallback after the redirect branch.)
+     */
+    public function testListingFallsBackToDefaultLocaleWhenForwardedWithoutRoute(): void
+    {
+        // Configure the homepage as a (non-singleton) listing, so HomepageController
+        // forwards the request to ListingController without a `_route`.
+        $this->setHomepage('pages');
+
+        $this->client->request('GET', '/fr/');
+        $response = $this->client->getResponse();
+
+        // No redirect, no error: the listing is rendered in the default locale.
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('<html lang="en"', (string) $response->getContent());
+    }
+
+    private function setHomepage(string $homepage): void
+    {
+        $config = self::getContainer()->get(Config::class);
+
+        // Mutate only the `general` collection in place; rebuilding the whole data
+        // tree would turn `contenttypes` into plain collections and break typing.
+        $property = new \ReflectionProperty(Config::class, 'data');
+        $property->getValue($config)->get('general')->put('homepage', $homepage);
+    }
+}


### PR DESCRIPTION
  # Propagate the current locale to custom 404 / 403 / 500 error pages

  ## Problem

  When a request hits a custom error page configured in `config/bolt/config.yaml`
  (`notfound`, `forbidden`, `internal_server_error`, `maintenance`), the page was
  always rendered in the **default locale**, even when the URL clearly carried a
  locale (e.g. `/nl/this-page-does-not-exist`).

  Root cause: on a 404/403, no route matches, so Symfony's `LocaleListener` never
  runs and the request locale is never set from the URL. As a result:

  - Localized record fields (e.g. a `heading`) rendered in the default language.
  - `<html lang="…">` did not reflect the requested locale.
  - `{% trans %}` strings in the error template rendered in the default language
    (the translator's locale was never set either).

  There was also a latent bug: forcing the "wrong locale" path through
  `redirectToDefaultLocale()` on a request **without a matched route** called
  `redirectToRoute(null, …)`, throwing a `TypeError` — a 404-within-a-404.

  ## Solution

  1. **Recover the locale from the URL path on error pages.**
     `ErrorController` now receives the configured locales (`%app_locales%`) and,
     in `showAction()`, recovers the locale from the first path segment
     (`/de/…` ⇒ `de`) before rendering. It's applied to:
     - the request used to render the record,
     - the current (sub-)request that Twig's `app.request` resolves to, and
     - the **translator** (so `{% trans %}` strings localize too).

     The translator call is guarded by `instanceof LocaleAwareInterface`: the
     contracts `TranslatorInterface` we depend on exposes only `trans()`/
     `getLocale()`, while `setLocale()` lives on `LocaleAwareInterface` (the
     concrete translator implements both). This keeps the declared dependency
     narrow.

  2. **Pass the locale explicitly into record rendering.**
     `attemptToRender()` now forwards `$request->getLocale()` to
     `DetailController::record()`, so it keeps the recovered locale instead of
     falling back to the default.

  3. **Make the "wrong locale" handling degrade gracefully.**
     Introduced `redirectToDefaultLocaleOrFallback()`: when there *is* a matched
     route it still redirects to the default-locale URL as before; when there
     *isn't* one (an error page, or a forwarded request) it resets the request to
     the default locale and returns `null`, so the caller renders in the default
     locale instead of erroring. `redirectToDefaultLocale()` now guards the missing
     `_route` case (fixing the `TypeError`) and reads `_route` from request
     attributes rather than `$request->get()`.

  ## Changes

  | File | Change |
  | --- | --- |
  | `src/Controller/ErrorController.php` | Inject `%app_locales%` and the translator; recover the locale from the path (`setLocaleFromPath()`) onto the request, sub-request and
  translator; pass the locale to `DetailController::record()`. |
  | `src/Controller/TwigAwareController.php` | Add `redirectToDefaultLocaleOrFallback()`; guard the no-`_route` case in `redirectToDefaultLocale()` and read `_route` from
  attributes. |
  | `src/Controller/Frontend/ListingController.php` | Use the new fallback so a forwarded listing renders in the default locale instead of erroring. |
  | `tests/php/Controller/Frontend/ErrorControllerTest.php` | New tests (see below). |
  | `tests/php/Controller/Frontend/ListingControllerTest.php` | New tests (see below). |

  ## Tests

  `ErrorControllerTest`:
  - `testNotFoundRecordRendersLocalizedFieldInRequestedLocale` — `/nl/…` 404 renders
    `<html lang="nl">` and the Dutch `heading`.
  - `testNotFoundRecordRendersLocalizedFieldInDefaultLocale` — no-locale 404 renders
    in `en`.
  - `testErrorPageRecoversTranslatorLocaleFromPath` — the shared translator's locale
    is set to `nl` for a `/nl/…` error (default is `en`).
  - `testForbiddenRecordRendersLocalizedFieldInRequestedLocale` — the 403 branch
    (`showForbidden`) localizes the configured `general/forbidden` record.
  - `testNotFoundPageWithNonLocalizedContentTypeDoesNotError` — regression for the
    `TypeError` when a non-localized ContentType is reached via a localized URL.

  `ListingControllerTest`:
  - `testListingRedirectsToDefaultLocaleWhenLocaleNotSupported` — matched route with
    an unsupported locale ⇒ 302 to the default locale.
  - `testListingFallsBackToDefaultLocaleWhenForwardedWithoutRoute` — forwarded
    request (no `_route`) ⇒ renders in the default locale instead of erroring.

  **Results:** new tests green (`ErrorControllerTest` 5/5, `ListingControllerTest`
  2/2). Full suite **195/196** — the single failure (`ConfigTest::testCanParse`, a
  `Console\Application::setDispatcher(null)` `TypeError`) is a **pre-existing
  test-ordering issue** unrelated to this change: it touches none of these files and
  passes in isolation. PHPStan and ECS are clean on all changed files.

  ## Notes / limitations

  - **Test approach for 403:** a frontend 403 isn't reachable from a routed request
    in the test app (all `access_control` rules are backend, and the backend 403
    path redirects to the dashboard rather than rendering the custom page), so that
    test drives the configured `error_controller` directly — the same entry point
    Symfony's error handling uses. `showAction()` returns the rendered page as a
    plain 200; promoting the status to the exception's code (403/404/…) is the
    kernel's job (`HttpKernel::handleThrowable()`), which the direct call bypasses —
    so that test asserts the locale handling that is this controller's
    responsibility, not the status code.
  - **Non-localized ContentType via a localized error URL:** `<html lang>` may show
    the URL locale while the record content uses the default locale. This is
    harmless (such content is identical across locales) and is documented inline.
  - **Constructor change:** `ErrorController::__construct` gains a required
    `string $locales` argument and a `TranslatorInterface`; both are autowired/bound
    via DI (`config/services.yaml`). Relevant only if the controller is extended or
    instantiated manually.