### PR TITLE
Fix TimedPublishSubscriber for doctrine/dbal 4.x

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 $ignoreErrors = [];
 $ignoreErrors[] = [

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 $ignoreErrors = [];
 $ignoreErrors[] = [

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -2666,12 +2666,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Event/Subscriber/AuthSubscriber.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Call to an undefined method object\\:\\:executeUpdate\\(\\)\\.$#',
-	'identifier' => 'method.notFound',
-	'count' => 2,
-	'path' => __DIR__ . '/src/Event/Subscriber/TimedPublishSubscriber.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method Bolt\\\\Event\\\\Subscriber\\\\TimedPublishSubscriber\\:\\:__construct\\(\\) has parameter \\$tablePrefix with no type specified\\.$#',
 	'identifier' => 'missingType.parameter',
 	'count' => 1,

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 $ignoreErrors = [];
 $ignoreErrors[] = [

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -24,8 +24,11 @@ class TimedPublishSubscriber implements EventSubscriberInterface
     private Connection $defaultConnection;
     private string $tablePrefix;
 
-    public function __construct($tablePrefix, ManagerRegistry $managerRegistry, private LoggerInterface $logger)
-    {
+    public function __construct(
+        $tablePrefix,
+        ManagerRegistry $managerRegistry,
+        private LoggerInterface $logger
+    ) {
         /** @var Connection $connection */
         $connection = $managerRegistry->getConnection('default');
         $this->defaultConnection = $connection;

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -23,9 +23,8 @@ class TimedPublishSubscriber implements EventSubscriberInterface
 
     private Connection $defaultConnection;
     private string $tablePrefix;
-    private LoggerInterface $logger;
 
-    public function __construct($tablePrefix, ManagerRegistry $managerRegistry, LoggerInterface $logger)
+    public function __construct($tablePrefix, ManagerRegistry $managerRegistry, private LoggerInterface $logger)
     {
         /** @var Connection $connection */
         $connection = $managerRegistry->getConnection('default');
@@ -33,7 +32,6 @@ class TimedPublishSubscriber implements EventSubscriberInterface
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)
             ->getTablePrefix($managerRegistry->getManager('default'));
-        $this->logger = $logger;
     }
 
     /**

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -27,7 +27,9 @@ class TimedPublishSubscriber implements EventSubscriberInterface
 
     public function __construct($tablePrefix, ManagerRegistry $managerRegistry)
     {
-        $this->defaultConnection = $managerRegistry->getConnection('default');
+        /** @var Connection $connection */
+        $connection = $managerRegistry->getConnection('default');
+        $this->defaultConnection = $connection;
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)
             ->getTablePrefix($managerRegistry->getManager('default'));

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -7,6 +7,7 @@ namespace Bolt\Event\Subscriber;
 use Bolt\Doctrine\TablePrefixTrait;
 use Bolt\Entity\Content;
 use Carbon\Carbon;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -20,13 +21,15 @@ class TimedPublishSubscriber implements EventSubscriberInterface
 
     public const PRIORITY = 30;
 
-    private object $defaultConnection;
+    private Connection $defaultConnection;
     private string $tablePrefix;
     private LoggerInterface $logger;
 
     public function __construct($tablePrefix, ManagerRegistry $managerRegistry, LoggerInterface $logger)
     {
-        $this->defaultConnection = $managerRegistry->getConnection('default');
+        /** @var Connection $connection */
+        $connection = $managerRegistry->getConnection('default');
+        $this->defaultConnection = $connection;
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)
             ->getTablePrefix($managerRegistry->getManager('default'));

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -29,9 +29,7 @@ class TimedPublishSubscriber implements EventSubscriberInterface
         ManagerRegistry $managerRegistry,
         private LoggerInterface $logger
     ) {
-        /** @var Connection $connection */
-        $connection = $managerRegistry->getConnection('default');
-        $this->defaultConnection = $connection;
+        $this->defaultConnection = $managerRegistry->getConnection('default');
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)
             ->getTablePrefix($managerRegistry->getManager('default'));

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -11,7 +11,6 @@ use Carbon\Carbon;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Throwable;

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -17,6 +17,7 @@ use Throwable;
 
 class TimedPublishSubscriber implements EventSubscriberInterface
 {
+    use LoggerTrait;
     use TablePrefixTrait;
 
     public const PRIORITY = 30;

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -7,7 +7,9 @@ namespace Bolt\Event\Subscriber;
 use Bolt\Doctrine\TablePrefixTrait;
 use Bolt\Entity\Content;
 use Carbon\Carbon;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Throwable;
@@ -20,13 +22,15 @@ class TimedPublishSubscriber implements EventSubscriberInterface
 
     private object $defaultConnection;
     private string $tablePrefix;
+    private LoggerInterface $logger;
 
-    public function __construct($tablePrefix, ManagerRegistry $managerRegistry)
+    public function __construct($tablePrefix, ManagerRegistry $managerRegistry, LoggerInterface $logger)
     {
         $this->defaultConnection = $managerRegistry->getConnection('default');
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)
             ->getTablePrefix($managerRegistry->getManager('default'));
+        $this->logger = $logger;
     }
 
     /**
@@ -49,10 +53,11 @@ class TimedPublishSubscriber implements EventSubscriberInterface
         );
 
         try {
-            $conn->executeUpdate($queryPublish, [':now' => $now]);
-            $conn->executeUpdate($queryDepublish, [':now' => $now]);
-        } catch (Throwable) {
+            $conn->executeStatement($queryPublish, ['now' => $now], ['now' => Types::DATETIME_MUTABLE]);
+            $conn->executeStatement($queryDepublish, ['now' => $now], ['now' => Types::DATETIME_MUTABLE]);
+        } catch (Throwable $exception) {
             // Fail silently, output user-friendly exception elsewhere.
+            $this->logger->debug('Failed to publish/depublish timed content', ['exception' => $exception]);
         }
     }
 

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -6,6 +6,7 @@ namespace Bolt\Event\Subscriber;
 
 use Bolt\Doctrine\TablePrefixTrait;
 use Bolt\Entity\Content;
+use Bolt\Log\LoggerTrait;
 use Carbon\Carbon;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
@@ -24,11 +25,8 @@ class TimedPublishSubscriber implements EventSubscriberInterface
     private Connection $defaultConnection;
     private string $tablePrefix;
 
-    public function __construct(
-        $tablePrefix,
-        ManagerRegistry $managerRegistry,
-        private LoggerInterface $logger
-    ) {
+    public function __construct($tablePrefix, ManagerRegistry $managerRegistry)
+    {
         $this->defaultConnection = $managerRegistry->getConnection('default');
         $this->tablePrefix = $this
             ->setTablePrefixes($tablePrefix, $managerRegistry)

--- a/src/Event/Subscriber/TimedPublishSubscriber.php
+++ b/src/Event/Subscriber/TimedPublishSubscriber.php
@@ -57,7 +57,7 @@ class TimedPublishSubscriber implements EventSubscriberInterface
             $conn->executeStatement($queryPublish, ['now' => $now], ['now' => Types::DATETIME_MUTABLE]);
             $conn->executeStatement($queryDepublish, ['now' => $now], ['now' => Types::DATETIME_MUTABLE]);
         } catch (Throwable $exception) {
-            // Fail silently, output user-friendly exception elsewhere.
+            // Fail silently for the user, but log at debug level for diagnostics.
             $this->logger->debug('Failed to publish/depublish timed content', ['exception' => $exception]);
         }
     }


### PR DESCRIPTION
- Replace removed Connection::executeUpdate() with executeStatement()
- Use plain (non colon-prefixed) named parameters as required by DBAL 4
- Pass an explicit Types::DATETIME_MUTABLE type for the bound Carbon/DateTime value
- Log caught exceptions at debug level instead of swallowing them silently

Fixes #3748