### PR TITLE
Update `bolt.cm` links to `boltcms.io`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,4 @@ Contributing to Bolt
 Bolt is an open source, community-driven project. Whether you're a user of
 Bolt, a developer or both, contributing to Bolt is easy!
 
-If you'd like to contribute, please read "[Contributing to Bolt][contributing]"
-on the documentation site.
-
-[contributing]: https://docs.bolt.cm/other/contributing
+If you'd like to contribute, please read "[Contributing to Bolt][https://docs.boltcms.io/other/contributing]" on the documentation site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Contributing to Bolt
 Bolt is an open source, community-driven project. Whether you're a user of
 Bolt, a developer or both, contributing to Bolt is easy!
 
-If you'd like to contribute, please read "[Contributing to Bolt][https://docs.boltcms.io/other/contributing]" on the documentation site.
+If you'd like to contribute, please read "[Contributing to Bolt](https://docs.boltcms.io/other/contributing)" on the documentation site.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ For **development** of Bolt CMS itself, check out the [setup guide](./SETUP.md)
 There are multiple ways to help the Bolt project going forward:
 
 * Star this repository
-* Learn how to [spread the word](https://docs.bolt.cm/other/contributing)
-* Help by writing and [contributing code or documentation](https://docs.bolt.cm/other/contributing)
+* Learn how to [spread the word](https://docs.boltcms.io/other/contributing)
+* Help by writing and [contributing code or documentation](https://docs.boltcms.io/other/contributing)
 
 
 ## Credits


### PR DESCRIPTION
Avoids browser warning page about expired `bolt.cm` certificate when following these links.