### PR TITLE
security: add allowed_classes => false to unserialize() in ArrayToJsonMigrator

### DIFF
--- a/src/Doctrine/Migrations/ArrayToJsonMigrator.php
+++ b/src/Doctrine/Migrations/ArrayToJsonMigrator.php
@@ -44,7 +44,7 @@ class ArrayToJsonMigrator
         foreach ($result->iterateAssociative() as $row) {
             $id = $row['id'];
             $propertyString = $row[$propertyName];
-            $propertyArray = unserialize($propertyString);
+            $propertyArray = unserialize($propertyString, ['allowed_classes' => false]);
             // This is where the actual migration happens
             $propertyJson = json_encode($propertyArray);
 


### PR DESCRIPTION
## Summary

Adds `['allowed_classes' => false]` to the `unserialize()` call in `ArrayToJsonMigrator` as a defence-in-depth measure against PHP Object Injection.

## Vulnerability

```php
// Before — no class restriction:
$propertyArray = unserialize($propertyString);
```

The migrator reads `$propertyString` from the database and passes it directly to `unserialize()` without restricting which PHP classes can be instantiated. Although the query filters for rows matching `LIKE 'a:%'` (serialized arrays), a compromised or hand-crafted database row could supply a serialized object payload instead. Without `allowed_classes => false`, this would allow arbitrary PHP classes present in the autoloader to be instantiated during deserialization — potentially triggering destructor/wakeup gadget chains.

## Fix

```php
// After — scalar types only:
$propertyArray = unserialize($propertyString, ['allowed_classes' => false]);
```

Since the migrator only ever needs to reconstruct plain PHP arrays (no objects), restricting to scalar types is safe and eliminates the object-injection surface.

## References
- https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection
- https://www.php.net/manual/en/function.unserialize.php