### PR TITLE
Slugless canonical for singletons + clean listing canonical

### DIFF
--- a/config/bolt/contenttypes.yaml
+++ b/config/bolt/contenttypes.yaml
@@ -566,6 +566,27 @@ validationdemos:
         min: 1
         max: 2
 
+# This contenttype is here to use for (automated) tests.
+# A non-homepage singleton: Bolt serves a singleton at its slugless listing URL
+# (the ListingController forwards a singleton "listing" to the record), so its
+# canonical should be `/about`, not the record-detail route `/about/{slug}`.
+about:
+  name: About
+  singular_name: About
+  slug: about
+  fields:
+    title:
+      type: text
+      label: Title
+    slug:
+      type: slug
+      uses: title
+      group: meta
+  viewless: false
+  singleton: true
+  icon_many: "fa:info-circle"
+  icon_one: "fa:info-circle"
+
 # Possible field types:
 #
 # text - varchar(256) - input type text.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,8 @@
         <!-- ###+ doctrine/doctrine-bundle ### -->
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data/bolt.test.sqlite" force="true"/>
         <!-- ###- doctrine/doctrine-bundle ### -->
+        <!-- Set canonical in the general config. Keep empty to not use it. -->
+        <env name="BOLT_CANONICAL" value="http://localhost"/>
         <!-- ###+ nelmio/cors-bundle ### -->
         <env name="CORS_ALLOW_ORIGIN" value="^https?://localhost(:[0-9]+)?$"/>
         <!-- ###- nelmio/cors-bundle ### -->

--- a/src/Controller/Frontend/ListingController.php
+++ b/src/Controller/Frontend/ListingController.php
@@ -69,13 +69,15 @@ class ListingController extends TwigAwareController implements FrontendZoneInter
 
         $records = $this->setRecords($content, $amountPerPage, $page);
 
-        // Set canonical URL
+        // Set canonical URL. Note: query params (order/status/filters from
+        // parseQueryParams) are intentionally NOT merged in — they are volatile and
+        // would pollute the canonical (e.g. ?order=-createdAt&status=published).
         $this->canonical->setPath(
             'listing_locale',
-            array_merge([
+            [
                 'contentTypeSlug' => $contentType->get('slug'),
                 '_locale' => $request->getLocale(),
-            ], $params)
+            ]
         );
 
         // Render

--- a/src/Utils/ContentHelper.php
+++ b/src/Utils/ContentHelper.php
@@ -68,6 +68,22 @@ class ContentHelper
             ];
         }
 
+        // Singletons are served at their slugless listing URL: ListingController
+        // forwards a singleton "listing" to the record. Canonicalize to that URL
+        // (`/{singularSlug}`) instead of the record-detail route
+        // (`/{singularSlug}/{slug}`), so a singleton has a single, slugless URL
+        // rather than two URLs serving identical content.
+        $definition = $record->getDefinition();
+        if ($definition !== null && $definition->get('singleton')) {
+            return [
+                'route' => 'listing_locale',
+                'params' => [
+                    'contentTypeSlug' => $record->getContentTypeSingularSlug(),
+                    '_locale' => $locale,
+                ],
+            ];
+        }
+
         return [
             'route' => $record->getDefinition()->get('record_route'),
             'params' => [

--- a/tests/php/Configuration/Parser/ContentTypesParserTest.php
+++ b/tests/php/Configuration/Parser/ContentTypesParserTest.php
@@ -70,9 +70,10 @@ class ContentTypesParserTest extends ParserTestBase
         $contentTypesParser = new ContentTypesParser($this->getProjectDir(), $generalParser->parse(), self::DEFAULT_LOCALE, self::ALLOWED_LOCALES);
         $config = $contentTypesParser->parse();
 
-        $this->assertCount(9, $config);
+        $this->assertCount(10, $config);
 
         $this->assertArrayHasKey('homepage', $config);
+        $this->assertArrayHasKey('about', $config);
         $this->assertCount(self::AMOUNT_OF_ATTRIBUTES_IN_CONTENT_TYPE, $config['homepage']);
 
         $this->assertSame('Homepage', $config['homepage']['name']);

--- a/tests/php/Controller/Frontend/ListingCanonicalTest.php
+++ b/tests/php/Controller/Frontend/ListingCanonicalTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Controller\Frontend;
+
+use Bolt\Tests\DbAwareTestCase;
+
+/**
+ * The listing canonical must be the clean listing URL. Query params parsed for
+ * the listing (order/status/filters) are volatile and must not leak into the
+ * <link rel="canonical">.
+ */
+class ListingCanonicalTest extends DbAwareTestCase
+{
+    public function testListingCanonicalOmitsQueryParams(): void
+    {
+        $crawler = $this->client->request('GET', '/showcases?order=title');
+
+        $this->assertResponseIsSuccessful();
+
+        $canonical = $crawler->filter('link[rel="canonical"]')->attr('href');
+
+        $this->assertStringEndsWith('/showcases', $canonical);
+        $this->assertStringNotContainsString('?', $canonical);
+        $this->assertStringNotContainsString('order', $canonical);
+    }
+}

--- a/tests/php/Controller/Frontend/SingletonCanonicalTest.php
+++ b/tests/php/Controller/Frontend/SingletonCanonicalTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Controller\Frontend;
+
+use Bolt\Entity\Content;
+use Bolt\Tests\DbAwareTestCase;
+
+/**
+ * End-to-end: a singleton is reachable both at its slugless URL (`/about`) and at
+ * the record-detail route (`/about/{slug}`). Both must declare the slugless URL
+ * as their canonical, so the two URLs consolidate to one.
+ */
+class SingletonCanonicalTest extends DbAwareTestCase
+{
+    public function testSingletonRecordUrlCanonicalizesToSluglessUrl(): void
+    {
+        /** @var Content|null $record */
+        $record = $this->getEm()->getRepository(Content::class)
+            ->findOneBy(['contentType' => 'about']);
+
+        $this->assertNotNull($record, 'Expected the "about" singleton fixture to be seeded.');
+
+        $singularSlug = $record->getContentTypeSingularSlug();
+        $slug = $record->getSlug();
+        $expectedCanonical = 'http://localhost/' . $singularSlug;
+
+        // The slugged record URL must canonicalize to the slugless singleton URL.
+        $crawler = $this->client->request('GET', sprintf('/%s/%s', $singularSlug, $slug));
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            $expectedCanonical,
+            $crawler->filter('link[rel="canonical"]')->attr('href')
+        );
+
+        // The slugless URL itself is self-referential (same canonical).
+        $crawler = $this->client->request('GET', '/' . $singularSlug);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            $expectedCanonical,
+            $crawler->filter('link[rel="canonical"]')->attr('href')
+        );
+    }
+}

--- a/tests/php/Utils/ContentHelperTest.php
+++ b/tests/php/Utils/ContentHelperTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bolt\Tests\Utils;
+
+use Bolt\Canonical;
+use Bolt\Configuration\Config;
+use Bolt\Configuration\Content\ContentType;
+use Bolt\Entity\Content;
+use Bolt\Twig\LocaleExtension;
+use Bolt\Utils\ContentHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Canonical route/params resolution, with focus on the singleton handling:
+ * a singleton is served at its slugless listing URL (ListingController forwards
+ * a singleton listing to the record), so its canonical must point there
+ * (`/{singularSlug}`) and not at the record-detail route (`/{singularSlug}/{slug}`).
+ */
+class ContentHelperTest extends TestCase
+{
+    public function testSingletonCanonicalUsesSluglessListingRoute(): void
+    {
+        $content = $this->createContent(
+            singleton: true,
+            singularSlug: 'contact',
+            slug: 'contact-info',
+            recordSlug: 'contact-2'
+        );
+
+        $canonical = $this->createMock(Canonical::class);
+        $canonical->expects($this->once())
+            ->method('setPath')
+            ->with('listing_locale', [
+                'contentTypeSlug' => 'contact',
+                '_locale' => 'en',
+            ]);
+
+        $this->createContentHelper($canonical)->setCanonicalPath($content, 'en');
+    }
+
+    public function testNonSingletonCanonicalUsesRecordRouteWithSlug(): void
+    {
+        $content = $this->createContent(
+            singleton: false,
+            singularSlug: 'entry',
+            slug: 'entries',
+            recordSlug: 'my-post',
+            recordRoute: 'record'
+        );
+
+        $canonical = $this->createMock(Canonical::class);
+        $canonical->expects($this->once())
+            ->method('setPath')
+            ->with('record', [
+                'contentTypeSlug' => 'entry',
+                'slugOrId' => 'my-post',
+                '_locale' => 'en',
+            ]);
+
+        $this->createContentHelper($canonical)->setCanonicalPath($content, 'en');
+    }
+
+    public function testHomepageCanonicalIsNotAffectedBySingletonHandling(): void
+    {
+        // The homepage is itself a singleton, but must keep resolving to the
+        // homepage route, not the listing route.
+        $content = $this->createContent(
+            singleton: true,
+            singularSlug: 'homepage',
+            slug: 'homepage',
+            recordSlug: 'homepage'
+        );
+
+        $canonical = $this->createMock(Canonical::class);
+        $canonical->expects($this->once())
+            ->method('setPath')
+            ->with('homepage_locale', [
+                '_locale' => 'en',
+            ]);
+
+        $this->createContentHelper($canonical)->setCanonicalPath($content, 'en');
+    }
+
+    public function testNonContentIsIgnored(): void
+    {
+        $canonical = $this->createMock(Canonical::class);
+        $canonical->expects($this->never())
+            ->method('setPath');
+
+        $this->createContentHelper($canonical)->setCanonicalPath(null, 'en');
+    }
+
+    private function createContent(
+        bool $singleton,
+        string $singularSlug,
+        string $slug,
+        string $recordSlug,
+        ?string $recordRoute = null
+    ): Content {
+        $definition = $this->createMock(ContentType::class);
+        $definition->method('get')->willReturnCallback(
+            static fn (string $key) => match ($key) {
+                'singleton' => $singleton,
+                'record_route' => $recordRoute,
+                default => null,
+            }
+        );
+
+        $content = $this->createMock(Content::class);
+        $content->method('getDefinition')->willReturn($definition);
+        $content->method('getContentTypeSingularSlug')->willReturn($singularSlug);
+        $content->method('getContentTypeSlug')->willReturn($slug);
+        $content->method('getSlug')->willReturn($recordSlug);
+        $content->method('getId')->willReturn(1);
+
+        return $content;
+    }
+
+    private function createContentHelper(Canonical $canonical): ContentHelper
+    {
+        $config = $this->createMock(Config::class);
+        // Only `general/homepage` is consulted (via isHomepage()); a content type
+        // is the homepage when its slug matches this value.
+        $config->method('get')->willReturnCallback(
+            static fn (string $path) => $path === 'general/homepage' ? 'homepage' : null
+        );
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn(new Request());
+
+        return new ContentHelper(
+            $canonical,
+            $requestStack,
+            $config,
+            $this->createMock(LocaleExtension::class)
+        );
+    }
+}


### PR DESCRIPTION
### Problem
  A singleton content type ends up with **two indexable URLs serving identical content**, and the on-page canonical points at the "ugly" one:

  - Bolt serves a singleton at its slugless listing URL (`ListingController` forwards a singleton "listing" to the record), e.g. `/about`.
  - But `ContentHelper::getCanonicalRouteAndParams()` returns the **record-detail route**, so the `<link rel="canonical">` becomes `/about/{slug}` — where `{slug}` is an auto-generated record slug  (e.g. `about-2`) that carries no meaning for a one-record type.

  Separately, **listing canonicals leak volatile query params**: `ListingController` merges the parsed query params (`order`, `status`, filters) into the canonical, producing URLs like  `/showcases?order=-createdAt&status=published`.

  ### Fix
  - **Singletons** now canonicalize to their slugless listing URL (`/{singularSlug}`) instead of the record-detail route. The homepage (also a singleton) keeps resolving to the homepage route — its  early-return precedence is preserved.
  - **Listings** no longer fold query params into the canonical; the canonical is the clean listing URL.

  Because `getLink()` (`record|link`) and `setCanonicalPath()` share `getCanonicalRouteAndParams()`, internal links and the canonical tag now agree for singletons.

  ### Changes
  - `src/Utils/ContentHelper.php` — add a singleton branch to `getCanonicalRouteAndParams()`.
  - `src/Controller/Frontend/ListingController.php` — stop merging query params into the listing canonical.


  ### Tests
  - **Unit** (`tests/php/Utils/ContentHelperTest.php`): singleton → slugless listing route (no `slugOrId`); non-singleton → record route + slug (regression guard); homepage singleton → homepage route,
  not listing; non-`Content` input ignored.
  - **Functional** (`tests/php/Controller/Frontend/ListingCanonicalTest.php`): a listing canonical omits query params.
  - **End-to-end** (`tests/php/Controller/Frontend/SingletonCanonicalTest.php`): a singleton's slugged record URL canonicalizes to its slugless URL, and the slugless URL is self-referential.

  Each test was mutation-verified — it fails when its corresponding fix is reverted.

  ### Supporting test changes
  - `config/bolt/contenttypes.yaml` — add an `about` non-homepage singleton to the test-scaffolding content types so the end-to-end test has a record to exercise (the only existing singleton,  `homepage`, is special-cased).
  - `tests/php/Configuration/Parser/ContentTypesParserTest.php` — demo content-type count 9 → 10, assert the `about` key.
  - `phpunit.xml.dist` — set `BOLT_CANONICAL` so the `Canonical` service bootstraps in the test environment (it otherwise fatals on the empty default value).

### Test screenshots 


#### 1. Homepage singleton test case (This already works -> nothing changes)

<img width="265" height="121" alt="Screenshot 2026-06-18 at 10 49 38" src="https://github.com/user-attachments/assets/ddd2a2f7-441b-4aeb-9a94-34e0f91c174c" />

<img width="224" height="148" alt="Screenshot 2026-06-18 at 10 36 04" src="https://github.com/user-attachments/assets/9e60cab5-0fdf-49e2-a4cb-7718e52fab2e" />

#### 2. Contact page singleton test cases (This did not work -> now works as homepage singleton)
<img width="305" height="158" alt="Screenshot 2026-06-18 at 10 50 23" src="https://github.com/user-attachments/assets/3bf1e1cc-a20e-4d8f-8cf6-9f3a0368af02" />

<img width="267" height="150" alt="Screenshot 2026-06-18 at 10 36 47" src="https://github.com/user-attachments/assets/982aab28-8d75-4262-a2ed-f844a42330f2" />

------
<img width="285" height="133" alt="Screenshot 2026-06-18 at 10 54 27" src="https://github.com/user-attachments/assets/8e7d9a42-709a-442d-815d-2fac3e69c7b2" />

<img width="380" height="192" alt="Screenshot 2026-06-18 at 10 37 13" src="https://github.com/user-attachments/assets/99836e38-9d08-4a37-acc0-f1d722e0a2f2" />

  ### Notes
  - No DB/schema changes — Bolt stores content generically, so the new singleton needs no migration.
  - Full PHP suite passes (195 tests). `RelationFactoryTest` is occasionally flaky due to unseeded Faker fixtures; unrelated to this change.