### PR TITLE
Make default query limit configurable via query_default_limit

### DIFF
--- a/config/bolt/config.yaml
+++ b/config/bolt/config.yaml
@@ -152,6 +152,12 @@ query_search:
 # example in `type: select`.
 maximum_listing_select: 50000
 
+# Default number of records returned by a content query (e.g. `{% setcontent %}`
+# or the query DSL) when no explicit `limit` is given. This guards against
+# unintentionally fetching an entire ContentType. Override per query with
+# `limit`, e.g. `{% setcontent pages limit 30 %}`.
+query_default_limit: 20
+
 # Template for showing the search results. If not defined, uses the settings for
 # listing_template and listing_records.
 #

--- a/src/Storage/ContentQueryParser.php
+++ b/src/Storage/ContentQueryParser.php
@@ -181,8 +181,9 @@ class ContentQueryParser
      */
     protected function parseDirectives(): void
     {
-        // If the user doesn't pass in a limit, we'll get 20. Don't break the site by fetching _all_.
-        $this->directives = ['limit' => 20];
+        // If the user doesn't pass in a limit, we fall back to the configured
+        // default (20). Don't break the site by fetching _all_.
+        $this->directives = ['limit' => $this->config->get('general/query_default_limit', 20)];
 
         if (! $this->params) {
             return;

--- a/yaml-migrations/m_2026-05-25-config_query_default_limit.yaml
+++ b/yaml-migrations/m_2026-05-25-config_query_default_limit.yaml
@@ -1,0 +1,6 @@
+# Add the configurable default limit for content queries (`{% setcontent %}` and the query DSL).
+file: bolt/config.yaml
+since: 6.2.0
+
+add:
+  query_default_limit: 20

--- a/yaml-migrations/m_2026-05-25-config_query_default_limit.yaml
+++ b/yaml-migrations/m_2026-05-25-config_query_default_limit.yaml
@@ -1,6 +1,0 @@
-# Add the configurable default limit for content queries (`{% setcontent %}` and the query DSL).
-file: bolt/config.yaml
-since: 6.2.0
-
-add:
-  query_default_limit: 20


### PR DESCRIPTION
## Make default query limit configurable via `query_default_limit`
  
  ### Summary

  The default record limit of **20** for content queries (`{% setcontent %}` and the query DSL) was hardcoded in `ContentQueryParser`. This change makes it configurable through a new `general/query_default_limit` config key, while keeping `20` as the fallback so **existing behavior is unchanged** when the  key is not set.
  
  ### Motivation

 When a content query doesn't specify a `limit`, Bolt caps the result set at 20 records to avoid accidentally fetching an entire ContentType (a performance/safety guard). Until now, the only ways to change this were to pass `limit N` on every individual query or to patch core — the latter being overwritten on every update. This adds a supported, persistent way to set a site-wide default.
  
  ### Changes

  | File | Change |
  | --- | --- |
  | `src/Storage/ContentQueryParser.php` | Default limit now read from config instead of a hardcoded `20` |
  | `config/bolt/config.yaml` | New documented `query_default_limit` key |

  **`ContentQueryParser::parseDirectives()`**
  ```php
  // If the user doesn't pass in a limit, we fall back to the configured
  // default (20). Don't break the site by fetching _all_.
  $this->directives = ['limit' => $this->config->get('general/query_default_limit', 20)];
  ```
  `Config` was already injected into the constructor, so no service wiring changes were required.

  **`config/bolt/config.yaml`**
  ```yaml
  # Default number of records returned by a content query (e.g. `{% setcontent %}`
  # or the query DSL) when no explicit `limit` is given. This guards against
  # unintentionally fetching an entire ContentType. Override per query with
  # `limit`, e.g. `{% setcontent pages limit 30 %}`.
  query_default_limit: 20
  ```


  ### Usage

  ```yaml
  # config/bolt/config.yaml
  query_default_limit: 50
  ```
  A per-query `limit` still takes precedence:
  ```twig
  {% setcontent pages limit 30 %}   {# overrides the configured default #}
  ```

  ### Backwards compatibility
  
  - No behavior change when the key is absent — the code falls back to `20`.


