### PR TITLE
Fix all translations files and harden their consistency 

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -64,6 +64,9 @@ jobs:
           - name: Check XLIFF translation files
             run: bin/console lint:xliff translations --ansi
 
+          - name: Validate translation catalogues
+            run: php bin/validate-translations
+
           - name: Check Doctrine Mapping
             run: bin/console doctrine:schema:validate --skip-sync -vvv --no-interaction --ansi
 

--- a/bin/update-translation-notes
+++ b/bin/update-translation-notes
@@ -1,0 +1,235 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Regenerates the <notes> blocks in translations/*.xlf so every unit lists
+ * the real usage locations (path:line) of its key in the codebase — src,
+ * templates, assets, themes and the bundled bolt widgets. The same notes are
+ * written to the en file and every locale file, so all catalogues stay
+ * identical in structure.
+ *
+ * Units whose keys are consumed by Symfony itself (standard security and
+ * validator messages) have no code location and therefore carry no notes.
+ *
+ * Run it after moving or adding translation keys:
+ *
+ *     php bin/update-translation-notes
+ */
+
+$root = dirname(__DIR__);
+$domains = ['messages', 'security', 'validators'];
+
+// Keys built at runtime: 'status.published' is used via trans('status.' . $status).
+$dynamicPrefixes = ['status.'];
+
+$usageDirs = ['src', 'templates', 'assets/js', 'config', 'tests', 'public/theme', 'vendor/bolt'];
+$usageExtensions = ['php', 'twig', 'js', 'vue', 'yaml', 'yml'];
+
+// Standard security/validator messages have no in-repo usage: they are emitted
+// by Symfony itself. For those, note the vendor source that produces them
+// (the exception returning the messageKey, the constraint declaring the message).
+$vendorFallbackDirs = [
+    'security' => ['vendor/symfony/security-core', 'vendor/symfony/security-http'],
+    'validators' => ['vendor/symfony/validator', 'vendor/symfony/form', 'vendor/symfony/doctrine-bridge', 'vendor/symfony/security-core'],
+];
+
+// ---------------------------------------------------------------------------
+// load the usage corpus
+// ---------------------------------------------------------------------------
+/**
+ * @param  string[]  $dirs
+ * @param  string[]  $extensions
+ * @return array<string, string> relative path => file content
+ */
+function loadCorpus(string $root, array $dirs, array $extensions): array
+{
+    $corpus = [];
+    foreach ($dirs as $dir) {
+        $base = "{$root}/{$dir}";
+        if (! is_dir($base)) {
+            continue;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveCallbackFilterIterator(
+                new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS),
+                static fn (SplFileInfo $f): bool => $f->getFilename() !== 'node_modules' && $f->getFilename() !== 'translations'
+            )
+        );
+        foreach ($iterator as $file) {
+            if ($file->isFile() && in_array($file->getExtension(), $extensions, true)) {
+                $corpus[substr((string) $file->getPathname(), strlen($root) + 1)] = (string) file_get_contents($file->getPathname());
+            }
+        }
+    }
+    ksort($corpus);
+
+    return $corpus;
+}
+
+$corpus = loadCorpus($root, $usageDirs, $usageExtensions);
+
+/**
+ * @var array<string, string[]> cached line splits per file
+ */
+$lineCache = [];
+
+/**
+ * @param  array<string, string>   $corpus
+ * @param  array<string, string[]> $lineCache
+ * @return string[] "path:line" locations where $needle occurs
+ */
+function locate(array $corpus, string $needle, array &$lineCache): array
+{
+    $locations = [];
+    foreach ($corpus as $path => $content) {
+        if (! str_contains($content, $needle)) {
+            continue;
+        }
+        if (! isset($lineCache[$path])) {
+            $lineCache[$path] = explode("\n", $content);
+        }
+        foreach ($lineCache[$path] as $i => $line) {
+            if (str_contains($line, $needle)) {
+                $locations[] = $path . ':' . ($i + 1);
+            }
+        }
+    }
+
+    return $locations;
+}
+
+/**
+ * @param  array<string, string>   $corpus
+ * @param  string[]                $dynamicPrefixes
+ * @param  array<string, string[]> $lineCache
+ * @param  array<string, string>   $vendorCorpus
+ * @param  array<string, string[]> $vendorLineCache
+ * @return string[]
+ */
+function usageNotes(array $corpus, string $key, array $dynamicPrefixes, array &$lineCache, array $vendorCorpus = [], array &$vendorLineCache = []): array
+{
+    $fuzzy = false;
+    // quoted occurrences are precise; fall back to a plain substring match
+    $locations = array_merge(locate($corpus, "'{$key}'", $lineCache), locate($corpus, "\"{$key}\"", $lineCache));
+    if ($locations === []) {
+        $locations = locate($corpus, $key, $lineCache);
+    }
+    if ($locations === []) {
+        foreach ($dynamicPrefixes as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                $locations = locate($corpus, "'{$prefix}'", $lineCache);
+                break;
+            }
+        }
+    }
+    if ($locations === [] && $vendorCorpus !== []) {
+        $escaped = str_replace("'", "\\'", $key); // 'user\'s current password.'
+        $locations = array_merge(
+            locate($vendorCorpus, "'{$key}'", $vendorLineCache),
+            locate($vendorCorpus, "\"{$key}\"", $vendorLineCache),
+            $escaped !== $key ? locate($vendorCorpus, "'{$escaped}'", $vendorLineCache) : []
+        );
+        // messages assembled at runtime, e.g. 'try again '.'in %minutes% minute':
+        // retry with the key progressively shortened from the right
+        $prefix = $key;
+        while ($locations === [] && str_contains($prefix, ' ')) {
+            $lastSpace = strrpos($prefix, ' ');
+            if ($lastSpace === false) {
+                break;
+            }
+            $prefix = trim(substr($prefix, 0, $lastSpace));
+            if (strlen($prefix) < 25) {
+                break;
+            }
+            $locations = locate($vendorCorpus, $prefix, $vendorLineCache);
+            if ($locations !== []) {
+                $fuzzy = true;
+            }
+        }
+    }
+    $locations = array_values(array_unique($locations));
+
+    // Sort by path first, then by line number numerically (not lexicographically).
+    usort($locations, static function (string $a, string $b): int {
+        $aColon = (int) strrpos($a, ':');
+        $bColon = (int) strrpos($b, ':');
+        $pathCmp = strcmp(substr($a, 0, $aColon), substr($b, 0, $bColon));
+        if ($pathCmp !== 0) {
+            return $pathCmp;
+        }
+        return ((int) substr($a, $aColon + 1)) - ((int) substr($b, $bColon + 1));
+    });
+
+    // Prefix fuzzy matches with '~' so downstream tools can identify them.
+    if ($fuzzy && $locations !== []) {
+        $locations = array_map(static fn (string $loc): string => '~' . $loc, $locations);
+    }
+
+    return $locations;
+}
+
+// ---------------------------------------------------------------------------
+// rewrite the xlf files
+// ---------------------------------------------------------------------------
+$notesByDomain = [];
+
+// Pre-load vendor corpora once across domains (avoids double-reading shared
+// vendor dirs like symfony/security-core that appear in multiple domains).
+$vendorCorpusCache = [];
+foreach ($vendorFallbackDirs as $domain => $dirs) {
+    foreach ($dirs as $dir) {
+        if (! isset($vendorCorpusCache[$dir])) {
+            $vendorCorpusCache[$dir] = loadCorpus($root, [$dir], ['php']);
+        }
+    }
+}
+
+foreach ($domains as $domain) {
+    // compute notes once per domain, based on the en key set
+    $enContent = (string) file_get_contents("{$root}/translations/{$domain}.en.xlf");
+    preg_match_all('/<source>(.*?)<\/source>/s', $enContent, $matches);
+    $vendorCorpus = [];
+    foreach ($vendorFallbackDirs[$domain] ?? [] as $dir) {
+        $vendorCorpus += $vendorCorpusCache[$dir];
+    }
+    $vendorLineCache = [];
+    $notes = [];
+    foreach ($matches[1] as $escapedKey) {
+        $key = html_entity_decode($escapedKey, ENT_QUOTES | ENT_XML1, 'UTF-8');
+        $notes[$key] = usageNotes($corpus, $key, $dynamicPrefixes, $lineCache, $vendorCorpus, $vendorLineCache);
+    }
+    $notesByDomain[$domain] = $notes;
+
+    foreach (glob("{$root}/translations/{$domain}.*.xlf") ?: [] as $path) {
+        $content = (string) file_get_contents($path);
+        $content = (string) preg_replace_callback(
+            '/([ \t]*)<unit [^>]*>\n(?:[ \t]*<notes>.*?<\/notes>\n)?(.*?<\/unit>\n)/s',
+            static function (array $m) use ($notes): string {
+                preg_match('/<source>(.*?)<\/source>/s', $m[0], $src);
+                $key = html_entity_decode($src[1] ?? '', ENT_QUOTES | ENT_XML1, 'UTF-8');
+                preg_match('/^[ \t]*<unit [^>]*>\n/', $m[0], $header);
+                $indent = $m[1];
+                $block = $header[0] ?? '';
+                if (! empty($notes[$key])) {
+                    $block .= "{$indent}  <notes>\n";
+                    foreach ($notes[$key] as $location) {
+                        $block .= "{$indent}    <note>{$location}</note>\n";
+                    }
+                    $block .= "{$indent}  </notes>\n";
+                }
+
+                return $block . $m[2];
+            },
+            $content
+        );
+        file_put_contents($path, $content);
+    }
+}
+
+foreach ($domains as $domain) {
+    $withNotes = count(array_filter($notesByDomain[$domain]));
+    $total = count($notesByDomain[$domain]);
+    echo "{$domain}: usage notes for {$withNotes}/{$total} keys, mirrored to all locale files\n";
+}

--- a/bin/validate-translations
+++ b/bin/validate-translations
@@ -1,0 +1,317 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+
+/*
+ * Validates the translation catalogues in translations/:
+ *
+ *  1. Structure parity: every <domain>.<locale>.xlf contains exactly the same
+ *     keys (and unit ids) as <domain>.en.xlf — nothing missing, nothing extra,
+ *     no duplicates.
+ *  2. Header sanity: <file id="domain.locale"> and trgLang match the filename.
+ *  3. Usage (messages domain): every key is referenced somewhere in the code
+ *     (src, templates, assets, config, public/theme, bundled bolt widgets),
+ *     and every key referenced in code exists in messages.en.xlf.
+ *     The security and validators domains are consumed by Symfony itself
+ *     (auth exception messageKeys, constraint messages), so only parity is
+ *     checked there.
+ *
+ * Exits 1 if any error is found, so it can run in CI:
+ *
+ *     php bin/validate-translations
+ */
+
+$root = dirname(__DIR__);
+$domains = ['messages', 'security', 'validators'];
+
+// Keys built at runtime, e.g. 'status.' ~ record.status in ContentExtension.
+$dynamicPrefixes = ['status.'];
+
+// Where translation keys may be referenced.
+$usageDirs = ['src', 'templates', 'assets/js', 'config', 'tests', 'public/theme', 'vendor/bolt'];
+$usageExtensions = ['php', 'twig', 'js', 'vue', 'yaml', 'yml'];
+
+// Fixed manifest of expected translation files. A deleted file must cause a
+// hard failure rather than silently validating fewer files.
+$expectedFiles = [
+    'messages.bg.xlf', 'messages.cs.xlf', 'messages.de.xlf', 'messages.el.xlf',
+    'messages.en.xlf', 'messages.es.xlf', 'messages.fr.xlf', 'messages.hu.xlf',
+    'messages.it.xlf', 'messages.nl.xlf', 'messages.pl.xlf', 'messages.pt_BR.xlf',
+    'messages.ru.xlf', 'messages.tr.xlf', 'messages.uk.xlf', 'messages.zh_CN.xlf',
+    'security.cs.xlf', 'security.de.xlf', 'security.el.xlf', 'security.en.xlf',
+    'security.es.xlf', 'security.fr.xlf', 'security.hu.xlf', 'security.nl.xlf',
+    'security.ru.xlf', 'security.tr.xlf', 'security.zh_CN.xlf',
+    'validators.cs.xlf', 'validators.de.xlf', 'validators.el.xlf', 'validators.en.xlf',
+    'validators.es.xlf', 'validators.fr.xlf', 'validators.hu.xlf', 'validators.it.xlf',
+    'validators.nl.xlf', 'validators.pl.xlf', 'validators.pt_BR.xlf',
+    'validators.ru.xlf', 'validators.tr.xlf', 'validators.uk.xlf', 'validators.zh_CN.xlf',
+];
+
+$errors = [];
+$warnings = [];
+
+// -------------------------------------------------------------------------
+// 0: verify the file manifest is complete
+// -------------------------------------------------------------------------
+foreach ($expectedFiles as $expected) {
+    if (! file_exists("{$root}/translations/{$expected}")) {
+        $errors[] = "{$expected}: expected file is missing from translations/";
+    }
+}
+$actualFiles = array_map(basename(...), glob("{$root}/translations/*.xlf") ?: []);
+foreach (array_diff($actualFiles, $expectedFiles) as $extra) {
+    $warnings[] = "{$extra}: file exists but is not in the expected manifest (add it to bin/validate-translations \$expectedFiles)";
+}
+
+/**
+ * @return array{units: array<string, string>, duplicates: string[], notes: array<string, string[]>, fileId: ?string, trgLang: ?string, loadError: bool}
+ */
+function parseXlf(string $path): array
+{
+    $dom = new DOMDocument();
+    if (! @$dom->load($path)) {
+        return [
+            'units' => [],
+            'duplicates' => [],
+            'notes' => [],
+            'fileId' => null,
+            'trgLang' => null,
+            'loadError' => true,
+        ];
+    }
+    $xliff = $dom->documentElement;
+    if ($xliff === null) {
+        return [
+            'units' => [],
+            'duplicates' => [],
+            'notes' => [],
+            'fileId' => null,
+            'trgLang' => null,
+            'loadError' => true,
+        ];
+    }
+    $xpath = new DOMXPath($dom);
+    $xpath->registerNamespace('x2', 'urn:oasis:names:tc:xliff:document:2.0');
+    $xpath->registerNamespace('x1', 'urn:oasis:names:tc:xliff:document:1.2');
+
+    $units = [];
+    $duplicates = [];
+    $notes = [];
+    foreach (['//x2:unit' => 'x2', '//x1:trans-unit' => 'x1'] as $query => $ns) {
+        $unitList = $xpath->query($query);
+        if ($unitList === false) {
+            continue;
+        }
+        /** @var DOMElement $unit */
+        foreach ($unitList as $unit) {
+            $sourceList = $xpath->query($ns === 'x2' ? 'x2:segment/x2:source' : 'x1:source', $unit);
+            $source = $sourceList !== false ? $sourceList->item(0) : null;
+            if (!$source instanceof DOMElement) {
+                continue;
+            }
+            $key = $source->textContent;
+            if (isset($units[$key])) {
+                $duplicates[] = $key;
+            }
+            $units[$key] = $unit->getAttribute('id');
+            $notes[$key] = [];
+            $noteList = $xpath->query($ns === 'x2' ? 'x2:notes/x2:note' : 'x1:note', $unit);
+            if ($noteList !== false) {
+                foreach ($noteList as $noteNode) {
+                    if ($noteNode instanceof DOMElement) {
+                        $notes[$key][] = $noteNode->textContent;
+                    }
+                }
+            }
+        }
+    }
+
+    $fileList = $xpath->query('//x2:file');
+    $file = $fileList !== false ? $fileList->item(0) : null;
+
+    return [
+        'units' => $units,
+        'duplicates' => $duplicates,
+        'notes' => $notes,
+        'fileId' => $file instanceof DOMElement ? $file->getAttribute('id') : null,
+        'trgLang' => $xliff->getAttribute('trgLang') ?: null,
+        'loadError' => false,
+    ];
+}
+
+// -------------------------------------------------------------------------
+// 1 + 2: structure parity and header sanity
+// -------------------------------------------------------------------------
+$enCatalogues = [];
+
+foreach ($domains as $domain) {
+    $enPath = "{$root}/translations/{$domain}.en.xlf";
+    if (! file_exists($enPath)) {
+        $errors[] = "{$domain}.en.xlf: file not found";
+        continue;
+    }
+    $en = parseXlf($enPath);
+    if ($en['loadError']) {
+        $errors[] = "{$domain}.en.xlf: failed to parse XML (malformed or truncated file)";
+        continue;
+    }
+    $enCatalogues[$domain] = $en;
+    foreach ($en['duplicates'] as $key) {
+        $errors[] = "{$domain}.en.xlf: duplicate key \"{$key}\"";
+    }
+
+    foreach (glob("{$root}/translations/{$domain}.*.xlf") ?: [] as $path) {
+        $filename = basename($path, '.xlf');
+        $locale = substr($filename, strlen($domain) + 1);
+        $parsed = $locale === 'en' ? $en : parseXlf($path);
+
+        if ($parsed['loadError']) {
+            $errors[] = "{$filename}.xlf: failed to parse XML (malformed or truncated file)";
+            continue;
+        }
+
+        if ($parsed['fileId'] !== $filename) {
+            $errors[] = "{$filename}.xlf: <file id=\"{$parsed['fileId']}\"> should be \"{$filename}\"";
+        }
+        $expectedTrgLang = str_replace('_', '-', $locale);
+        if ($parsed['trgLang'] !== null && $parsed['trgLang'] !== $expectedTrgLang) {
+            $errors[] = "{$filename}.xlf: trgLang=\"{$parsed['trgLang']}\" should be \"{$expectedTrgLang}\"";
+        }
+
+        if ($locale === 'en') {
+            continue;
+        }
+        foreach ($parsed['duplicates'] as $key) {
+            $errors[] = "{$filename}.xlf: duplicate key \"{$key}\"";
+        }
+        foreach (array_diff_key($en['units'], $parsed['units']) as $key => $id) {
+            $errors[] = "{$filename}.xlf: missing key \"{$key}\"";
+        }
+        foreach (array_diff_key($parsed['units'], $en['units']) as $key => $id) {
+            $errors[] = "{$filename}.xlf: redundant key \"{$key}\" (not in {$domain}.en.xlf)";
+        }
+        foreach (array_intersect_key($parsed['units'], $en['units']) as $key => $id) {
+            if ($id !== $en['units'][$key]) {
+                $warnings[] = "{$filename}.xlf: unit id \"{$id}\" for \"{$key}\" differs from en (\"{$en['units'][$key]}\")";
+            }
+            if (($parsed['notes'][$key] ?? []) !== ($en['notes'][$key] ?? [])) {
+                $errors[] = "{$filename}.xlf: <notes> for \"{$key}\" differ from {$domain}.en.xlf (run bin/update-translation-notes)";
+            }
+        }
+    }
+
+    // en notes must point at files that still exist
+    foreach ($en['notes'] as $key => $noteList) {
+        foreach ($noteList as $note) {
+            $notePath = explode(':', ltrim($note, '~'))[0];
+            if (! file_exists("{$root}/{$notePath}")) {
+                $warnings[] = "{$domain}.en.xlf: note \"{$note}\" for \"{$key}\" points at a missing file (run bin/update-translation-notes)";
+            }
+        }
+    }
+
+    // byte-level parity: outside <target>, trgLang and <file id>, every locale
+    // file must be identical to the en file (same order, notes, formatting)
+    $skeleton = static function (string $path): string {
+        $content = (string) file_get_contents($path);
+        $content = (string) preg_replace('/<target>.*?<\/target>/s', '<target>_</target>', $content);
+        $content = (string) preg_replace('/trgLang="[^"]*"/', 'trgLang="_"', $content, 1);
+
+        return (string) preg_replace('/<file id="[^"]*">/', '<file id="_">', $content, 1);
+    };
+    $enSkeleton = $skeleton($enPath);
+    foreach (glob("{$root}/translations/{$domain}.*.xlf") ?: [] as $path) {
+        if ($skeleton($path) !== $enSkeleton) {
+            $errors[] = basename($path) . ": file structure differs from {$domain}.en.xlf outside <target> (order, notes or formatting drift)";
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// 3: usage audit for the messages domain
+// -------------------------------------------------------------------------
+$corpus = '';
+foreach ($usageDirs as $dir) {
+    $base = "{$root}/{$dir}";
+    if (! is_dir($base)) {
+        continue;
+    }
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS),
+            static fn (SplFileInfo $f): bool => $f->getFilename() !== 'node_modules' && $f->getFilename() !== 'translations'
+        )
+    );
+    foreach ($iterator as $file) {
+        if ($file->isFile() && in_array($file->getExtension(), $usageExtensions, true)) {
+            $corpus .= (string) file_get_contents($file->getPathname()) . "\n";
+        }
+    }
+}
+
+if (isset($enCatalogues['messages'])) {
+    // 3a: every key in messages.en.xlf is referenced somewhere
+    foreach ($enCatalogues['messages']['units'] as $key => $id) {
+        if (str_contains($corpus, "'{$key}'") || str_contains($corpus, "\"{$key}\"") || str_contains($corpus, $key)) {
+            continue;
+        }
+        $dynamic = false;
+        foreach ($dynamicPrefixes as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                $dynamic = true;
+                break;
+            }
+        }
+        if (! $dynamic) {
+            $errors[] = "messages.en.xlf: unused key \"{$key}\" (not referenced in code, themes or bundled widgets)";
+        }
+    }
+
+    // 3b: every key referenced in code exists in one of the en catalogues
+    $known = [];
+    foreach ($enCatalogues as $catalogue) {
+        $known += $catalogue['units'];
+    }
+    $patterns = [
+        "/'([^'\\n]{2,120})'\\s*\\|\\s*trans\\b/",            // twig: 'key'|trans
+        '/\"([^\"\\n]{2,120})\"\\s*\\|\\s*trans\\b/',            // twig: "key"|trans
+        "/__\\(\\s*'([^'\\n]{2,120})'/",                      // twig helper: __('key')
+        "/->trans\\(\\s*'([^'\\n]{2,120})'/",                 // php: ->trans('key')
+        '/->trans\\(\\s*\"([^\"\\n]{2,120})\"/',
+    ];
+    $used = [];
+    foreach ($patterns as $pattern) {
+        preg_match_all($pattern, $corpus, $matches);
+        foreach ($matches[1] as $key) {
+            $used[$key] = true;
+        }
+    }
+    foreach (array_keys($used) as $key) {
+        if (in_array($key, $dynamicPrefixes, true)) {
+            continue; // concatenated at runtime, e.g. trans('status.' . $status)
+        }
+        if (! isset($known[$key])) {
+            $errors[] = "missing key \"{$key}\": referenced in code but present in no *.en.xlf catalogue";
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// report
+// -------------------------------------------------------------------------
+foreach ($warnings as $warning) {
+    echo "\033[33m[WARN]\033[0m  {$warning}\n";
+}
+foreach ($errors as $error) {
+    echo "\033[31m[ERROR]\033[0m {$error}\n";
+}
+
+$files = count(glob("{$root}/translations/*.xlf") ?: []);
+if ($errors === []) {
+    echo "\033[32m[OK]\033[0m {$files} translation files validated: structure in sync with en, no unused or missing keys.\n";
+    exit(0);
+}
+
+printf("\n%d error(s), %d warning(s) in %d translation files.\n", count($errors), count($warnings), $files);
+exit(1);

--- a/translations/messages.bg.xlf
+++ b/translations/messages.bg.xlf
@@ -1,1210 +1,3437 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="bg">
   <file id="messages.bg">
+    <unit id="1sstKF9" name="title.edit_user">
+      <notes>
+        <note>templates/users/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user</source>
+        <target>Редактирай потребител</target>
+      </segment>
+    </unit>
     <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
       <segment>
         <source>action.save</source>
         <target>Запази</target>
       </segment>
     </unit>
-    <unit id="TpGxDI3" name="user.unknown_user">
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
-        <source>user.unknown_user</source>
-        <target>Неизвестен потребител</target>
+        <source>action.do_something</source>
+        <target>Направи нещо</target>
       </segment>
     </unit>
-    <unit id="7aLIA3c" name="caption.dashboard">
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
-        <source>caption.dashboard</source>
-        <target>Болт табло</target>
-      </segment>
-    </unit>
-    <unit id="1xlE8ex" name="caption.content">
-      <segment>
-        <source>caption.content</source>
-        <target>Съдържание</target>
-      </segment>
-    </unit>
-    <unit id="ZO.uqIZ" name="caption.settings">
-      <segment>
-        <source>caption.settings</source>
-        <target>Настройки</target>
-      </segment>
-    </unit>
-    <unit id="zOLL.7E" name="caption.configuration">
-      <segment>
-        <source>caption.configuration</source>
-        <target>Конфигурация</target>
-      </segment>
-    </unit>
-    <unit id="ipmA6Ah" name="caption.users_permissions">
-      <segment>
-        <source>caption.users_permissions</source>
-        <target>Потребители и права за достъп</target>
-      </segment>
-    </unit>
-    <unit id="kXNBV9S" name="caption.main_configuration">
-      <segment>
-        <source>caption.main_configuration</source>
-        <target>Основна конфигурация</target>
-      </segment>
-    </unit>
-    <unit id="_w7J5rZ" name="caption.contenttypes">
-      <segment>
-        <source>caption.contenttypes</source>
-        <target>Типове съдържание</target>
-      </segment>
-    </unit>
-    <unit id="drK.0GZ" name="caption.taxonomies">
-      <segment>
-        <source>caption.taxonomies</source>
-        <target>Таксономии</target>
-      </segment>
-    </unit>
-    <unit id="2RUXD4A" name="caption.menu_setup">
-      <segment>
-        <source>caption.menu_setup</source>
-        <target>Настройки на навицагията</target>
-      </segment>
-    </unit>
-    <unit id="wBKDkwl" name="caption.routing_setup">
-      <segment>
-        <source>caption.routing_setup</source>
-        <target>Конфигурация на маршрутите</target>
-      </segment>
-    </unit>
-    <unit id="i4cbdta" name="caption.all_configuration_files">
-      <segment>
-        <source>caption.all_configuration_files</source>
-        <target>Всички конфугурационни файлове</target>
-      </segment>
-    </unit>
-    <unit id="OpKTKAL" name="caption.maintenance">
-      <segment>
-        <source>caption.maintenance</source>
-        <target>Поддръжка</target>
-      </segment>
-    </unit>
-    <unit id="mfvtHPQ" name="caption.extensions">
-      <segment>
-        <source>caption.extensions</source>
-        <target>Разширения</target>
-      </segment>
-    </unit>
-    <unit id="2MtT_h0" name="caption.logviewer">
-      <segment>
-        <source>caption.logviewer</source>
-        <target>Преглед на дневника</target>
-      </segment>
-    </unit>
-    <unit id="Dvu2HQx" name="caption.api">
-      <segment>
-        <source>caption.api</source>
-        <target>ППИ (API)</target>
-      </segment>
-    </unit>
-    <unit id="K6TmK4B" name="caption.clear_cache">
-      <segment>
-        <source>caption.clear_cache</source>
-        <target>Изчисти кеш паметта</target>
-      </segment>
-    </unit>
-    <unit id="dd5MzCM" name="caption.translations">
-      <segment>
-        <source>caption.translations</source>
-        <target>Преводи / етикети</target>
-      </segment>
-    </unit>
-    <unit id="Wou02nK" name="caption.kitchensink">
-      <segment>
-        <source>caption.kitchensink</source>
-        <target>Всички компоненти</target>
-      </segment>
-    </unit>
-    <unit id="wLaDaK5" name="caption.about_bolt">
-      <segment>
-        <source>caption.about_bolt</source>
-        <target>За Болт</target>
-      </segment>
-    </unit>
-    <unit id="l4yt0BE" name="caption.file_management">
-      <segment>
-        <source>caption.file_management</source>
-        <target>Управление на файловете</target>
-      </segment>
-    </unit>
-    <unit id="bq6bSf4" name="caption.uploaded_files">
-      <segment>
-        <source>caption.uploaded_files</source>
-        <target>Качени файлове</target>
-      </segment>
-    </unit>
-    <unit id="K4D568R" name="caption.view_edit_templates">
-      <segment>
-        <source>caption.view_edit_templates</source>
-        <target>Преглед и редакция на шаблоните</target>
-      </segment>
-    </unit>
-    <unit id="UZFanGF" name="about.bolt_documentation">
-      <segment>
-        <source>about.bolt_documentation</source>
-        <target>Болт документация</target>
-      </segment>
-    </unit>
-    <unit id="b_RPpcB" name="general.greeting">
-      <segment>
-        <source>general.greeting</source>
-        <target>Привет, админ!</target>
-      </segment>
-    </unit>
-    <unit id="bmdn3u9" name="action.logout">
-      <segment>
-        <source>action.logout</source>
-        <target>Изход</target>
-      </segment>
-    </unit>
-    <unit id="zOfpTLD" name="action.edit_profile">
-      <segment>
-        <source>action.edit_profile</source>
-        <target>Редактирай профил</target>
-      </segment>
-    </unit>
-    <unit id="k.JymqB" name="about.visit_bolt">
-      <segment>
-        <source>about.visit_bolt</source>
-        <target>Посети Boltcms.io</target>
-      </segment>
-    </unit>
-    <unit id="wGlnx8X" name="general.phrase.search">
-      <segment>
-        <source>general.phrase.search</source>
-        <target>Търсене</target>
-      </segment>
-    </unit>
-    <unit id="O_m7mx1" name="listing.placeholder_search">
-      <segment>
-        <source>listing.placeholder_search</source>
-        <target>Търси клучова дума…</target>
-      </segment>
-    </unit>
-    <unit id="Dgtkgju" name="title.edit_user_profile">
-      <segment>
-        <source>title.edit_user_profile</source>
-        <target>Редактирай потребителски профил</target>
-      </segment>
-    </unit>
-    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment>
-        <source>admin_sidebar_toggler.toggle</source>
-        <target><![CDATA[<span class="sr-only">Превключи </span>меню	]]></target>
-      </segment>
-    </unit>
-    <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <segment>
-        <source>admin_sidebar.toggler</source>
-        <target>Превключи ширина на страничната лента</target>
-      </segment>
-    </unit>
-    <unit id="f.rvF6y" name="action.new">
-      <segment>
-        <source>action.new</source>
-        <target>Нов</target>
-      </segment>
-    </unit>
-    <unit id="TtmWqX3" name="action.view">
-      <segment>
-        <source>action.view</source>
-        <target>Прегледай</target>
+        <source>action.edit</source>
+        <target>Редактирай</target>
       </segment>
     </unit>
     <unit id="LDhDPrF" name="label.username">
+      <notes>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
+      </notes>
       <segment>
         <source>label.username</source>
         <target>Потребителско име</target>
       </segment>
     </unit>
-    <unit id="SeTqePC" name="label.display_name">
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
       <segment>
-        <source>label.display_name</source>
-        <target>Показано име</target>
+        <source>title.login</source>
+        <target>Вход</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
       <segment>
         <source>label.password</source>
         <target>Парола</target>
       </segment>
     </unit>
-    <unit id="D2N6_cP" name="label.email">
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
       <segment>
-        <source>label.email</source>
-        <target>Имейл адрес</target>
+        <source>action.log_in</source>
+        <target>Вход</target>
       </segment>
     </unit>
-    <unit id="mEDsKHk" name="label.locale">
+    <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
       <segment>
-        <source>label.locale</source>
-        <target>Локал</target>
+        <source>title.contentlisting</source>
+        <target>Списък на записи</target>
       </segment>
     </unit>
-    <unit id="N_0yRcH" name="action.close_alert">
+    <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
       <segment>
-        <source>action.close_alert</source>
-        <target>Затвори</target>
-      </segment>
-    </unit>
-    <unit id="z2AgHGp" name="flash_messages.notification">
-      <segment>
-        <source>flash_messages.notification</source>
-        <target>Известие</target>
-      </segment>
-    </unit>
-    <unit id="ruQIhH0" name="success">
-      <segment>
-        <source>success</source>
-        <target>Успех!</target>
-      </segment>
-    </unit>
-    <unit id="YDH.7uR" name="user.updated_profile">
-      <segment>
-        <source>user.updated_profile</source>
-        <target>Потребителският профил беше актуализиран!</target>
-      </segment>
-    </unit>
-    <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment>
-        <source>listing_filter.button_compact</source>
-        <target>Компактен</target>
-      </segment>
-    </unit>
-    <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment>
-        <source>listing_filter.button_expanded</source>
-        <target>Разширен</target>
-      </segment>
-    </unit>
-    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <segment>
-        <source>listing_table.actions.view_on_site</source>
-        <target>Виж на сайта</target>
-      </segment>
-    </unit>
-    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment>
-        <source>listing_table.actions.status_to_publish</source>
-        <target>Промени статуса на 'публикуван'</target>
-      </segment>
-    </unit>
-    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment>
-        <source>listing_table.actions.status_to_held</source>
-        <target>Промени статуса на 'задържан'</target>
-      </segment>
-    </unit>
-    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment>
-        <source>listing_table.actions.status_to_draft</source>
-        <target>Промени статуса на 'чернова'</target>
-      </segment>
-    </unit>
-    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment>
-        <source>listing_table.actions.duplicate</source>
-        <target>Копирай</target>
-      </segment>
-    </unit>
-    <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <segment>
-        <source>listing_table.actions.delete</source>
-        <target>Изтрий</target>
-      </segment>
-    </unit>
-    <unit id="5zbX1vo" name="listing_table.actions.slug">
-      <segment>
-        <source>listing_table.actions.slug</source>
-        <target>Път/линк</target>
-      </segment>
-    </unit>
-    <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <segment>
-        <source>listing_table.actions.created_on</source>
-        <target>Създаден на</target>
-      </segment>
-    </unit>
-    <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <segment>
-        <source>listing_table.actions.published_on</source>
-        <target>Публикуван на</target>
-      </segment>
-    </unit>
-    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment>
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Последно променен на</target>
-      </segment>
-    </unit>
-    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <segment>
-        <source>listing_table.actions.button_edit</source>
-        <target>Промени</target>
-      </segment>
-    </unit>
-    <unit id="AMxTho9" name="pager.previous">
-      <segment>
-        <source>pager.previous</source>
-        <target>Предишна страница</target>
-      </segment>
-    </unit>
-    <unit id="L_YQKUn" name="pager.next">
-      <segment>
-        <source>pager.next</source>
-        <target>Следваща страница</target>
-      </segment>
-    </unit>
-    <unit id="JEnqOi." name="title.primary_actions">
-      <segment>
-        <source>title.primary_actions</source>
-        <target>Основни действия</target>
-      </segment>
-    </unit>
-    <unit id="dQIY7_J" name="action.preview">
-      <segment>
-        <source>action.preview</source>
-        <target>Прегледай</target>
-      </segment>
-    </unit>
-    <unit id=".I3mIHo" name="label.current_status">
-      <segment>
-        <source>label.current_status</source>
-        <target>Настоящ статус</target>
-      </segment>
-    </unit>
-    <unit id="oxqDDuK" name="status.held">
-      <segment>
-        <source>status.held</source>
-        <target>Задържан</target>
-      </segment>
-    </unit>
-    <unit id="6Gw1lsE" name="action.confirm_delete">
-      <segment>
-        <source>action.confirm_delete</source>
-        <target>Сигурен/а ли си, че искаш да изтриеш настоящото съдържание?</target>
-      </segment>
-    </unit>
-    <unit id="hTKWQ6g" name="action.delete">
-      <segment>
-        <source>action.delete</source>
-        <target>Изтрий</target>
-      </segment>
-    </unit>
-    <unit id="7616Os4" name="title.options">
-      <segment>
-        <source>title.options</source>
-        <target>Опции</target>
+        <source>field.id</source>
+        <target>Идентификатор</target>
       </segment>
     </unit>
     <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
       <segment>
         <source>field.status</source>
         <target>Статус</target>
       </segment>
     </unit>
-    <unit id="utGAKaQ" name="status.published">
-      <segment>
-        <source>status.published</source>
-        <target>Публикуван</target>
-      </segment>
-    </unit>
-    <unit id="h7dP3WY" name="status.timed">
-      <segment>
-        <source>status.timed</source>
-        <target>Определен за време</target>
-      </segment>
-    </unit>
-    <unit id="HJbHjee" name="status.draft">
-      <segment>
-        <source>status.draft</source>
-        <target>Чернова</target>
-      </segment>
-    </unit>
-    <unit id="3gdi1dy" name="field.publishedAt">
-      <segment>
-        <source>field.publishedAt</source>
-        <target>Публикуван на</target>
-      </segment>
-    </unit>
-    <unit id="BINgtmK" name="editor_date.toggle">
-      <segment>
-        <source>editor_date.toggle</source>
-        <target>Превключи</target>
-      </segment>
-    </unit>
-    <unit id="eN7IfEL" name="field.depublishedAt">
-      <segment>
-        <source>field.depublishedAt</source>
-        <target>Отпубликуван на</target>
-      </segment>
-    </unit>
-    <unit id="aQX4Emy" name="field.author">
-      <segment>
-        <source>field.author</source>
-        <target>Автор</target>
-      </segment>
-    </unit>
     <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
       <segment>
         <source>field.createdAt</source>
         <target>Създаден на</target>
       </segment>
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
       <segment>
         <source>field.modifiedAt</source>
         <target>Променен на</target>
       </segment>
     </unit>
-    <unit id="SNELzJ2" name="field.id">
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
       <segment>
-        <source>field.id</source>
-        <target>Идентификатор</target>
+        <source>field.publishedAt</source>
+        <target>Публикуван на</target>
       </segment>
     </unit>
-    <unit id="HK7XTUX" name="caption.edit">
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
       <segment>
-        <source>caption.edit</source>
-        <target>Редактирай</target>
+        <source>field.depublishedAt</source>
+        <target>Отпубликуван на</target>
       </segment>
     </unit>
-    <unit id="XQ2U6fN" name="slug.button_unlocked">
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
       <segment>
-        <source>slug.button_unlocked</source>
-        <target>Отключен</target>
+        <source>field.title</source>
+        <target>Заглавие</target>
       </segment>
     </unit>
-    <unit id="kaK5Wdr" name="slug.button_locked">
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
       <segment>
-        <source>slug.button_locked</source>
-        <target>Заключен</target>
+        <source>field.description</source>
+        <target>Описание</target>
       </segment>
     </unit>
-    <unit id="qcDEz5O" name="slug.button_edit">
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
       <segment>
-        <source>slug.button_edit</source>
-        <target>Редактирай</target>
+        <source>field.copyright</source>
+        <target>Авторски права</target>
       </segment>
     </unit>
-    <unit id="raO5QSf" name="slug.generate_from">
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
       <segment>
-        <source>slug.generate_from</source>
-        <target>Генерирай от:</target>
+        <source>field.originalFilename</source>
+        <target>Оригинално име на файла</target>
       </segment>
     </unit>
-    <unit id="YZJO3Ul" name="upload.allow_file_types">
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
       <segment>
-        <source>upload.allow_file_types</source>
-        <target>Типове файлове, разрешени за прикачване:</target>
+        <source>field.width</source>
+        <target>Ширина</target>
       </segment>
     </unit>
-    <unit id="noOf4ML" name="upload.max_size">
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
       <segment>
-        <source>upload.max_size</source>
-        <target>Максимален размер на файла:</target>
-      </segment>
-    </unit>
-    <unit id="vptPhch" name="image.button_upload">
-      <segment>
-        <source>image.button_upload</source>
-        <target>Прикачи</target>
-      </segment>
-    </unit>
-    <unit id="vIVO1lU" name="image.button_from_library">
-      <segment>
-        <source>image.button_from_library</source>
-        <target>От библиотеката</target>
-      </segment>
-    </unit>
-    <unit id="FqVh1Hv" name="image.button_remove">
-      <segment>
-        <source>image.button_remove</source>
-        <target>Премахни</target>
-      </segment>
-    </unit>
-    <unit id="oOuVKRv" name="image.placeholder_filename">
-      <segment>
-        <source>image.placeholder_filename</source>
-        <target>Име на файл (прикачи нов файл или избери съществуващ)</target>
-      </segment>
-    </unit>
-    <unit id="BWubOnS" name="image.placeholder_alt_text">
-      <segment>
-        <source>image.placeholder_alt_text</source>
-        <target>Алтернативно съобщение</target>
-      </segment>
-    </unit>
-    <unit id="eHV6ZJB" name="image.button_edit_attributes">
-      <segment>
-        <source>image.button_edit_attributes</source>
-        <target>Редактирай атрибутите</target>
-      </segment>
-    </unit>
-    <unit id="kHeY93_" name="editor_embed.content_url">
-      <segment>
-        <source>editor_embed.content_url</source>
-        <target>Линк към съдържанието за вграждане</target>
-      </segment>
-    </unit>
-    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-      <segment>
-        <source>editor_embed.placeholder_content_url</source>
-        <target>Линк към съдържанието в Facebook (Фейсбук), Twitter (Туитър), Soundcloud (Саундклауд), Youtube (Ютюб), Vimeo (Вимео)…</target>
-      </segment>
-    </unit>
-    <unit id="1.Eb1GS" name="editor_embed.label_height">
-      <segment>
-        <source>editor_embed.label_height</source>
+        <source>field.height</source>
         <target>Височина</target>
       </segment>
     </unit>
-    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
       <segment>
-        <source>editor_embed.label_pixel</source>
-        <target>пиксел</target>
+        <source>field.filesize</source>
+        <target>Размер на файла</target>
       </segment>
     </unit>
-    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
       <segment>
-        <source>editor_embed.label_matched_embed</source>
-        <target>Съвпадащо съдържание за вграждане</target>
+        <source>label.username_or_email</source>
+        <target>Потребителско име или имейл</target>
       </segment>
     </unit>
-    <unit id="zATju4V" name="editor_embed.label_preview">
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
       <segment>
-        <source>editor_embed.label_preview</source>
-        <target>Прегледай</target>
+        <source>label.rememberme</source>
+        <target>Запомни ме?</target>
       </segment>
     </unit>
-    <unit id="9SQ0oaR" name="editor_embed.label_size">
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
       <segment>
-        <source>editor_embed.label_size</source>
-        <target>Размер</target>
+        <source>about.visit_bolt</source>
+        <target>Посети Boltcms.io</target>
       </segment>
     </unit>
-    <unit id="nrWBJNm" name="extensions.title_desc">
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
       <segment>
-        <source>extensions.title_desc</source>
-        <target>Описание:</target>
-      </segment>
-    </unit>
-    <unit id="7raDJAR" name="extensions.title_author">
-      <segment>
-        <source>extensions.title_author</source>
-        <target>Автор:</target>
-      </segment>
-    </unit>
-    <unit id="UP8pNGy" name="extensions.title_package">
-      <segment>
-        <source>extensions.title_package</source>
-        <target>Пакет / име на клас:</target>
-      </segment>
-    </unit>
-    <unit id="hgNZLwW" name="extensions.title_configuration">
-      <segment>
-        <source>extensions.title_configuration</source>
-        <target>Конфигурационен файл</target>
-      </segment>
-    </unit>
-    <unit id="QFQ1uTC" name="extensions.title_version">
-      <segment>
-        <source>extensions.title_version</source>
-        <target>Версия</target>
-      </segment>
-    </unit>
-    <unit id="BFARQEU" name="extensions.button_detailed_view">
-      <segment>
-        <source>extensions.button_detailed_view</source>
-        <target>Виж детайлите</target>
-      </segment>
-    </unit>
-    <unit id="mjhFljb" name="extensions.button_configuration">
-      <segment>
-        <source>extensions.button_configuration</source>
-        <target>Конфигурация</target>
-      </segment>
-    </unit>
-    <unit id="r3ryNTG" name="extensions.button_source">
-      <segment>
-        <source>extensions.button_source</source>
-        <target>Програмен код</target>
-      </segment>
-    </unit>
-    <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment>
-        <source>extensions.message_not_implemented</source>
-        <target>Все още не работи. Извинете!</target>
-      </segment>
-    </unit>
-    <unit id="qc3rFkZ" name="extensions.button_remove">
-      <segment>
-        <source>extensions.button_remove</source>
-        <target>Изтрий разширението</target>
-      </segment>
-    </unit>
-    <unit id="SLZyVzU" name="extensions.button_disable">
-      <segment>
-        <source>extensions.button_disable</source>
-        <target>Изключи разширението</target>
-      </segment>
-    </unit>
-    <unit id="rCKtTo5" name="caption.redirection_page">
-      <segment>
-        <source>caption.redirection_page</source>
-        <target>Страница за пренасочване</target>
-      </segment>
-    </unit>
-    <unit id="HBwIQ9b" name="controller.user.subtitle">
-      <segment>
-        <source>controller.user.subtitle</source>
-        <target>За редактиране на потребителите и техните права за достъп</target>
-      </segment>
-    </unit>
-    <unit id="Iy4HXCU" name="controller.user.title">
-      <segment>
-        <source>controller.user.title</source>
-        <target>Потребители и права за достъп</target>
-      </segment>
-    </unit>
-    <unit id="7cXqH5s" name="listing.title_display_name">
-      <segment>
-        <source>listing.title_display_name</source>
-        <target>Показано име</target>
-      </segment>
-    </unit>
-    <unit id="Ay7xZ2h" name="listing.title_username">
-      <segment>
-        <source>listing.title_username</source>
-        <target>Потребителско име</target>
-      </segment>
-    </unit>
-    <unit id="RN1tdtJ" name="listing.title_email">
-      <segment>
-        <source>listing.title_email</source>
-        <target>Имейл</target>
-      </segment>
-    </unit>
-    <unit id="0pjZ.GV" name="listing.title_roles">
-      <segment>
-        <source>listing.title_roles</source>
-        <target>Роли</target>
-      </segment>
-    </unit>
-    <unit id="hXEFV1n" name="listing.title_last_seen">
-      <segment>
-        <source>listing.title_last_seen</source>
-        <target>Възраст на сесията</target>
-      </segment>
-    </unit>
-    <unit id="pn7kE17" name="listing.title_last_ip">
-      <segment>
-        <source>listing.title_last_ip</source>
-        <target>Последно IP</target>
-      </segment>
-    </unit>
-    <unit id="GZ65uOC" name="listing.title_actions">
-      <segment>
-        <source>listing.title_actions</source>
-        <target>Действия</target>
-      </segment>
-    </unit>
-    <unit id="ovKkXwU" name="action.edit">
-      <segment>
-        <source>action.edit</source>
-        <target>Редактирай</target>
-      </segment>
-    </unit>
-    <unit id="ryXZRAu" name="action.disable">
-      <segment>
-        <source>action.disable</source>
-        <target>Деактиривай</target>
-      </segment>
-    </unit>
-    <unit id="3zlZmRK" name="action.add_user">
-      <segment>
-        <source>action.add_user</source>
-        <target>Добави потребител</target>
-      </segment>
-    </unit>
-    <unit id="Npkio79" name="listing.title_session_expires">
-      <segment>
-        <source>listing.title_session_expires</source>
-        <target>Изтичане на сесията</target>
-      </segment>
-    </unit>
-    <unit id="mmUDcto" name="listing.title_ip_address">
-      <segment>
-        <source>listing.title_ip_address</source>
-        <target>IP адрес</target>
-      </segment>
-    </unit>
-    <unit id="x9qAwrz" name="listing.title_browser">
-      <segment>
-        <source>listing.title_browser</source>
-        <target>Браузър / платформа</target>
-      </segment>
-    </unit>
-    <unit id="7whLbH8" name="user.new_user">
-      <segment>
-        <source>user.new_user</source>
-        <target>Нов потребител</target>
-      </segment>
-    </unit>
-    <unit id="1sstKF9" name="title.edit_user">
-      <segment>
-        <source>title.edit_user</source>
-        <target>Редактирай потребител</target>
-      </segment>
-    </unit>
-    <unit id="hiE9jap" name="password.suggested">
-      <segment>
-        <source>password.suggested</source>
-        <target><![CDATA[Предложена сигурна парола: <code>%password%</code>]]></target>
-      </segment>
-    </unit>
-    <unit id="iD6CNOO" name="label.roles">
-      <segment>
-        <source>label.roles</source>
-        <target>Роли</target>
-      </segment>
-    </unit>
-    <unit id="FSroufa" name="caption.path">
-      <segment>
-        <source>caption.path</source>
-        <target>Път</target>
-      </segment>
-    </unit>
-    <unit id="P1FHg3Q" name="caption.edit_file">
-      <segment>
-        <source>caption.edit_file</source>
-        <target>Редактирай файл</target>
-      </segment>
-    </unit>
-    <unit id="txRonia" name="label.id">
-      <segment>
-        <source>label.id</source>
-        <target>Идентификатор</target>
-      </segment>
-    </unit>
-    <unit id="IwLLxxx" name="label.level">
-      <segment>
-        <source>label.level</source>
-        <target>Ниво</target>
-      </segment>
-    </unit>
-    <unit id="51OQi14" name="label.message">
-      <segment>
-        <source>label.message</source>
-        <target>Съобщение</target>
-      </segment>
-    </unit>
-    <unit id="S0f6iTL" name="label.timestamp">
-      <segment>
-        <source>label.timestamp</source>
-        <target>Време</target>
-      </segment>
-    </unit>
-    <unit id="FlGE3qB" name="label.request">
-      <segment>
-        <source>label.request</source>
-        <target>Заявка (request)</target>
-      </segment>
-    </unit>
-    <unit id="l71Tprl" name="label.trace">
-      <segment>
-        <source>label.trace</source>
-        <target>Следа (trace)</target>
-      </segment>
-    </unit>
-    <unit id="29ZEo1r" name="label.context">
-      <segment>
-        <source>label.context</source>
-        <target>Контекст</target>
-      </segment>
-    </unit>
-    <unit id="O2X4xZH" name="label.user">
-      <segment>
-        <source>label.user</source>
-        <target>Потребител</target>
-      </segment>
-    </unit>
-    <unit id="2MMvCKK" name="label.cache_cleared">
-      <segment>
-        <source>label.cache_cleared</source>
-        <target>Кеш паметта беше изчистена успешно!</target>
-      </segment>
-    </unit>
-    <unit id="cH6rDCP" name="Button">
-      <segment>
-        <source>Button</source>
-        <target>Бутон</target>
-      </segment>
-    </unit>
-    <unit id="1LzKCXS" name="&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.">
-      <segment>
-        <source>&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.</source>
-        <target><![CDATA[<strong>Поздравления!</strong> Успешно пречете това важно известие.]]></target>
-      </segment>
-    </unit>
-    <unit id="Bicbr0l" name="info">
-      <segment>
-        <source>info</source>
-        <target>Информация</target>
-      </segment>
-    </unit>
-    <unit id="RaGzSx5" name="57d589f">
-      <segment>
-        <source>57d589f</source>
-        <target><![CDATA[<strong>Внимание</strong> Това известие се нуждае от внимание, но не е от изключителна важност.]]></target>
-      </segment>
-    </unit>
-    <unit id="S9k1S7Z" name="warning">
-      <segment>
-        <source>warning</source>
-        <target>Предупреждение</target>
-      </segment>
-    </unit>
-    <unit id="JYILFeM" name="&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.">
-      <segment>
-        <source>&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.</source>
-        <target><![CDATA[<strong>Предупреждение!</strong> Провери се, защото не изглеждаш много добре.]]></target>
-      </segment>
-    </unit>
-    <unit id="Ej.WZqo" name="danger">
-      <segment>
-        <source>danger</source>
-        <target>Опасност</target>
-      </segment>
-    </unit>
-    <unit id="OGd6iOm" name="&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.">
-      <segment>
-        <source>&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.</source>
-        <target><![CDATA[<strong>Ох, нещо се случи</strong> Промени няколко неща и опитай да изпратиш отново.]]></target>
-      </segment>
-    </unit>
-    <unit id="5IxD63c" name="general.latest_bolt_news">
-      <segment>
-        <source>general.latest_bolt_news</source>
-        <target>Последни новини от Болт</target>
-      </segment>
-    </unit>
-    <unit id="Pily_qo" name="general.phrase.read-more">
-      <segment>
-        <source>general.phrase.read-more</source>
-        <target>Прочети повече</target>
-      </segment>
-    </unit>
-    <unit id="a2vzLi7" name="action.do_something">
-      <segment>
-        <source>action.do_something</source>
-        <target>Направи нещо</target>
-      </segment>
-    </unit>
-    <unit id="hAysbHB" name="label.translatable">
-      <segment>
-        <source>label.translatable</source>
-        <target>Това поле може да се преведе</target>
-      </segment>
-    </unit>
-    <unit id="xN1kSQQ" name="caption.bolt_payoff">
-      <segment>
-        <source>caption.bolt_payoff</source>
-        <target>Функционална, лека и лесна система за управление на съдържанието</target>
-      </segment>
-    </unit>
-    <unit id="QVRwwK4" name="about.system_info">
-      <segment>
-        <source>about.system_info</source>
-        <target>Системна информация</target>
+        <source>about.bolt_documentation</source>
+        <target>Болт документация</target>
       </segment>
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
       <segment>
         <source>about.bolt_on_github</source>
         <target>Болт в GitHub</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
       <segment>
         <source>about.used_libraries</source>
         <target>Потребителски библиотеки / компоненти</target>
       </segment>
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Отдолу са външните библиотеки, използвани от Болт:</target>
       </segment>
     </unit>
-    <unit id="LaDIuZA" name="caption.meta_information">
+    <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
       <segment>
-        <source>caption.meta_information</source>
-        <target>Мета информация</target>
+        <source>label.email</source>
+        <target>Имейл адрес</target>
       </segment>
     </unit>
-    <unit id="73A2bWM" name="finder.label_view">
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
       <segment>
-        <source>finder.label_view</source>
-        <target>Виж:</target>
+        <source>label.about</source>
+        <target>Относно</target>
       </segment>
     </unit>
-    <unit id="m3tNvJb" name="finder.button_list">
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
       <segment>
-        <source>finder.button_list</source>
-        <target>Лист</target>
+        <source>user.updated_successfully</source>
+        <target>Успешно актуализиране</target>
       </segment>
     </unit>
-    <unit id="tRLgeoX" name="finder.button_cards">
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
       <segment>
-        <source>finder.button_cards</source>
-        <target>Карти</target>
+        <source>content.updated_successfully</source>
+        <target>Съдържанието е актуализирано успешно</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Медийният елемент е създаден успешно</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>Медийният елемент не можа да бъде записан</target>
+      </segment>
+    </unit>
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
+        <source>label.locale</source>
+        <target>Локал</target>
+      </segment>
+    </unit>
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
+        <source>The Default theme</source>
+        <target>Темата по подразбиране</target>
+      </segment>
+    </unit>
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>The Default Dark theme</source>
+        <target>Тъмната тема по подразбиране</target>
+      </segment>
+    </unit>
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Прилича малко на онази другата CMS</target>
+      </segment>
+    </unit>
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.dashboard</source>
+        <target>Болт табло</target>
+      </segment>
+    </unit>
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>caption.clear_cache</source>
+        <target>Изчисти кеш паметта</target>
+      </segment>
+    </unit>
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
+        <source>caption.menu_setup</source>
+        <target>Настройки на навицагията</target>
+      </segment>
+    </unit>
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
+        <source>caption.taxonomies</source>
+        <target>Таксономии</target>
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
+        <source>caption.contenttypes</source>
+        <target>Типове съдържание</target>
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
+        <source>caption.main_configuration</source>
+        <target>Основна конфигурация</target>
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
+        <source>caption.users_permissions</source>
+        <target>Потребители и права за достъп</target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Конфигурация</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Настройки</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Съдържание</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Управление на файловете</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Разширения</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target>Преглед и редакция на шаблоните</target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Качени файлове</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Конфигурация на маршрутите</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Преводи / етикети</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>За Болт</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target>Функционална, лека и лесна система за управление на съдържанието</target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Редактирай</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Прикачване на файлове</target>
       </segment>
     </unit>
-    <unit id="283aB_E" name="caption.file_upload.upload_text">
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
-        <source>caption.file_upload.upload_text</source>
-        <target>Пусни файлове тук, за да прикачиш</target>
-      </segment>
-    </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Папки</target>
-      </segment>
-    </unit>
-    <unit id="KHvGNGW" name="directoryname">
-      <segment>
-        <source>directoryname</source>
-        <target>Име на директорията</target>
-      </segment>
-    </unit>
-    <unit id="Kw3N1AA" name="actions">
-      <segment>
-        <source>actions</source>
-        <target>Действия</target>
-      </segment>
-    </unit>
-    <unit id="_XSgfqS" name="filename">
-      <segment>
-        <source>filename</source>
-        <target>Име на файла</target>
-      </segment>
-    </unit>
-    <unit id="gPYflhh" name="thumbnail">
-      <segment>
-        <source>thumbnail</source>
-        <target>Миниатюра</target>
-      </segment>
-    </unit>
-    <unit id="zNy_hG8" name="size">
-      <segment>
-        <source>size</source>
-        <target>Размер</target>
+        <source>caption.meta_information</source>
+        <target>Мета информация</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Дата</target>
       </segment>
     </unit>
-    <unit id="QQvRJe." name="files_cards.button_toggle">
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
-        <source>files_cards.button_toggle</source>
-        <target>Превключи падащото меню</target>
+        <source>size</source>
+        <target>Размер</target>
       </segment>
     </unit>
-    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
-        <source>files_cards.action_edit_image_info</source>
-        <target>Промени информацията на снимката</target>
+        <source>thumbnail</source>
+        <target>Миниатюра</target>
       </segment>
     </unit>
-    <unit id="H1pgP94" name="files_cards.action_view_original">
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
-        <source>files_cards.action_view_original</source>
-        <target>Виж оригинала</target>
+        <source>filename</source>
+        <target>Име на файла</target>
       </segment>
     </unit>
-    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
-        <source>files_cards.action_duplicate</source>
-        <target>Копирай</target>
+        <source>actions</source>
+        <target>Действия</target>
       </segment>
     </unit>
-    <unit id="wHPoBzP" name="file.delete_confirm">
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
-        <source>file.delete_confirm</source>
-        <target>Сигурен/а ли си, че искаш да изтриеш този файл?</target>
+        <source>directoryname</source>
+        <target>Име на директорията</target>
       </segment>
     </unit>
-    <unit id="JjU6ZQP" name="files_cards.action_delete">
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
-        <source>files_cards.action_delete</source>
-        <target>Изтрий</target>
+        <source>form.quick_select_file</source>
+        <target>Бързо изберете файл за редактиране…</target>
       </segment>
     </unit>
-    <unit id="3jdNwuk" name="files_cards.label_filename">
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
-        <source>files_cards.label_filename</source>
-        <target>Име на файла:</target>
+        <source>caption.path</source>
+        <target>Път</target>
       </segment>
     </unit>
-    <unit id="Y90_Pn1" name="files_cards.label_title">
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
-        <source>files_cards.label_title</source>
-        <target>Заглавие:</target>
-      </segment>
-    </unit>
-    <unit id="EdCfIKX" name="files_cards.label_dimensions">
-      <segment>
-        <source>files_cards.label_dimensions</source>
-        <target>Размери:</target>
-      </segment>
-    </unit>
-    <unit id="eQBhceV" name="files_cards.label_filesize">
-      <segment>
-        <source>files_cards.label_filesize</source>
-        <target>Размер на файла:</target>
-      </segment>
-    </unit>
-    <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <segment>
-        <source>files_cards.label_created_on</source>
-        <target>Създаден на</target>
-      </segment>
-    </unit>
-    <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <segment>
-        <source>files_cards.action_edit_file</source>
-        <target>Редактирай файла в редактора</target>
-      </segment>
-    </unit>
-    <unit id=".fL0AbE" name="files_list.remark">
-      <segment>
-        <source>files_list.remark</source>
-        <target>Няма файлове в настоящата папка. Избери папка.</target>
-      </segment>
-    </unit>
-    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <segment>
-        <source>listing_select_box.card_header.selected</source>
-        <target>Избран(и)</target>
-      </segment>
-    </unit>
-    <unit id="WeJxw6Z" name="action.update_all">
-      <segment>
-        <source>action.update_all</source>
-        <target>Приложи за всички</target>
-      </segment>
-    </unit>
-    <unit id="vJwSCBO" name="title.contentlisting">
-      <segment>
-        <source>title.contentlisting</source>
-        <target>Списък на записи</target>
+        <source>caption.filename</source>
+        <target>Име на файла</target>
       </segment>
     </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Създай нов</target>
       </segment>
     </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Привет, %name%!</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Изход</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Редактирай профил</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>Затвори</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>ППИ (API)</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Всички конфугурационни файлове</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Поддръжка</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Редактирай файл</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Текуща локализация</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Превключи към локализация</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Автор</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Редактиране</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Неизвестно</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Написано от %name% на %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>Страницата „Относно“ липсва</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Блокът „Относно“ липсва</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>Скорошни %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>…</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Търсене</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Преглед на %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Не са намерени скорошни %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Меню</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Търсене</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Постоянна връзка</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>Кеш паметта беше изчистена успешно!</target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Всички компоненти</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Резултати от търсенето за „%search%“.</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>Няма намерени резултати за „%search%“.</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Моля, въведете дума за търсене, за да се покажат подходящи резултати.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Прочети повече</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Този уебсайт е <a href='https://boltcms.io' target='_blank' title='Изтънчена, лека и проста CMS'>създаден с Bolt</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Последни новини от Болт</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Прегледай</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Преглед на запазената версия</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Показано име</target>
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.duplicate</source>
+        <target>Дублиране</target>
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
+        <source>label.new_password</source>
+        <target>Нова парола</target>
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
+        <source>editfile.updated_successfully</source>
+        <target>Файлът е актуализиран успешно!</target>
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
+        <source>action.add_user</source>
+        <target>Добави потребител</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Успех!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>Потребителският профил беше актуализиран!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Роли</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Нов потребител</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Прегледай</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Заключен</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Редактирай</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Генерирай от:</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Прикачи</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>От библиотеката</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Виж на сайта</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Промени статуса на 'публикуван'</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Промени статуса на 'задържан'</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Промени статуса на 'чернова'</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Копирай</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Изтрий</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Път/линк</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Създаден на</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Публикуван на</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Последно променен на</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Избран(и)</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>Линк към съдържанието за вграждане</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>Линк към съдържанието в Facebook (Фейсбук), Twitter (Туитър), Soundcloud (Саундклауд), Youtube (Ютюб), Vimeo (Вимео)…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Височина</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>пиксел</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Съвпадащо съдържание за вграждане</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Прегледай</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Размер</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Име на файл (прикачи нов файл или избери съществуващ)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Алтернативно съобщение</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Атрибут Title</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Превключи ширина на страничната лента</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Превключи </span>меню	]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Превключи</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Известие</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Виж информация за локализацията</target>
+      </segment>
+    </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Сортирай по</target>
       </segment>
     </unit>
-    <unit id="hp554Ds" name="listing.option_select_sortby">
-      <segment>
-        <source>listing.option_select_sortby</source>
-        <target>Избери поле за сортиране</target>
-      </segment>
-    </unit>
-    <unit id="IWbf2by" name="listing.title_filterby">
-      <segment>
-        <source>listing.title_filterby</source>
-        <target>Търси / филтрирай по</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Дума за търсене</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Търсене</target>
       </segment>
     </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Изчисти сортиране/филтър</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>По подразбиране</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Липсва</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Превключи падащото меню</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Промени информацията на снимката</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Редактирай файла в редактора</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Виж оригинала</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Копирай</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Изтрий</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Име на файла:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Заглавие:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Размери:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Размер на файла:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Създаден на</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Няма файлове в настоящата папка. Избери папка.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Изберете файл:</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Лист</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Карти</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Описание:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Автор:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Пакет / име на клас:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Версия</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Това е локален пакет, не е инсталиран чрез Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Име на класа:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Конфигурация</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Програмен код</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Изтрий разширението</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Изключи разширението</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Вход</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Все още не работи. Извинете!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Общ преглед на</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>В тази папка няма файлове. Изберете папка за навигация от дясната страна.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Компактен</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Разширен</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Виж:</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Промени</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target>Потребители и права за достъп</target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>За редактиране на потребителите и техните права за достъп</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Показано име</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Потребителско име</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>Имейл</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Роли</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Възраст на сесията</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Последно IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Действия</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Неизвестен потребител</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Преобладаващи цветове в изображението</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Преглед за „%slug%“</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Свързано съдържание</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Търсене</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Нов %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>Неозаглавен %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Редактирай потребителски профил</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Страница за пренасочване</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Редактиране на изображение</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Предложена сигурна парола: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Изрязване X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Позиция на изрязване по оста X, диапазон 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Позиция на изрязване по оста Y, диапазон 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Изрязване Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Коефициент на мащабиране при изрязване</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Ниво на мащабиране при изрязване, диапазон 1-10.</target>
+      </segment>
+    </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>Тип съдържание</target>
       </segment>
     </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Няма намерени резултати. Разширете критериите за филтриране или добавете още съдържание.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Избери поле за сортиране</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Основни действия</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Опции</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Изтрий</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Активиране</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Деактиривай</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>Изтичане на сесията</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>IP адрес</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Браузър / платформа</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Премахни</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Редактирай атрибутите</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Добавяне на ново изображение</target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Добавяне на нов файл</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Премахване на елемент</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Добавяне на нов елемент към „%name%“</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Премести нагоре</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Премести надолу</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Виж детайлите</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Конфигурационен файл</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Пусни файлове тук, за да прикачиш</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Следваща страница</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Предишна страница</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Нагоре</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Надолу</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Изтегляне</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Преглед на дневника</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Заявка (request)</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Следа (trace)</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Контекст</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>Идентификатор</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Ниво</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Съобщение</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Време</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Потребител</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Деактивирано</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Отключен</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Няма намерено съдържание</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Няма</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Празно</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Приложи за всички</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Системна информация</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Сигурен/а ли си, че искаш да изтриеш настоящото съдържание?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>вашето потребителско име или имейл</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>вашата парола</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Друго съдържание</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>Запазването е деактивирано, защото целевият файл не може да бъде записан.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Това поле може да се преведе</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Съдържание</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>Файлът е изтрит успешно!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Сигурен/а ли си, че искаш да изтриеш този файл?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Търси / филтрирай по</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Статусът е променен успешно</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Съдържанието е изтрито успешно</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Настоящ статус</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Публикуван</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Чернова</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Определен за време</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Задържан</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Сигурни ли сте, че искате да изтриете този елемент от колекцията?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Типове файлове, разрешени за прикачване:</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Максимален размер на файла:</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Търси клучова дума…</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Цялото съдържание, филтрирано по <em>„%filter%“</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Преглед на уебсайта</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Нов</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Няма известни зависимости</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Зависимости</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Разгъни всички</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Свий всички</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>Дефиницията за този тип съдържание (ContentType) липсва! Редактирането на този запис няма да работи според очакванията. Моля, проверете вашия файл contenttypes.yaml, за да се уверите, че съдържа %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Изберете …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Моля, въведете вашето потребителско име или имейл</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Моля, въведете вашата парола</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Моля, въведете вашия имейл</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Филтриране по поле</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>От URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Копирай връзката към файла</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Предупреждение</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Папката вече съществува</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Папката не можа да бъде създадена</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Папката е създадена успешно.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Папката е изтрита успешно</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Нова папка</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Аватар</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Забравена парола</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Нулиране на паролата</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Въведете вашия имейл адрес и ще ви изпратим връзка за нулиране на паролата.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Изпрати</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Имейл</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Обратно към входа</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Нулиране на вашата парола</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Имейлът за нулиране на паролата е изпратен</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Изпратен е имейл, който съдържа връзка, върху която можете да кликнете, за да нулирате паролата си. Тази връзка ще изтече след %hours% часа.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Ако не получите имейл, моля, проверете папката със спам или %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Нулиране на паролата</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Здравейте!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>За да нулирате паролата си, моля, посетете следната връзка</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Тази връзка ще изтече след %hours% часа.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Благодарим!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Моля, въведете парола</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Повторете паролата</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Полетата за парола трябва да съвпадат.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Вашата парола трябва да е поне %s символа</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Не е намерен токен за нулиране на паролата в URL адреса или в сесията.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Вашата парола беше нулирана успешно.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Възникна проблем при обработката на вашата заявка за нулиране на паролата - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>филтрирано по</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Споделяне на защитена връзка за преглед</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Спри симулация на роля</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Представяне като друг потребител</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Режимът на поддръжка е активиран</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Опресняване</target>
+      </segment>
+    </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
       <segment>
         <source>listing_details_box.showing_records</source>
         <target>Показва записи %current% от общо %total%</target>
       </segment>
     </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
       <segment>
         <source>listing_details_box.name</source>
         <target>Име: %name% (единично: %singularName%)</target>
       </segment>
     </unit>
     <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
       <segment>
         <source>listing_details_box.slug</source>
         <target>Слъг: %slug% (единичен: %singularSlug%)</target>
       </segment>
     </unit>
     <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
       <segment>
         <source>listing_details_box.record_template</source>
         <target>Единичен шаблон: %template%</target>
       </segment>
     </unit>
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
       <segment>
         <source>listing_details_box.listing_template</source>
-        <target>Шаблон за списък: %template%</target>
+        <target>Шаблон за списък: %template% (%listingRecords% записа)</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
       <segment>
         <source>listing_details_box.locales</source>
         <target>Локали: %locales%</target>
       </segment>
     </unit>
-    <unit id="zYeSeNJ" name="action.stop_impersonating">
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
       <segment>
-        <source>action.stop_impersonating</source>
-        <target>Спри симулация на роля</target>
+        <source>action.edit_permissions</source>
+        <target>Редактиране на разрешенията</target>
       </segment>
     </unit>
-    <unit id="Hlf9c1s" name="listing.title_overview">
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
       <segment>
-        <source>listing.title_overview</source>
-        <target>Общ преглед на</target>
+        <source>general.label.search</source>
+        <target>Търсене</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Преглед на изображението</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Избери всички</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Запомни ме? (%duration% дни)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Текущи сесии</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Опции за качване</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Подредба</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>вашият имейл</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Изберете файл</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Изберете изображение</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Качване от URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Зареждане...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Запази</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Затвори</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -1,254 +1,120 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="cs">
   <file id="messages.cs">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment state="translated">
-        <source>not_available</source>
-        <target>Nedostupný</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error.name</source>
-        <target>Chyba %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error.description</source>
-        <target>Objevila se neznámá chyba (HTTP %status_code%), která zabránila v dokončení požadavku.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Zkuste tuto stránku načíst znovu během několika minut nebo <a href="%url%">přejděte na domovskou stránku</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_403.description</source>
-        <target>K tomuto prostředku nemáte přístup.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_403.suggestion</source>
-        <target>Požádejte svého manažera či systémového administrátora, aby vám přiřadil potřebná práva.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_404.description</source>
-        <target>Nepodařilo se nám najít požadovanou stránku.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Zkontrolujte, zda jste neudělali chybu v adrese nebo <a href="%url%">přejděte na domovskou stránku</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_500.description</source>
-        <target>Došlo k interní chybě serveru.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_500.suggestion</source>
-        <target>Zkuste tuto stránku načíst znovu během několika minut nebo &lt;a href="%url%"&gt;přejděte na domovskou stránku&lt;/a&gt;.</target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment state="translated">
-        <source>title.source_code</source>
-        <target>Zdrojový kód použit pro vykreslení této stránky</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment state="translated">
-        <source>title.controller_code</source>
-        <target>Kód controlleru</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment state="translated">
-        <source>title.twig_template_code</source>
-        <target>Kód Twig šablony</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>title.edit_user</source>
         <target>Upravit uživatele</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment state="translated">
-        <source>action.show_code</source>
-        <target>Zobraz kód</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>action.save</source>
         <target>Uložit změny</target>
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
-      <segment state="translated">
-        <source>action.do_something</source>
-        <target>Zmáčkni mě</target>
-      </segment>
-    </unit>
-    <unit id="etGJjTo" name="action.edit_user">
       <notes>
-        <note>templates/users/change_password.twig:26</note>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
       </notes>
-      <segment state="translated">
-        <source>action.edit_user</source>
-        <target>Upravit uživatele</target>
+      <segment>
+        <source>action.do_something</source>
+        <target>Udělej něco</target>
       </segment>
     </unit>
     <unit id="ovKkXwU" name="action.edit">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
         <source>action.edit</source>
         <target>Upravit</target>
       </segment>
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.username</source>
         <target>Uživatelské jméno</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment state="translated">
-        <source>help.show_code</source>
-        <target><![CDATA[Klikněte na toto tlačítko pro zobrazení zdrojového kódu <strong>controlleru</strong> a <strong>šablony</strong> použité pro vykreslení této stránky.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment state="translated">
-        <source>info.change_password</source>
-        <target>Po změně hesla budete odhlášeni.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>title.login</source>
         <target>Přihlášení</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.password</source>
         <target>Heslo</target>
       </segment>
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>action.log_in</source>
         <target>Přihlásit se</target>
       </segment>
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
-        <target>Contentlisting</target>
-      </segment>
-    </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment state="translated">
-        <source>action.change_password</source>
-        <target>Změnit heslo</target>
+        <target>Výpis obsahu</target>
       </segment>
     </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,2447 +123,3312 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.status</source>
         <target>Stav</target>
       </segment>
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.createdAt</source>
         <target>Vytvořeno</target>
       </segment>
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.modifiedAt</source>
         <target>Upraveno</target>
       </segment>
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.publishedAt</source>
         <target>Zveřejněno</target>
       </segment>
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.depublishedAt</source>
-        <target>Ztáhnuto</target>
+        <target>Staženo</target>
       </segment>
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.title</source>
         <target>Titulek</target>
       </segment>
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.description</source>
         <target>Popis</target>
       </segment>
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.copyright</source>
         <target>Autorská práva</target>
       </segment>
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.originalFilename</source>
         <target>Původní název souboru</target>
       </segment>
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.width</source>
-        <target>šířka</target>
+        <target>Šířka</target>
       </segment>
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.height</source>
-        <target>výška</target>
+        <target>Výška</target>
       </segment>
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.filesize</source>
         <target>Velikost souboru</target>
       </segment>
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.username_or_email</source>
-        <target>Uživatelské jméno nebo heslo</target>
+        <target>Uživatelské jméno nebo e-mail</target>
       </segment>
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.rememberme</source>
         <target>Zapamatuj si mě?</target>
       </segment>
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.visit_bolt</source>
         <target>Navštivte Boltcms.io</target>
       </segment>
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.bolt_documentation</source>
         <target>Dokumentace Bolt</target>
       </segment>
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.bolt_on_github</source>
         <target>Bolt na Githubu</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.used_libraries</source>
-        <target>Uživatelské knihovny / komponenty</target>
+        <target>Použité knihovny / komponenty</target>
       </segment>
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.list_of_used_libraries</source>
         <target>Níže jsou uvedeny knihovny třetích stran, které Bolt používá.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment state="translated">
-        <source>label.fullname</source>
-        <target>Celé jméno</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.email</source>
         <target>Emailová adresa</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>O uživateli</target>
+      </segment>
+    </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>user.updated_successfully</source>
         <target>Aktualizace proběhla úspěšně</target>
       </segment>
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>content.updated_successfully</source>
         <target>Obsah byl úspěšně upraven</target>
       </segment>
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>content.created_successfully</source>
         <target>Médium bylo úspěšně vytvořeno</target>
       </segment>
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>editfile.could_not_write</source>
         <target>Médium se nepodařilo zapsat</target>
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
         <source>label.locale</source>
         <target>Jazyk</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment state="translated">
-        <source>label.backend_theme</source>
-        <target>Šablona administrace</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
         <source>The Default theme</source>
         <target>Výchozí šablona</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
         <source>The Default Dark theme</source>
         <target>Výchozí tmavá šablona</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Vypadá tak trochu jako jiné CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.dashboard</source>
         <target>Nástěnka Bolt</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment state="translated" subState="poedit:fuzzy">
-        <source>caption.translations: messages</source>
-        <target>caption.translations: messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
         <source>caption.clear_cache</source>
         <target>Vyčistit cache</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment state="translated">
-        <source>caption.check_database</source>
-        <target>Zkontrolovat databázi</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment state="translated" subState="poedit:fuzzy">
-        <source>caption.routing set up</source>
-        <target>caption.routing set up</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
         <source>caption.menu_setup</source>
         <target>Nastavení menu</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
         <source>caption.taxonomies</source>
         <target>Taxonomie</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
         <source>caption.contenttypes</source>
         <target>Typy obsahu</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
         <source>caption.main_configuration</source>
         <target>Hlavní konfigurace</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Uživatelé & oprávnění]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
         <source>caption.configuration</source>
         <target>Konfigurace</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
         <source>caption.settings</source>
         <target>Nastavení</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
         <source>caption.content</source>
         <target>Obsah</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.file_management</source>
         <target>Správa souborů</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.extensions</source>
         <target>Rozšíření</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
         <source>caption.view_edit_templates</source>
         <target><![CDATA[Zobrazit & upravit šablony]]></target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
         <source>caption.uploaded_files</source>
         <target>Nahrané soubory</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
         <source>caption.routing_setup</source>
         <target>Konfigurace routingu</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
         <source>caption.translations</source>
-        <target>Překlady / značky</target>
+        <target>Překlady / popisky</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.about_bolt</source>
         <target>O Boltu</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
         <source>caption.bolt_payoff</source>
         <target><![CDATA[Sofistikovaný, lehký & jednoduchý CMS]]></target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
         <source>caption.edit</source>
         <target>Upravit</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
         <source>caption.file_uploader</source>
         <target>Nahrávač souborů</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
         <source>caption.meta_information</source>
         <target>Meta informace</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
         <source>date</source>
         <target>Datum</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
         <source>size</source>
         <target>Velikost</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
         <source>thumbnail</source>
         <target>Miniatura</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
         <source>filename</source>
-        <target>Název soubru</target>
+        <target>Název souboru</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
         <source>actions</source>
         <target>Akce</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
         <source>directoryname</source>
         <target>Název složky</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment state="translated">
-        <source>action.go</source>
-        <target>Přejít</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
         <source>form.quick_select_file</source>
         <target>Rychle zvolit soubor k editaci…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment state="translated">
-        <source>label.quick_select</source>
-        <target>Rychlý výběr</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
         <source>caption.path</source>
         <target>Cesta</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
-      <segment state="translated">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
         <source>caption.filename</source>
         <target>Název souboru</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment state="translated">
-        <source>action.visit_site</source>
-        <target>Navštívit stránky</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
         <source>action.create_new</source>
         <target>Vytvořit nové</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
         <source>general.greeting</source>
         <target>Ahoj, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
         <source>action.logout</source>
         <target>Odhlásit se</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
         <source>action.edit_profile</source>
         <target>Upravit profil</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
         <source>action.close_alert</source>
         <target>zavřít</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
         <source>caption.all_configuration_files</source>
         <target>Všechny konfigurační soubory</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
         <source>caption.maintenance</source>
         <target>Údržba</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fixtures (Dummy Content)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
         <source>caption.edit_file</source>
         <target>Upravit soubor</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment state="translated">
-        <source>caption.installation_checks</source>
-        <target>Kontroly instalace</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment state="translated">
-        <source>form.select_language</source>
-        <target>Vybrat jazyk</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment state="translated">
-        <source>field.locale</source>
-        <target>Jazyk</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
         <source>field.current_locale</source>
         <target>Aktuální jazyk</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
         <source>field.switch_to_locale</source>
         <target>Přepnout na jazyk</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
         <source>field.author</source>
         <target>Autor</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
         <source>general.phrase.edit</source>
         <target>Upravit</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
         <source>Unknown</source>
         <target>Neznámé</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
         <source>general.phrase.written-by-on</source>
         <target>Napsal(a) %name% dne %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page</source>
         <target>Stránka "O nás" chybí</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>Blok "O nás" chybí</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.recent</source>
         <target>Nedávné %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
         <source>general.phrase.search</source>
         <target>Vyhledávání</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment state="translated">
-        <source>9fb3e6e</source>
-        <target>Tyto stránky jsou &lt;a href='%url%' target='_blank' title='Sofistikovaný, lehký &amp; jednoduchý CMS'&gt;postaveny na Boltu&lt;/a&gt;.</target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.overview</source>
         <target>Přehled %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Žádný nedávný %contenttype% nebyl nalezen</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
         <source>Menu</source>
         <target>Menu</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
-      <segment state="translated">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
         <source>Search</source>
         <target>Hledat</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
         <source>general.phrase.permalink</source>
         <target>Trvalý odkaz</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment state="translated">
-        <source>label.displayname</source>
-        <target>Zobrazované jméno</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
         <source>label.cache_cleared</source>
         <target>Cache byla úspěšně vyčištěna!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
-        <target>The Kitchensink</target>
-      </segment>
-    </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment state="translated">
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Výsledky hledání pro '%search%'.</target>
+        <target>Všehochuť (Kitchensink)</target>
       </segment>
     </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>general.phrase.search-results-for</source>
         <target>Výsledky hledání pro '%search%'.</target>
       </segment>
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>general.phrase.no-search-results-for</source>
         <target>Pro '%search%' nebyly nalezeny žádné výsledky.</target>
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Pro zobrazení relevantních výsledků, prosím zadejte termín pro hledání.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
         <source>general.phrase.read-more</source>
         <target>Číst dále</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
         <source>general.phrase.built-with-bolt</source>
         <target><![CDATA[Tyto stránky jsou <a href='https://boltcms.io' target='_blank' title='Sofistikovaný, lehký & jednoduchý CMS'>postaveny na Boltu</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
-      <segment state="translated">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
         <source>general.latest_bolt_news</source>
         <target>Novinky Boltu</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
         <source>action.preview</source>
         <target>Náhled</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
         <source>action.view_saved</source>
         <target>Zobrazit uloženou verzi</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
         <source>label.display_name</source>
         <target>Zobrazované jméno</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
         <source>caption.duplicate</source>
-        <target>Kopie</target>
-      </segment>
-    </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment state="translated">
-        <source>label.current_password</source>
-        <target>Aktuální heslo</target>
+        <target>Duplikovat</target>
       </segment>
     </unit>
     <unit id="iiWFLaI" name="label.new_password">
-      <segment state="translated">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
         <source>label.new_password</source>
         <target>Nové heslo</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment state="translated">
-        <source>label.new_password_confirm</source>
-        <target>Nové heslo (znovu)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
         <source>editfile.updated_successfully</source>
         <target>Soubor byl úspěšně aktualizován!</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
         <source>action.add_user</source>
         <target>Přidat uživatele</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
         <source>success</source>
         <target>Úspěch!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
         <source>user.updated_profile</source>
         <target>Uživatelský profil byl aktualizován!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
         <source>label.roles</source>
         <target>Role</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
         <source>user.new_user</source>
         <target>Nový uživatel</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
         <source>action.view</source>
         <target>Zobrazit</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment state="translated">
-        <source>caption.folders</source>
-        <target>Složky</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
         <source>slug.button_locked</source>
         <target>Uzamčeno</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
         <source>slug.button_edit</source>
         <target>Upravit</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
         <source>slug.generate_from</source>
         <target>Vygenerovat z:</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
         <source>image.button_upload</source>
         <target>Nahrát</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
         <source>image.button_from_library</source>
         <target>Z knihovny</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>Zobrazit na stránkách</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Změnit stav na 'zveřejněno'</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Změnit stav na 'pozdrženo'</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Změnit stav na 'koncept'</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Duplikovat</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.delete</source>
         <target>Smazat</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.created_on</source>
         <target>Vytvořeno</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.published_on</source>
         <target>Zveřejněno</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Naposledy upraveno</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Vybráno</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment state="translated">
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>vybrané id předaných položek</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment state="translated">
-        <source>listing_select_box.card_body.remark</source>
-        <target>(tyto mohou být použity s něčím jako axios pro hromadnou úpravu/mazání)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
         <source>editor_embed.content_url</source>
         <target>URL adresa obsahu pro vložení</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL adresa obsahu na Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
         <source>editor_embed.label_height</source>
         <target>Výška</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
         <source>editor_embed.label_pixel</source>
         <target>pixel</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Přiřazená vložená položka</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
         <source>editor_embed.label_preview</source>
         <target>Náhled</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
         <source>editor_embed.label_size</source>
         <target>Velikost</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
         <source>image.placeholder_filename</source>
         <target>Název souboru (nahrajte nový soubor nebo vyberte existující)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
         <source>image.placeholder_alt_text</source>
         <target>Alt atribut</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
         <source>image.placeholder_title</source>
         <target>Title atribut</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <segment state="translated">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
         <source>admin_sidebar.toggler</source>
         <target>Přepnout šířku panelu</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment state="translated">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[<span class="sr-only">Přepnout </span>menu]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
         <source>editor_date.toggle</source>
         <target>Přepnout</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment state="translated">
-        <source>file.label_filename</source>
-        <target>Název souboru</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment state="translated">
-        <source>file.label_title</source>
-        <target>Titulek</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment state="translated">
-        <source>file.button_view</source>
-        <target>Zobrazit obrázek</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment state="translated">
-        <source>file.button_upload</source>
-        <target>Nahrát obrázek</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment state="translated">
-        <source>file.remark</source>
-        <target><![CDATA[Poznámka: Toto pole je prakticky stejné jako pole <code>image</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment state="translated">
-        <source>filelist.remark</source>
-        <target><![CDATA[Poznámka: Toto pole je prakticky stejné jako pole <code>imagelist</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment state="translated">
-        <source>geolocation.label_geolocation</source>
-        <target>Geolokace:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment state="translated">
-        <source>geolocation.label_address</source>
-        <target>Vyhledávání adresy</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment state="translated">
-        <source>geolocation.placeholder_address</source>
-        <target>Ulice, PSČ, město nebo jiná lokace…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment state="translated">
-        <source>geolocation.label_lat</source>
-        <target>Zeměpisná šířka</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment state="translated">
-        <source>geolocation.label_address_matched</source>
-        <target>Souhlasící adresa</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment state="translated">
-        <source>geolocation.label_marker</source>
-        <target>Umístění popisovače</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment state="translated">
-        <source>geolocation.label_control</source>
-        <target>Připnout k nejbližší adrese</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment state="translated">
-        <source>geolocation.label_long</source>
-        <target>Zeměpisná délka</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment state="translated">
-        <source>imagelist.remark</source>
-        <target><![CDATA[Poznámka: Toto pole je prakticky stejné jako pole <code>filelist</code>.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
         <source>flash_messages.notification</source>
         <target>Oznámení</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Zobrazit rozbalovací nabídku</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
         <source>localeswitcher.button_info</source>
         <target>Zobrazit informace o lokalizaci</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
         <source>listing.title_sortby</source>
         <target>Řadit dle</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment state="translated">
-        <source>listing.option_select_item</source>
-        <target>Vybrat položku</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment state="translated">
-        <source>listing.title_title</source>
-        <target>Titulek</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
         <source>listing.placeholder_filter</source>
         <target>Hledat podle klíčového slova…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
         <source>listing.button_filter</source>
         <target>Filtrovat</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
         <source>listing.button_clear</source>
         <target>Vyčistit řazení/filtr</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
         <source>view_locales.badge_default</source>
         <target>Výchozí</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
         <source>view_locales.badge_missing</source>
         <target>Chybějící</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Přepnout rozbalovací seznam</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Upravit informace o obrázku</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
         <source>files_cards.action_edit_file</source>
         <target>Upravit soubor v editoru</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
         <source>files_cards.action_view_original</source>
         <target>Zobrazit originál</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
         <source>files_cards.action_duplicate</source>
         <target>Duplikovat</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
         <source>files_cards.action_delete</source>
         <target>Smazat</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
         <source>files_cards.label_filename</source>
         <target>Název souboru:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
         <source>files_cards.label_title</source>
         <target>Titulek:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
         <source>files_cards.label_dimensions</source>
         <target>Rozměry:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
         <source>files_cards.label_filesize</source>
-        <target>Název souboru:</target>
+        <target>Velikost souboru:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
         <source>files_cards.label_created_on</source>
         <target>Vytvořeno:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>V této složce nejsou žádné soubory. Vyberte složku, do které chcete přejít.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
         <source>quickselect.title_select</source>
         <target>Vyberte soubor:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
         <source>finder.button_list</source>
         <target>Seznam</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
         <source>finder.button_cards</source>
         <target>Karty</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
         <source>extensions.title_desc</source>
         <target>Popis:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
         <source>extensions.title_author</source>
         <target>Autor:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
         <source>extensions.title_package</source>
         <target>Název balíčku / třídy</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
         <source>extensions.title_version</source>
         <target>Verze:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
         <source>extensions.info_not_installed</source>
         <target>Toto je místní balíček, není nainstalován pomocí Composeru</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
         <source>extensions.title_class</source>
         <target>Název třídy:</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
         <source>extensions.button_configuration</source>
         <target>Konfigurace</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
         <source>extensions.button_source</source>
         <target>Zdroj</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
         <source>extensions.button_remove</source>
         <target>Odebrat rozšíření</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
         <source>extensions.button_disable</source>
         <target>Zakázat rozšíření</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
-      <segment state="translated">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
         <source>login.header_login</source>
         <target>Bolt » Přihlášení</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
         <source>extensions.message_not_implemented</source>
         <target>Dosud neimplementováno. Promiň!</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
         <source>listing.title_overview</source>
         <target>Přehled</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>V této složce nejsou žádné soubory. Vyberte složku, do které chcete přejít, na pravé straně.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
         <source>listing_filter.button_compact</source>
         <target>Kompaktní</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
         <source>listing_filter.button_expanded</source>
         <target>Rozšířené</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
         <source>finder.label_view</source>
         <target>Zobrazení:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Upravit</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
         <source>controller.user.title</source>
         <target><![CDATA[Uživatelé & oprávnění]]></target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
         <source>controller.user.subtitle</source>
         <target>Pro úpravu uživatelů a jejich oprávnění</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment state="translated">
-        <source>controller.database.check_title</source>
-        <target>Zkontrolovat databázi</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment state="translated">
-        <source>controller.database.check_subtitle</source>
-        <target>Pro kontrolu databáze</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment state="translated">
-        <source>controller.database.update_title</source>
-        <target>Aktualizace databáze</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment state="translated">
-        <source>controller.database.update_subtitle</source>
-        <target>Pro aktualizaci databáze</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>To search, in an omni-like fashion</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
         <source>listing.title_display_name</source>
         <target>Zobrazované jméno</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
         <source>listing.title_username</source>
         <target>Uživatelské jméno</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
-        <target>Email</target>
+        <target>E-mail</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
         <source>listing.title_roles</source>
         <target>Role</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
         <source>listing.title_last_seen</source>
         <target>Délka relace</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
         <source>listing.title_last_ip</source>
         <target>Poslední IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
         <source>listing.title_actions</source>
         <target>Akce</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment state="translated">
-        <source>user.not_valid_email</source>
-        <target>Chybný email</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment state="translated">
-        <source>user.not_valid_password</source>
-        <target>Chybné heslo. Heslo by mělo obsahovat minimálně 6 znaků.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
         <source>user.unknown_user</source>
         <target>Neznámý uživatel</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
-      <segment state="translated">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Převládající barvy v obrázku</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
         <source>general.phrase.overview-for</source>
         <target>Přehled pro '%slug%'</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
         <source>general.phrase.related-content</source>
         <target>Související obsah</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
         <source>action.search</source>
         <target>Hledat</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
         <source>caption.new_contenttype</source>
         <target>Nový %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
         <source>caption.untitled_contenttype</source>
         <target>Nepojmenovaný %contenttype%</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
         <source>title.edit_user_profile</source>
         <target>Upravit uživatelský profil</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
         <source>caption.redirection_page</source>
         <target>Stránka přesměrování</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
-      <segment state="translated">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.edit_image</source>
         <target>Upravit obrázek</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment state="translated">
-        <source>general.phrase.select_language</source>
-        <target>Vyberte jazyk</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
         <source>password.suggested</source>
         <target><![CDATA[Navrhované bezpečné heslo: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
-      <segment state="translated">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
         <source>field.cropX</source>
         <target>Oříznout X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Pozice ořezu na ose X, rozsah 0-100.</target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Pozice ořezu na ose Y, rozsah 0-100.</target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
-      <segment state="translated">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
         <source>field.cropY</source>
         <target>Oříznout Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>Faktor přiblížení oříznutí</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>Úroveň přiblížení ořezu, rozsah 1-10.</target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
         <source>title.contentType</source>
         <target>Typ obsahu</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment state="translated">
-        <source>listing.title_taxonomy</source>
-        <target>Taxonomie</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
-        <target>No results found. Broaden the filtering criteria, or add some more content.</target>
+        <target>Nebyly nalezeny žádné výsledky. Rozšiřte kritéria vyhledávání nebo přidejte další obsah.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
-        <target>Select Field to sort by…</target>
+        <target>Vyberte pole pro řazení…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
         <source>title.primary_actions</source>
         <target>Primární akce</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
         <source>title.options</source>
         <target>Možnosti</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
         <source>action.delete</source>
         <target>Smazat</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
         <source>action.enable</source>
         <target>Povolit</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
         <source>action.disable</source>
         <target>Zakázat</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment state="translated">
-        <source>user.enabled_successfully</source>
-        <target>Uživatel byl úspěšně povolen!</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment state="translated">
-        <source>user.disabled_successfully</source>
-        <target>Uživatel byl úspěšně zakázán!</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
-        <target>Session expires</target>
+        <target>Platnost relace vyprší</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
         <source>listing.title_ip_address</source>
         <target>IP adresa</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
         <source>listing.title_browser</source>
         <target>Prohlížeč / platforma</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
         <source>image.button_remove</source>
         <target>Odebrat</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
         <source>image.button_edit_attributes</source>
         <target>Upravit atributy</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment state="translated">
-        <source>image.button_move_up</source>
-        <target>Posunout výše</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment state="translated">
-        <source>image.button_move_down</source>
-        <target>Posunout níže</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
         <source>image.add_new_image</source>
         <target>Přidat nový obrázek</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
         <source>file.add_new_file</source>
         <target>Přidat nový soubor</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
         <source>collection.remove_item</source>
         <target>Odebrat položku</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
         <source>collection.add_item</source>
         <target>Přidat položku do %name%</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
         <source>collection.move_item_up</source>
         <target>Posunout výše</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
         <source>collection.move_item_down</source>
         <target>Posunout níže</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
         <source>extensions.button_detailed_view</source>
         <target>Zobrazit detaily</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
         <source>extensions.title_configuration</source>
         <target>Konfigurační soubor</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Přetáhněte sem soubory pro nahrání</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
-      <segment state="translated">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
         <source>pager.next</source>
         <target>Další</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
-      <segment state="translated">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
         <source>pager.previous</source>
         <target>Předchozí</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
         <source>image.button_up</source>
         <target>Nahoru</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
         <source>image.button_down</source>
         <target>Dolů</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
-      <segment state="translated">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
         <source>general.phrase.download</source>
         <target>Stáhnout</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.logviewer</source>
         <target>Prohlížeč protokolu</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
         <source>label.request</source>
         <target>Požadavek</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
-        <target>Trace</target>
+        <target>Trasování</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
         <source>label.context</source>
         <target>Kontext</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
         <source>label.level</source>
         <target>Úroveň</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
         <source>label.message</source>
         <target>Zpráva</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
         <source>label.timestamp</source>
         <target>Čas</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
         <source>label.user</source>
         <target>Uživatel</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
         <source>listing.disabled</source>
         <target>Zakázáno</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
         <source>slug.button_unlocked</source>
         <target>Odemčeno</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
         <source>general.phrase.no-content-found</source>
         <target>Nebyl nalezen žádný obsah</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
-      <segment state="translated">
-        <source>general.phrase.empty-database</source>
-        <target>Vypadá to, že je databáze prázdná.  Write some content in the Bolt backend, or run the command to add some fixtures (dummy content). </target>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Žádné</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
         <source>view_locales.badge_empty</source>
         <target>Prázdné</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
         <source>action.update_all</source>
         <target>Použít na vše</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
         <source>about.system_info</source>
         <target>Systémové informace</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment state="translated">
-        <source>user.not_valid_display_name</source>
-        <target>Chybné zobrazované jméno</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
         <source>action.confirm_delete</source>
         <target>Opravdu si přejete smazat tento obsah?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
-      <segment state="translated">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
         <source>placeholder.username_or_email</source>
         <target>vaše uživatelské jméno nebo email</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
-      <segment state="translated">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
         <source>placeholder.password</source>
         <target>vaše heslo</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
         <source>caption.other_content</source>
         <target>Další obsah</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
         <source>editfile.target_not_writable</source>
         <target>Ukládání je zakázáno, protože do cílového souboru nelze zapisovat.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
         <source>label.translatable</source>
         <target>Toto pole je přeložitelné</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
         <source>label.content</source>
         <target>Obsah</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
         <source>file.delete_success</source>
         <target>Soubor byl úspěšně smazán!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
         <source>file.delete_confirm</source>
         <target>Opravdu si přejete smazat tento soubor?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
         <source>listing.title_filterby</source>
         <target>Hledat / filtrovat podle</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
         <source>content.status_changed_successfully</source>
         <target>Stav byl úspěšně změněn</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
         <source>content.deleted_successfully</source>
         <target>Obsah byl úspěšně smazán</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
         <source>label.current_status</source>
         <target>Aktuální stav</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
-      <segment state="translated">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
         <source>status.published</source>
         <target>Zveřejněno</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
-      <segment state="translated">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
         <source>status.draft</source>
         <target>Koncept</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
-      <segment state="translated">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
         <source>status.timed</source>
         <target>Naplánováno</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
-      <segment state="translated">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
         <source>status.held</source>
         <target>Pozdrženo</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
         <source>collection.confirm_delete</source>
         <target>Opravdu si přejete smazat tuto položku kolekce?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
         <source>upload.allow_file_types</source>
         <target>Typy souborů povolené pro nahrání</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
         <source>upload.max_size</source>
         <target>Maximální velikost souboru pro nahrání</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
         <source>listing.placeholder_search</source>
         <target>Hledat klíčové slovo …</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[Všechen obsah, filtrován podle <em>'%filter%'</em>.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
         <source>action.view_site</source>
         <target>Zobrazit stránky</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
         <source>action.new</source>
         <target>Nové</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
         <source>extensions.no_dependencies</source>
         <target>Žádné závislosti</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
         <source>extensions.title_dependencies</source>
         <target>Závislosti</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Rozbalit všechny položky</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Zabalit všechny položky</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
         <target>Definice tohoto ContentType chybí! Úprava tohoto záznamu nebude fungovat podle očekávání. Zkontrolujte prosím svůj soubor contenttypes.yaml a ujistěte se, že obsahuje %contenttype%.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>Vybrat …</target>
       </segment>
     </unit>
     <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
       <segment>
         <source>form.empty_username_email</source>
         <target>Zadejte prosím své uživatelské jméno nebo e-mail</target>
       </segment>
     </unit>
     <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
       <segment>
         <source>form.empty_password</source>
         <target>Zadejte prosím své heslo</target>
       </segment>
     </unit>
     <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
       <segment>
         <source>form.empty_email</source>
         <target>Zadejte prosím svůj e-mail</target>
       </segment>
     </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Filtrovat podle pole</target>
       </segment>
     </unit>
     <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
       <segment>
         <source>image.button_from_url</source>
         <target>Nahrát z URL</target>
       </segment>
     </unit>
     <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
       <segment>
         <source>files_cards.copy_to_clipboard</source>
         <target>Kopírovat odkaz na soubor</target>
       </segment>
     </unit>
     <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
       <segment>
         <source>warning</source>
         <target>Varování</target>
       </segment>
     </unit>
     <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_already_exists</source>
-        <target>Složka již existuje.</target>
+        <target>Složka již existuje</target>
       </segment>
     </unit>
     <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_error</source>
-        <target>Nepodařilo se vytvořit složku.</target>
+        <target>Nepodařilo se vytvořit složku</target>
       </segment>
     </unit>
     <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_success</source>
         <target>Složka byla úspěšně vytvořena.</target>
       </segment>
     </unit>
     <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
       <segment>
         <source>filemanager.delete_folder_successful</source>
-        <target>Složka byla úspěšně odstraněna.</target>
+        <target>Složka byla úspěšně odstraněna</target>
       </segment>
     </unit>
     <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
       <segment>
         <source>folder.create_new</source>
         <target>Nová složka</target>
       </segment>
     </unit>
-    <unit id="FcXvWL8" name="title.add_user">
-      <segment>
-        <source>title.add_user</source>
-        <target>Přidat uživatele</target>
-      </segment>
-    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>Obrázek uživatele</target>
       </segment>
     </unit>
     <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
       <segment>
         <source>login.forgotpassword</source>
         <target>Zapomenuté heslo</target>
       </segment>
     </unit>
     <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.request_header</source>
         <target>Resetovat heslo</target>
       </segment>
     </unit>
     <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
       <segment>
         <source>reset_password.request_description</source>
         <target>Zadejte svou e-mailovou adresu a my Vám zašleme odkaz pro obnovení hesla.</target>
       </segment>
     </unit>
     <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
       <segment>
         <source>reset_password.request_send</source>
         <target>Zaslat e-mail na změnu hesla</target>
       </segment>
     </unit>
     <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
       <segment>
         <source>Email</source>
         <target>E-mail</target>
       </segment>
     </unit>
     <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
       <segment>
         <source>reset_password.back-to-login</source>
         <target>Zpět k přihlášení</target>
       </segment>
     </unit>
     <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
       <segment>
         <source>reset_password.reset_header</source>
         <target>Reset hesla</target>
       </segment>
     </unit>
     <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_header</source>
         <target>E-mail s žádostí o obnovení hesla byl odeslán</target>
       </segment>
     </unit>
     <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_1</source>
-        <target>Byl Vám zaslán e-mail s odkazem, na který můžete kliknout a obnovit tak své heslo. Platnost tohoto odkazu vyprší za %hours% hodin.</target>
+        <target>Byl Vám zaslán e-mail s odkazem, na který můžete kliknout a obnovit tak své heslo. Platnost tohoto odkazu vyprší za %hours% hod.</target>
       </segment>
     </unit>
     <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_2</source>
         <target>Pokud e-mail neobdržíte, zkontrolujte složku se spamem nebo %tryagain%.</target>
       </segment>
     </unit>
     <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
       <segment>
         <source>reset_password.reset_btn</source>
         <target>Reset hesla</target>
       </segment>
     </unit>
     <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
       <segment>
         <source>reset_password.email_title</source>
-        <target>Požadavek na změnu hesla</target>
+        <target>Dobrý den!</target>
       </segment>
     </unit>
     <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
       <segment>
         <source>reset_password.email_description</source>
         <target>Chcete-li obnovit své heslo, navštivte následující odkaz.</target>
       </segment>
     </unit>
     <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
       <segment>
         <source>reset_password.email_expire</source>
-        <target>Platnost tohoto odkazu vyprší za %hours% hodin.</target>
+        <target>Platnost tohoto odkazu vyprší za %hours% hod.</target>
       </segment>
     </unit>
     <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
       <segment>
         <source>reset_password.email_thanks</source>
         <target>Děkujeme!</target>
       </segment>
     </unit>
     <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
       <segment>
         <source>reset_password.enter_pwd</source>
         <target>Zadejte prosím heslo</target>
       </segment>
     </unit>
     <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
       <segment>
         <source>label.repeat_password</source>
         <target>Zopakování hesla</target>
       </segment>
     </unit>
     <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
       <segment>
         <source>reset_password.not_matching_pwds</source>
         <target>Hesla se musí shodovat!</target>
       </segment>
     </unit>
     <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
       <segment>
         <source>reset_password.minimum_length</source>
         <target>Vaše heslo by mělo mít alespoň %s znaků</target>
       </segment>
     </unit>
     <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
       <segment>
         <source>reset_password.no_token</source>
         <target>V adrese URL ani v relaci nebyl nalezen token pro resetování hesla.</target>
       </segment>
     </unit>
     <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
       <segment>
         <source>reset_password.reset_successful</source>
         <target>Vaše heslo bylo úspěšně resetováno.</target>
       </segment>
     </unit>
     <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
       <segment>
         <source>reset_password.problem_with_request</source>
         <target>Při zpracování Vašeho požadavku na reset hesla došlo k problému - %s</target>
       </segment>
     </unit>
     <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>label.filtered_by</source>
         <target>Filtrováno podle</target>
       </segment>
     </unit>
     <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
       <segment>
         <source>action.preview_secure_share</source>
-        <target>Sdílet zabezpečený náhled odkazu</target>
+        <target>Sdílet zabezpečený odkaz na náhled</target>
       </segment>
     </unit>
     <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
       <segment>
         <source>action.stop_impersonating</source>
-        <target>Zastavit napodobování</target>
+        <target>Přestat se vydávat za</target>
       </segment>
     </unit>
     <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
       <segment>
         <source>action.impersonate</source>
         <target>Vydávat se za</target>
       </segment>
     </unit>
     <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
       <segment>
         <source>maintenance.activated_warning</source>
         <target>Je aktivován režim údržby</target>
       </segment>
     </unit>
     <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
       <segment>
         <source>action.refresh</source>
         <target>Obnovit</target>
       </segment>
     </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
       <segment>
         <source>listing_details_box.showing_records</source>
         <target>Zobrazeno záznamů %current% z %total%</target>
       </segment>
     </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
       <segment>
         <source>listing_details_box.name</source>
-        <target>Jméno: %name% (singular: %singularName%)</target>
+        <target>Jméno: %name% (jednotné číslo: %singularName%)</target>
       </segment>
     </unit>
     <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
       <segment>
         <source>listing_details_box.slug</source>
-        <target>Slug: %slug% (singular: %singularSlug%)</target>
+        <target>Slug: %slug% (jednotné číslo: %singularSlug%)</target>
       </segment>
     </unit>
     <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
       <segment>
         <source>listing_details_box.record_template</source>
-        <target>Record template: %template%</target>
+        <target>Šablona záznamu: %template%</target>
       </segment>
     </unit>
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
       <segment>
         <source>listing_details_box.listing_template</source>
-        <target>Listing template: %template% (%listingRecords% záznamů)</target>
+        <target>Šablona výpisu: %template% (%listingRecords% záznamů)</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
       <segment>
         <source>listing_details_box.locales</source>
-        <target>Locales: %locales%</target>
+        <target>Lokalizace: %locales%</target>
       </segment>
     </unit>
     <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
       <segment>
         <source>action.edit_permissions</source>
         <target>Upravit oprávnění</target>
       </segment>
     </unit>
     <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
       <segment>
         <source>general.label.search</source>
         <target>Vyhledat</target>
       </segment>
     </unit>
     <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.image_preview</source>
         <target>Náhled obrázku</target>
       </segment>
     </unit>
     <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
       <segment>
         <source>listing_table.actions.select_all</source>
         <target>Vybrat vše</target>
       </segment>
     </unit>
     <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
       <segment>
         <source>label.remembermeduration</source>
         <target>Zapamatovat přihlášení? (%duration% dnů)</target>
       </segment>
     </unit>
     <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
       <segment>
         <source>listing.current_sessions_header</source>
         <target>Aktuální relace</target>
       </segment>
     </unit>
     <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
       <segment>
         <source>image.button_upload_options</source>
         <target>Možnosti nahrávání</target>
       </segment>
     </unit>
-    <unit id="hKmDb7q" name="Share secure preview link">
-      <segment>
-        <source>Share secure preview link</source>
-        <target>Sdílet zabezpečený náhled odkazu</target>
-      </segment>
-    </unit>
     <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
       <segment>
         <source>Order</source>
-        <target>Objednávka</target>
+        <target>Pořadí</target>
       </segment>
     </unit>
     <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
       <segment>
         <source>placeholder.email</source>
         <target>Váš e-mail</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>Pro přístup na tuto stránku se musíte přihlásit.</target>
-      </segment>
-    </unit>
     <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>modal.title.file_field</source>
         <target>Výběr souboru</target>
       </segment>
     </unit>
     <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
       <segment>
         <source>modal.title.image_field</source>
         <target>Výběr obrázku</target>
       </segment>
     </unit>
     <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
       <segment>
         <source>modal.title.upload_from_url</source>
         <target>Nahrát z adresy URL</target>
       </segment>
     </unit>
     <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
       <segment>
         <source>modal.text.loading</source>
         <target>Načítání...</target>
       </segment>
     </unit>
     <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
       <segment>
         <source>modal.button_save</source>
         <target>Uložit</target>
       </segment>
     </unit>
     <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
       <segment>
         <source>modal.button_deny</source>
         <target>Zavřít</target>

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1,1706 +1,161 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
   <file id="messages.de">
-    <unit id="Zssh7In" name="content.status_changed_successfully">
+    <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/BulkOperationsController.php:63</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:298</note>
-        <note category="state" priority="1">new</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
-        <source>content.status_changed_successfully</source>
-        <target>Status erfolgreich geändert</target>
+        <source>title.edit_user</source>
+        <target>Benutzer bearbeiten</target>
       </segment>
     </unit>
-    <unit id="GOhQBY9" name="content.deleted_successfully">
+    <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/BulkOperationsController.php:86</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:324</note>
-        <note category="state" priority="1">new</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
-        <source>content.deleted_successfully</source>
-        <target>Inhalt erfolgreich gelöscht</target>
+        <source>action.save</source>
+        <target>Speichern</target>
       </segment>
     </unit>
-    <unit id="2MMvCKK" name="label.cache_cleared">
+    <unit id="a2vzLi7" name="action.do_something">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ClearCacheController.php:28</note>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
       </notes>
       <segment>
-        <source>label.cache_cleared</source>
-        <target>Der Cache wurde erfolgreich geleert!</target>
+        <source>action.do_something</source>
+        <target>Beispieltext</target>
       </segment>
     </unit>
-    <unit id="iH0RRIt" name="content.validation_errors">
+    <unit id="ovKkXwU" name="action.edit">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:198</note>
-        <note category="state" priority="1">new</note>
+        <note>templates/users/listing.html.twig:64</note>
       </notes>
       <segment>
-        <source>content.validation_errors</source>
-        <target>Fehler beim validieren</target>
+        <source>action.edit</source>
+        <target>Bearbeiten</target>
       </segment>
     </unit>
-    <unit id="ruQIhH0" name="success">
+    <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:227</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
-        <source>success</source>
-        <target>Erfolg!</target>
+        <source>label.username</source>
+        <target>Benutzername</target>
       </segment>
     </unit>
-    <unit id="3hkt.eH" name="content.updated_successfully">
+    <unit id="80JoLd0" name="title.login">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:228</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:236</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/MediaEditController.php:85</note>
-        <note category="state" priority="1">new</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
-        <source>content.updated_successfully</source>
-        <target>Inhalt erfolgreich aktualisiert</target>
-      </segment>
-    </unit>
-    <unit id="z2AgHGp" name="flash_messages.notification">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ContentEditController.php:229</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_flash_messages.html.twig:8</note>
-      </notes>
-      <segment>
-        <source>flash_messages.notification</source>
-        <target>Benachrichtigung</target>
-      </segment>
-    </unit>
-    <unit id="Iyry5.g" name="editfile.updated_successfully">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FileEditController.php:105</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>editfile.updated_successfully</source>
-        <target>Datei erfolgreich aktualisiert!</target>
-      </segment>
-    </unit>
-    <unit id="b1jqjUC" name="editfile.could_not_write">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FileEditController.php:107</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>editfile.could_not_write</source>
-        <target>Datei konnte nicht gespeichert werden</target>
-      </segment>
-    </unit>
-    <unit id="v7ZTnja" name="file.delete_success">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FileEditController.php:151</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>file.delete_success</source>
-        <target>Datei erfolgreich gelöscht!</target>
-      </segment>
-    </unit>
-    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:128</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>filemanager.delete_folder_successful</source>
-        <target>Ordner erfolgreich gelöscht</target>
-      </segment>
-    </unit>
-    <unit id="VNOIZGY" name="filemanager.delete_folder_error">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:130</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>filemanager.delete_folder_error</source>
-        <target>Ordner konnte nicht gelöscht werden</target>
-      </segment>
-    </unit>
-    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:165</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>filemanager.create_folder_already_exists</source>
-        <target>Ordner existiert bereits</target>
-      </segment>
-    </unit>
-    <unit id="aSxePCB" name="filemanager.create_folder_error">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:166</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:172</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>filemanager.create_folder_error</source>
-        <target>Ordner konnte nicht erstellt werden</target>
-      </segment>
-    </unit>
-    <unit id="wbFKypA" name="filemanager.create_folder_success">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/FilemanagerController.php:170</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>filemanager.create_folder_success</source>
-        <target>Ordner wurde erfolgreich erstellt.</target>
-      </segment>
-    </unit>
-    <unit id="1LzKCXS" name="&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/GeneralController.php:57</note>
-      </notes>
-      <segment>
-        <source>&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.</source>
-        <target><![CDATA[<strong>Gut gemacht!</strong> Sie haben diese wichtige Meldung erfolgreich gelesen. ]]></target>
-      </segment>
-    </unit>
-    <unit id="ibSB.pZ">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/GeneralController.php:58</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>&lt;strong&gt;Heads up!&lt;/strong&gt; This alert needs your attention, but it's not super important.</source>
-        <target>&lt;strong&gt;Achtung!&lt;/strong&gt; Diese Benachrichtigung benötigt Ihre Aufmerksamkeit, aber es ist nciht super wichtig..</target>
-      </segment>
-    </unit>
-    <unit id="JYILFeM" name="&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/GeneralController.php:59</note>
-      </notes>
-      <segment>
-        <source>&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.</source>
-        <target><![CDATA[<strong>Warnung!</strong> Pass auf, etwas stimmt nicht.]]></target>
-      </segment>
-    </unit>
-    <unit id="OGd6iOm" name="&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/GeneralController.php:60</note>
-      </notes>
-      <segment>
-        <source>&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.</source>
-        <target><![CDATA[<strong>Ohje!</strong> Ändere ein paar Dinge und versuche es erneut.]]></target>
-      </segment>
-    </unit>
-    <unit id="IB0mNQh" name="content.created_successfully">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/MediaEditController.php:111</note>
-      </notes>
-      <segment>
-        <source>content.created_successfully</source>
-        <target>Mediendatei wurde erfolgreich erstellt!</target>
-      </segment>
-    </unit>
-    <unit id="GUQYLn2" name="reset_password.no_token">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ResetPasswordController.php:106</note>
-      </notes>
-      <segment>
-        <source>reset_password.no_token</source>
-        <target>In der URL oder in der Sitzung wurde kein Token zum Zurücksetzen des Passworts gefunden.</target>
-      </segment>
-    </unit>
-    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ResetPasswordController.php:113</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ResetPasswordController.php:179</note>
-      </notes>
-      <segment>
-        <source>reset_password.problem_with_request</source>
-        <target>Es gab ein Problem bei der Bearbeitung Ihrer Anfrage zum Zurücksetzen des Passworts - %s</target>
-      </segment>
-    </unit>
-    <unit id="SjuOnue" name="reset_password.reset_successful">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/ResetPasswordController.php:141</note>
-      </notes>
-      <segment>
-        <source>reset_password.reset_successful</source>
-        <target>Passwort Reset war erfolgreich.</target>
-      </segment>
-    </unit>
-    <unit id="OBmPOoB" name="user.updated_successfully">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/UserEditController.php:157</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.updated_successfully</source>
-        <target>Erfolgreich aktualisiert</target>
-      </segment>
-    </unit>
-    <unit id="YDH.7uR" name="user.updated_profile">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/UserEditController.php:191</note>
-        <note category="file-source" priority="1">bolt-core/src/Controller/Backend/UserEditController.php:223</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.updated_profile</source>
-        <target>Benutzer erfolgreich aktualisiert!</target>
-      </segment>
-    </unit>
-    <unit id="harDiJR" name="reset_password.enter_pwd">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:34</note>
-      </notes>
-      <segment>
-        <source>reset_password.enter_pwd</source>
-        <target>Bitte ein Passwort eingeben</target>
-      </segment>
-    </unit>
-    <unit id="1JZeWxG" name="reset_password.minimum_length">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:38</note>
-      </notes>
-      <segment>
-        <source>reset_password.minimum_length</source>
-        <target>Ihr Passwort sollte mindestens %s Zeichen lang sein</target>
-      </segment>
-    </unit>
-    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:48</note>
-      </notes>
-      <segment>
-        <source>reset_password.not_matching_pwds</source>
-        <target>Die Passwortfelder stimmen nicht überein.</target>
-      </segment>
-    </unit>
-    <unit id="iiWFLaI" name="label.new_password">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:31</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>label.new_password</source>
-        <target>Neues Passwort</target>
-      </segment>
-    </unit>
-    <unit id="rU9cSfq" name="label.repeat_password">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:45</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>label.repeat_password</source>
-        <target>Passwort wiederholen</target>
-      </segment>
-    </unit>
-    <unit id="RZQ0CeQ" name="Plain password">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ChangePasswordFormType.php:28</note>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Plain password</source>
-        <target>Klarpasswort</target>
-      </segment>
-    </unit>
-    <unit id="2SSLP1K" name="form.empty_username_email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:45</note>
-      </notes>
-      <segment>
-        <source>form.empty_username_email</source>
-        <target>Bitte Usernamen oder Email-Adresse eingeben</target>
-      </segment>
-    </unit>
-    <unit id="5Qf_RiO" name="form.empty_password">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:57</note>
-      </notes>
-      <segment>
-        <source>form.empty_password</source>
-        <target>Bitte Passwort eingeben</target>
-      </segment>
-    </unit>
-    <unit id="RMPnq6o" name="label.username_or_email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:41</note>
-      </notes>
-      <segment>
-        <source>label.username_or_email</source>
-        <target>Username oder Email</target>
+        <source>title.login</source>
+        <target>In Bolt anmelden</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:53</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:51</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:42</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
         <target>Passwort</target>
       </segment>
     </unit>
-    <unit id="2hoKa1k" name="label.remembermeduration">
+    <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:68</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
-        <source>label.remembermeduration</source>
-        <target>Angemeldet bleiben? (%duration% Tage)</target>
+        <source>action.log_in</source>
+        <target>Einloggen</target>
       </segment>
     </unit>
-    <unit id="z_tOHwq" name="placeholder.username_or_email">
+    <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:49</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
-        <source>placeholder.username_or_email</source>
-        <target>Usernamen oder Email eingeben</target>
+        <source>title.contentlisting</source>
+        <target>Inhaltsauflistung</target>
       </segment>
     </unit>
-    <unit id="xgYhRkc" name="placeholder.password">
+    <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/LoginType.php:63</note>
-        <note category="state" priority="1">new</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
-        <source>placeholder.password</source>
-        <target>Ihr Passwort</target>
-      </segment>
-    </unit>
-    <unit id="f8zXapF" name="form.empty_email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ResetPasswordRequestFormType.php:31</note>
-      </notes>
-      <segment>
-        <source>form.empty_email</source>
-        <target>Bitte Email-Adresse eingeben</target>
-      </segment>
-    </unit>
-    <unit id="Y7ajNNN" name="placeholder.email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ResetPasswordRequestFormType.php:35</note>
-      </notes>
-      <segment>
-        <source>placeholder.email</source>
-        <target>Ihre Email-Adresse</target>
-      </segment>
-    </unit>
-    <unit id="D2N6_cP" name="label.email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/ResetPasswordRequestFormType.php:27</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:68</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:51</note>
-      </notes>
-      <segment>
-        <source>label.email</source>
-        <target>E-Mail-Adresse</target>
-      </segment>
-    </unit>
-    <unit id="yo6CbZw" name="Avatar">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Avatar</source>
-        <target>Profilbild</target>
-      </segment>
-    </unit>
-    <unit id="yj3GEvR" name="Locale">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Locale</source>
-        <target>Sprache</target>
-      </segment>
-    </unit>
-    <unit id="lpzL089" name="Email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Email</source>
-        <target>E-Mail</target>
-      </segment>
-    </unit>
-    <unit id="K39qhN6" name="Display name">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Display name</source>
-        <target>Anzeigename</target>
-      </segment>
-    </unit>
-    <unit id="47ienTP" name="Username">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:79</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Username</source>
-        <target>Benutzername</target>
-      </segment>
-    </unit>
-    <unit id="kg5BPH1" name="Status">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:121</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Status</source>
-        <target>Status</target>
-      </segment>
-    </unit>
-    <unit id="wlM3BVR" name="Roles">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Form/UserType.php:121</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Roles</source>
-        <target>Rollen</target>
-      </segment>
-    </unit>
-    <unit id="7aLIA3c" name="caption.dashboard">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:83</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/dashboard.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.dashboard</source>
-        <target>Bolt Dashboard</target>
-      </segment>
-    </unit>
-    <unit id="1xlE8ex" name="caption.content">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:91</note>
-      </notes>
-      <segment>
-        <source>caption.content</source>
-        <target>Inhalte</target>
-      </segment>
-    </unit>
-    <unit id="ZO.uqIZ" name="caption.settings">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:107</note>
-      </notes>
-      <segment>
-        <source>caption.settings</source>
-        <target>Einstellungen</target>
-      </segment>
-    </unit>
-    <unit id="zOLL.7E" name="caption.configuration">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:119</note>
-      </notes>
-      <segment>
-        <source>caption.configuration</source>
-        <target>Konfiguration</target>
-      </segment>
-    </unit>
-    <unit id="ipmA6Ah" name="caption.users_permissions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:129</note>
-      </notes>
-      <segment>
-        <source>caption.users_permissions</source>
-        <target><![CDATA[Benutzer & Rechte]]></target>
-      </segment>
-    </unit>
-    <unit id="kXNBV9S" name="caption.main_configuration">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:142</note>
-      </notes>
-      <segment>
-        <source>caption.main_configuration</source>
-        <target>Hauptkonfiguration</target>
-      </segment>
-    </unit>
-    <unit id="_w7J5rZ" name="caption.contenttypes">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:153</note>
-      </notes>
-      <segment>
-        <source>caption.contenttypes</source>
-        <target>Inhaltstypen</target>
-      </segment>
-    </unit>
-    <unit id="drK.0GZ" name="caption.taxonomies">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:164</note>
-      </notes>
-      <segment>
-        <source>caption.taxonomies</source>
-        <target>Taxonomien</target>
-      </segment>
-    </unit>
-    <unit id="2RUXD4A" name="caption.menu_setup">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:175</note>
-      </notes>
-      <segment>
-        <source>caption.menu_setup</source>
-        <target>Menü</target>
-      </segment>
-    </unit>
-    <unit id="wBKDkwl" name="caption.routing_setup">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:187</note>
-      </notes>
-      <segment>
-        <source>caption.routing_setup</source>
-        <target>Routen</target>
-      </segment>
-    </unit>
-    <unit id="i4cbdta" name="caption.all_configuration_files">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:195</note>
-      </notes>
-      <segment>
-        <source>caption.all_configuration_files</source>
-        <target>Konfigurationsdateien</target>
-      </segment>
-    </unit>
-    <unit id="OpKTKAL" name="caption.maintenance">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:207</note>
-      </notes>
-      <segment>
-        <source>caption.maintenance</source>
-        <target>Wartung</target>
-      </segment>
-    </unit>
-    <unit id="mfvtHPQ" name="caption.extensions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:217</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.extensions</source>
-        <target>Erweiterungen</target>
-      </segment>
-    </unit>
-    <unit id="2MtT_h0" name="caption.logviewer">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:227</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/logviewer.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.logviewer</source>
-        <target>Protokolle</target>
-      </segment>
-    </unit>
-    <unit id="Dvu2HQx" name="caption.api">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:237</note>
-      </notes>
-      <segment>
-        <source>caption.api</source>
-        <target>API</target>
-      </segment>
-    </unit>
-    <unit id="K6TmK4B" name="caption.clear_cache">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:247</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/clearcache.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/clearcache.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>caption.clear_cache</source>
-        <target>Cache leeren</target>
-      </segment>
-    </unit>
-    <unit id="dd5MzCM" name="caption.translations">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:257</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>caption.translations</source>
-        <target>Übersetzungen</target>
-      </segment>
-    </unit>
-    <unit id="Wou02nK" name="caption.kitchensink">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:268</note>
-      </notes>
-      <segment>
-        <source>caption.kitchensink</source>
-        <target>Testumgebung</target>
-      </segment>
-    </unit>
-    <unit id="wLaDaK5" name="caption.about_bolt">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:278</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.about_bolt</source>
-        <target>Über Bolt</target>
-      </segment>
-    </unit>
-    <unit id="l4yt0BE" name="caption.file_management">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:290</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.file_management</source>
-        <target>Dateiverwaltung</target>
-      </segment>
-    </unit>
-    <unit id="bq6bSf4" name="caption.uploaded_files">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:300</note>
-      </notes>
-      <segment>
-        <source>caption.uploaded_files</source>
-        <target>Hochgeladene Dateien</target>
-      </segment>
-    </unit>
-    <unit id="K4D568R" name="caption.view_edit_templates">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:310</note>
-      </notes>
-      <segment>
-        <source>caption.view_edit_templates</source>
-        <target>Templates verwalten</target>
-      </segment>
-    </unit>
-    <unit id="KshyLfh" name="caption.other_content">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:366</note>
-      </notes>
-      <segment>
-        <source>caption.other_content</source>
-        <target>Andere Inhalte</target>
-      </segment>
-    </unit>
-    <unit id="Z7aWRoY" name="Dashboard">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:80</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Dashboard</source>
-        <target>Dashboard</target>
-      </segment>
-    </unit>
-    <unit id="R70pB1_" name="Content">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:89</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Content</source>
-        <target>Inhalt</target>
-      </segment>
-    </unit>
-    <unit id="dKiDoDe" name="Settings">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:105</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Settings</source>
-        <target>Einstellungen</target>
-      </segment>
-    </unit>
-    <unit id="szLDSS1" name="Configuration">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:114</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Configuration</source>
-        <target>Einrichtung</target>
-      </segment>
-    </unit>
-    <unit id="L_GMMkf" name="Users &amp;amp; Permissions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:126</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Users &amp;amp; Permissions</source>
-        <target>Benutzer &amp; Rechte</target>
-      </segment>
-    </unit>
-    <unit id="jb9I1wY" name="Main configuration">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:136</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Main configuration</source>
-        <target>Haupt</target>
-      </segment>
-    </unit>
-    <unit id="uo1bGDD" name="ContentTypes">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:147</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>ContentTypes</source>
-        <target>Inhaltstypen</target>
-      </segment>
-    </unit>
-    <unit id="0_HwkHi" name="Taxonomies">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:158</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Taxonomies</source>
-        <target>Taxonomie</target>
-      </segment>
-    </unit>
-    <unit id="wpYayj3" name="Menu set up">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:169</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Menu set up</source>
-        <target>Menü-Einrichtung</target>
-      </segment>
-    </unit>
-    <unit id="WcVgNHo" name="Routing set up">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:181</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Routing set up</source>
-        <target>Routen-Einrichtung</target>
-      </segment>
-    </unit>
-    <unit id="yDV.P5Y" name="All configuration files">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:192</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>All configuration files</source>
-        <target>Alle Konfigurationsdateien</target>
-      </segment>
-    </unit>
-    <unit id="F8z6W2g" name="Maintenance">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:202</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Maintenance</source>
-        <target>Wartung</target>
-      </segment>
-    </unit>
-    <unit id=".jQ2r4a" name="Extensions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:214</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Extensions</source>
-        <target>Erweiterungen</target>
-      </segment>
-    </unit>
-    <unit id="qH__ewO" name="Log viewer">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:224</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Log viewer</source>
-        <target>Log-Ansicht</target>
-      </segment>
-    </unit>
-    <unit id="ldt1zD." name="Bolt API">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:234</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Bolt API</source>
-        <target>Bolt API</target>
-      </segment>
-    </unit>
-    <unit id="iDvBicF" name="Clear the cache">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:244</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Clear the cache</source>
-        <target>Cache leeren</target>
-      </segment>
-    </unit>
-    <unit id="JmpBuQ1" name="Translations">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:254</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Translations</source>
-        <target>Übersetzungen</target>
-      </segment>
-    </unit>
-    <unit id="7_UlZWQ" name="The Kitchensink">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:265</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>The Kitchensink</source>
-        <target>Die Küchenspüle</target>
-      </segment>
-    </unit>
-    <unit id="aQw9smj" name="About Bolt">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:275</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>About Bolt</source>
-        <target>Über Bolt</target>
-      </segment>
-    </unit>
-    <unit id="fgUoR4S" name="File Management">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:285</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>File Management</source>
-        <target>Dateiverwaltung</target>
-      </segment>
-    </unit>
-    <unit id="PE1dkX_" name="Uploaded files">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:297</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>Uploaded files</source>
-        <target>Datei hochladen</target>
-      </segment>
-    </unit>
-    <unit id="eV_CM1t" name="View/edit Templates">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Menu/BackendMenuBuilder.php:307</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>View/edit Templates</source>
-        <target>Templates anzeigen/bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="UZFanGF" name="about.bolt_documentation">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:37</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:66</note>
-      </notes>
-      <segment>
-        <source>about.bolt_documentation</source>
-        <target>Bolt Dokumentation</target>
-      </segment>
-    </unit>
-    <unit id="b_RPpcB" name="general.greeting">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:39</note>
-      </notes>
-      <segment>
-        <source>general.greeting</source>
-        <target>Hallo, %name%!</target>
-      </segment>
-    </unit>
-    <unit id="bmdn3u9" name="action.logout">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:40</note>
-      </notes>
-      <segment>
-        <source>action.logout</source>
-        <target>Ausloggen</target>
-      </segment>
-    </unit>
-    <unit id="zYeSeNJ" name="action.stop_impersonating">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:41</note>
-      </notes>
-      <segment>
-        <source>action.stop_impersonating</source>
-        <target>Impersonierung beenden</target>
-      </segment>
-    </unit>
-    <unit id="zOfpTLD" name="action.edit_profile">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:42</note>
-      </notes>
-      <segment>
-        <source>action.edit_profile</source>
-        <target>Profil bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="k.JymqB" name="about.visit_bolt">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:43</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:63</note>
-      </notes>
-      <segment>
-        <source>about.visit_bolt</source>
-        <target>Besucht Boltcms.io</target>
-      </segment>
-    </unit>
-    <unit id="wGlnx8X" name="general.phrase.search">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:44</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search</source>
-        <target>Suche</target>
-      </segment>
-    </unit>
-    <unit id="O_m7mx1" name="listing.placeholder_search">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:45</note>
-      </notes>
-      <segment>
-        <source>listing.placeholder_search</source>
-        <target>Nach Schlüsselwörtern suchen ...</target>
-      </segment>
-    </unit>
-    <unit id="OYUVA5." name="general.label.search">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:46</note>
-      </notes>
-      <segment>
-        <source>general.label.search</source>
-        <target>Suche</target>
-      </segment>
-    </unit>
-    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:82</note>
-      </notes>
-      <segment>
-        <source>admin_sidebar_toggler.toggle</source>
-        <target><![CDATA[Menü<span class="sr-only"> umschalten</span>]]></target>
-      </segment>
-    </unit>
-    <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:91</note>
-      </notes>
-      <segment>
-        <source>admin_sidebar.toggler</source>
-        <target>Menü umschalten</target>
-      </segment>
-    </unit>
-    <unit id="f.rvF6y" name="action.new">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:92</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_createfolder.html.twig:9</note>
-      </notes>
-      <segment>
-        <source>action.new</source>
-        <target>Neu</target>
-      </segment>
-    </unit>
-    <unit id="TtmWqX3" name="action.view">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_base/layout.html.twig:93</note>
-      </notes>
-      <segment>
-        <source>action.view</source>
-        <target>Ansehen</target>
-      </segment>
-    </unit>
-    <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:13</note>
-      </notes>
-      <segment>
-        <source>listing_filter.button_compact</source>
-        <target>Kompakteansicht</target>
-      </segment>
-    </unit>
-    <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:14</note>
-      </notes>
-      <segment>
-        <source>listing_filter.button_expanded</source>
-        <target>Detailansicht</target>
-      </segment>
-    </unit>
-    <unit id="OEqzPDO" name="listing_table.actions.select_all">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.select_all</source>
-        <target>Alle auswählen</target>
-      </segment>
-    </unit>
-    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:23</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.view_on_site</source>
-        <target>Anzeigen</target>
-      </segment>
-    </unit>
-    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:27</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:43</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.status_to_publish</source>
-        <target>Veröffentlichen</target>
-      </segment>
-    </unit>
-    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:25</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:42</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.status_to_held</source>
-        <target>Festhalten</target>
-      </segment>
-    </unit>
-    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:41</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.status_to_draft</source>
-        <target>Als Vorlage markieren</target>
-      </segment>
-    </unit>
-    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:28</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.duplicate</source>
-        <target>Duplizieren</target>
-      </segment>
-    </unit>
-    <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:29</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.delete</source>
-        <target>Löschen</target>
-      </segment>
-    </unit>
-    <unit id="5zbX1vo" name="listing_table.actions.slug">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:30</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.slug</source>
-        <target>Slug</target>
-      </segment>
-    </unit>
-    <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:31</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.created_on</source>
-        <target>Erstellt am</target>
-      </segment>
-    </unit>
-    <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:32</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.published_on</source>
-        <target>Veröffentlicht am</target>
-      </segment>
-    </unit>
-    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:33</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Zuletzt bearbeitet am</target>
-      </segment>
-    </unit>
-    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_content_listing.html.twig:34</note>
-      </notes>
-      <segment>
-        <source>listing_table.actions.button_edit</source>
-        <target>Bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="N_0yRcH" name="action.close_alert">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/_flash_messages.html.twig:1</note>
-      </notes>
-      <segment>
-        <source>action.close_alert</source>
-        <target>Schließen</target>
-      </segment>
-    </unit>
-    <unit id="ApPu4P_" name="collection.move_item_up">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/_collection_buttons.html.twig:5</note>
-      </notes>
-      <segment>
-        <source>collection.move_item_up</source>
-        <target>Hoch bewegen</target>
-      </segment>
-    </unit>
-    <unit id="KzBtfHi" name="collection.move_item_down">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/_collection_buttons.html.twig:9</note>
-      </notes>
-      <segment>
-        <source>collection.move_item_down</source>
-        <target>Runter bewegen</target>
-      </segment>
-    </unit>
-    <unit id="JpJFIFq" name="collection.confirm_delete">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/_collection_buttons.html.twig:13</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/_collection_buttons.html.twig:14</note>
-      </notes>
-      <segment>
-        <source>collection.confirm_delete</source>
-        <target>Sind Sie sicher, dass Sie dieses Kollektionsobjekt löschen möchten?</target>
-      </segment>
-    </unit>
-    <unit id=".t1ICS7" name="collection.remove_item">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/_collection_buttons.html.twig:20</note>
-      </notes>
-      <segment>
-        <source>collection.remove_item</source>
-        <target>Objekt entfernen</target>
-      </segment>
-    </unit>
-    <unit id="0C9.Vmh" name="collection.add_item">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/collection.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>collection.add_item</source>
-        <target>Objekt zu %name% hinzufügen </target>
-      </segment>
-    </unit>
-    <unit id="H9knE.O" name="collection.expand_all">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/collection.html.twig:7</note>
-      </notes>
-      <segment>
-        <source>collection.expand_all</source>
-        <target>Alles einblenden</target>
-      </segment>
-    </unit>
-    <unit id="JjvI6hp" name="collection.collapse_all">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/collection.html.twig:8</note>
-      </notes>
-      <segment>
-        <source>collection.collapse_all</source>
-        <target>Alles ausblenden</target>
-      </segment>
-    </unit>
-    <unit id="RBJ0NMl" name="collection.select">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/collection.html.twig:10</note>
-      </notes>
-      <segment>
-        <source>collection.select</source>
-        <target>Auswählen ...</target>
-      </segment>
-    </unit>
-    <unit id="BINgtmK" name="editor_date.toggle">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/date.html.twig:39</note>
-      </notes>
-      <segment>
-        <source>editor_date.toggle</source>
-        <target>Umschalten</target>
-      </segment>
-    </unit>
-    <unit id="kHeY93_" name="editor_embed.content_url">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:20</note>
-      </notes>
-      <segment>
-        <source>editor_embed.content_url</source>
-        <target>URL des einzubettenden Inhalts</target>
-      </segment>
-    </unit>
-    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>editor_embed.placeholder_content_url</source>
-        <target>URL des Inhalts von Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
-      </segment>
-    </unit>
-    <unit id="1.Eb1GS" name="editor_embed.label_height">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:22</note>
-      </notes>
-      <segment>
-        <source>editor_embed.label_height</source>
-        <target>Höhe</target>
-      </segment>
-    </unit>
-    <unit id="eWLSFJs" name="editor_embed.label_pixel">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:23</note>
-      </notes>
-      <segment>
-        <source>editor_embed.label_pixel</source>
-        <target>Pixel</target>
-      </segment>
-    </unit>
-    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:24</note>
-      </notes>
-      <segment>
-        <source>editor_embed.label_matched_embed</source>
-        <target>Zugeordnete Einbettung</target>
-      </segment>
-    </unit>
-    <unit id="zATju4V" name="editor_embed.label_preview">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:25</note>
-      </notes>
-      <segment>
-        <source>editor_embed.label_preview</source>
-        <target>Vorschau</target>
-      </segment>
-    </unit>
-    <unit id="9SQ0oaR" name="editor_embed.label_size">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:26</note>
-      </notes>
-      <segment>
-        <source>editor_embed.label_size</source>
-        <target>Größe</target>
-      </segment>
-    </unit>
-    <unit id="hTKWQ6g" name="action.delete">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:27</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/_buttons.html.twig:69</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:44</note>
-      </notes>
-      <segment>
-        <source>action.delete</source>
-        <target>Löschen</target>
-      </segment>
-    </unit>
-    <unit id="CvNi3GD" name="action.refresh">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:28</note>
-      </notes>
-      <segment>
-        <source>action.refresh</source>
-        <target>Neu laden</target>
-      </segment>
-    </unit>
-    <unit id="vlRe8Tx" name="field.width">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:29</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:128</note>
-      </notes>
-      <segment>
-        <source>field.width</source>
-        <target>Breite</target>
-      </segment>
-    </unit>
-    <unit id="CZbXbM_" name="field.height">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:30</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:135</note>
-      </notes>
-      <segment>
-        <source>field.height</source>
-        <target>Höhe</target>
-      </segment>
-    </unit>
-    <unit id="VKhfRZB" name="field.title">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:31</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:39</note>
-      </notes>
-      <segment>
-        <source>field.title</source>
-        <target>Title</target>
-      </segment>
-    </unit>
-    <unit id="aQX4Emy" name="field.author">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/embed.html.twig:32</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside.html.twig:33</note>
-      </notes>
-      <segment>
-        <source>field.author</source>
-        <target>Autor</target>
-      </segment>
-    </unit>
-    <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:5</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:5</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:5</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:5</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:49</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_uploader.html.twig:3</note>
-      </notes>
-      <segment>
-        <source>upload.allow_file_types</source>
-        <target>Erlaubte Dateiformate</target>
-      </segment>
-    </unit>
-    <unit id="noOf4ML" name="upload.max_size">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:50</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_uploader.html.twig:4</note>
-      </notes>
-      <segment>
-        <source>upload.max_size</source>
-        <target>Maximale Dateigröße</target>
-      </segment>
-    </unit>
-    <unit id="vptPhch" name="image.button_upload">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:16</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:16</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:17</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:16</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:58</note>
-      </notes>
-      <segment>
-        <source>image.button_upload</source>
-        <target>Hochladen</target>
-      </segment>
-    </unit>
-    <unit id="a_COwtV" name="image.button_upload_options">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:17</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:17</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:18</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:17</note>
-      </notes>
-      <segment>
-        <source>image.button_upload_options</source>
-        <target>Upload Optionen</target>
-      </segment>
-    </unit>
-    <unit id="vIVO1lU" name="image.button_from_library">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:18</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:18</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:19</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:18</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:59</note>
-      </notes>
-      <segment>
-        <source>image.button_from_library</source>
-        <target>Aus der Bibliothek</target>
-      </segment>
-    </unit>
-    <unit id="FqVh1Hv" name="image.button_remove">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:19</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:22</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:20</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:22</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:60</note>
-      </notes>
-      <segment>
-        <source>image.button_remove</source>
-        <target>Entfernen</target>
-      </segment>
-    </unit>
-    <unit id="oOuVKRv" name="image.placeholder_filename">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:20</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:19</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:21</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:19</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:61</note>
-      </notes>
-      <segment>
-        <source>image.placeholder_filename</source>
-        <target>Dateiname</target>
-      </segment>
-    </unit>
-    <unit id="BWubOnS" name="image.placeholder_alt_text">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:21</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:20</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:22</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:20</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:62</note>
-      </notes>
-      <segment>
-        <source>image.placeholder_alt_text</source>
-        <target>Alternativer Text</target>
-      </segment>
-    </unit>
-    <unit id="VPV0lFM" name="image.placeholder_title">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:22</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:21</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>image.placeholder_title</source>
-        <target>Titel</target>
-      </segment>
-    </unit>
-    <unit id="eHV6ZJB" name="image.button_edit_attributes">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:23</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:23</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:23</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:63</note>
-      </notes>
-      <segment>
-        <source>image.button_edit_attributes</source>
-        <target>Attribute bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="MjY7.cg" name="modal.title.file_field">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:27</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>modal.title.file_field</source>
-        <target>Datei auswählen</target>
-      </segment>
-    </unit>
-    <unit id="VlfWDQr" name="modal.button_save">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:25</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:28</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:28</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:30</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>modal.button_save</source>
-        <target>Speichern</target>
-      </segment>
-    </unit>
-    <unit id="ct_I4w3" name="modal.button_deny">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/file.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:29</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:29</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:31</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>modal.button_deny</source>
-        <target>Schließen</target>
-      </segment>
-    </unit>
-    <unit id="7aSD0Qr" name="image.button_up">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:23</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:25</note>
-      </notes>
-      <segment>
-        <source>image.button_up</source>
-        <target>Hoch</target>
-      </segment>
-    </unit>
-    <unit id="WihD8Y5" name="image.button_down">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:26</note>
-      </notes>
-      <segment>
-        <source>image.button_down</source>
-        <target>Runter</target>
-      </segment>
-    </unit>
-    <unit id="8Q4FxVw" name="file.add_new_file">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/filelist.html.twig:25</note>
-      </notes>
-      <segment>
-        <source>file.add_new_file</source>
-        <target>Neue Datei hinzufügen</target>
-      </segment>
-    </unit>
-    <unit id="kciiidS" name="image.button_from_url">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/simple_image.html.twig:64</note>
-      </notes>
-      <segment>
-        <source>image.button_from_url</source>
-        <target>Von einer URL</target>
-      </segment>
-    </unit>
-    <unit id="wG04eAa" name="image.image_preview">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:25</note>
-      </notes>
-      <segment>
-        <source>image.image_preview</source>
-        <target>Bildvorschau anzeigen</target>
-      </segment>
-    </unit>
-    <unit id="0yPnNMd" name="modal.title.image_field">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:28</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>modal.title.image_field</source>
-        <target>Bild auswählen</target>
-      </segment>
-    </unit>
-    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/image.html.twig:27</note>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:29</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>modal.title.upload_from_url</source>
-        <target>Von URL hochladen</target>
-      </segment>
-    </unit>
-    <unit id="Oj2UZ5J" name="image.add_new_image">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/imagelist.html.twig:27</note>
-      </notes>
-      <segment>
-        <source>image.add_new_image</source>
-        <target>Neues Bild hinzufügen</target>
-      </segment>
-    </unit>
-    <unit id="XQ2U6fN" name="slug.button_unlocked">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/slug.html.twig:17</note>
-      </notes>
-      <segment>
-        <source>slug.button_unlocked</source>
-        <target>Entsperrt</target>
-      </segment>
-    </unit>
-    <unit id="kaK5Wdr" name="slug.button_locked">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/slug.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>slug.button_locked</source>
-        <target>Deaktiviert</target>
-      </segment>
-    </unit>
-    <unit id="qcDEz5O" name="slug.button_edit">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/slug.html.twig:19</note>
-      </notes>
-      <segment>
-        <source>slug.button_edit</source>
-        <target>Bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="raO5QSf" name="slug.generate_from">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/_partials/fields/slug.html.twig:20</note>
-      </notes>
-      <segment>
-        <source>slug.generate_from</source>
-        <target>Erzeugt aus:</target>
-      </segment>
-    </unit>
-    <unit id="qoZwSEY" name="action.preview_secure_share">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_buttons.html.twig:34</note>
-      </notes>
-      <segment>
-        <source>action.preview_secure_share</source>
-        <target>Sicheren Vorschau-Link teilen</target>
-      </segment>
-    </unit>
-    <unit id="eVkSIKu" name="field.modifiedAt">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_buttons.html.twig:50</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside_summary.html.twig:16</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:159</note>
-      </notes>
-      <segment>
-        <source>field.modifiedAt</source>
-        <target>Bearbeitet am</target>
-      </segment>
-    </unit>
-    <unit id="6Gw1lsE" name="action.confirm_delete">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_buttons.html.twig:63</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_folders.html.twig:40</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_folders.html.twig:41</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:89</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:90</note>
-      </notes>
-      <segment>
-        <source>action.confirm_delete</source>
-        <target>Sind Sie sicher, dass Sie diesen Inhalt löschen möchten?
-</target>
+        <source>field.id</source>
+        <target>ID</target>
       </segment>
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside.html.twig:5</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:153</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
         <target>Status</target>
       </segment>
     </unit>
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
+      <segment>
+        <source>field.createdAt</source>
+        <target>Erstellt am</target>
+      </segment>
+    </unit>
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
+      <segment>
+        <source>field.modifiedAt</source>
+        <target>Bearbeitet am</target>
+      </segment>
+    </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside.html.twig:15</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -1709,640 +164,26 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside.html.twig:24</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
         <target>Veröffentlichung zurückgezogen am</target>
       </segment>
     </unit>
-    <unit id="O9wtVOp" name="field.createdAt">
+    <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside_summary.html.twig:6</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:151</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
-        <source>field.createdAt</source>
-        <target>Erstellt am</target>
-      </segment>
-    </unit>
-    <unit id="SNELzJ2" name="field.id">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_fields_aside_summary.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:121</note>
-      </notes>
-      <segment>
-        <source>field.id</source>
-        <target>ID</target>
-      </segment>
-    </unit>
-    <unit id="8zEzq8N" name="field.current_locale">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_localeswitcher.html.twig:7</note>
-      </notes>
-      <segment>
-        <source>field.current_locale</source>
-        <target>Aktuelle Sprache</target>
-      </segment>
-    </unit>
-    <unit id="ahZvOJz" name="field.switch_to_locale">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_localeswitcher.html.twig:14</note>
-      </notes>
-      <segment>
-        <source>field.switch_to_locale</source>
-        <target>Sprache wechseln zu</target>
-      </segment>
-    </unit>
-    <unit id="a_CQgly" name="Order">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/_taxonomies.html.twig:27</note>
-      </notes>
-      <segment>
-        <source>Order</source>
-        <target>Bestellung</target>
-      </segment>
-    </unit>
-    <unit id="EvAqL__" name="caption.duplicate">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/edit.html.twig:22</note>
-      </notes>
-      <segment>
-        <source>caption.duplicate</source>
-        <target>Kopieren</target>
-      </segment>
-    </unit>
-    <unit id="HK7XTUX" name="caption.edit">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/edit.html.twig:22</note>
-      </notes>
-      <segment>
-        <source>caption.edit</source>
-        <target>Bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="pXtciRI" name="content.edit_missing_definition">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/edit.html.twig:45</note>
-      </notes>
-      <segment>
-        <source>content.edit_missing_definition</source>
-        <target>Die Definition für diesen ContentType fehlt! Die Bearbeitung dieses Datensatzes wird nicht wie erwartet funktionieren. Bitte überprüfen Sie Ihre contenttypes.yaml, um sicherzustellen, dass sie %contenttype% enthält.</target>
-      </segment>
-    </unit>
-    <unit id="JEnqOi." name="title.primary_actions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/edit.html.twig:103</note>
-      </notes>
-      <segment>
-        <source>title.primary_actions</source>
-        <target>Primäre Aktionen</target>
-      </segment>
-    </unit>
-    <unit id="7616Os4" name="title.options">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/edit.html.twig:115</note>
-      </notes>
-      <segment>
-        <source>title.options</source>
-        <target>Optionen</target>
-      </segment>
-    </unit>
-    <unit id="Hlf9c1s" name="listing.title_overview">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>listing.title_overview</source>
-        <target>Übersicht für</target>
-      </segment>
-    </unit>
-    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:40</note>
-      </notes>
-      <segment>
-        <source>listing_select_box.card_header.selected</source>
-        <target>Ausgewählt</target>
-      </segment>
-    </unit>
-    <unit id="WeJxw6Z" name="action.update_all">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:45</note>
-      </notes>
-      <segment>
-        <source>action.update_all</source>
-        <target>auf alle anwenden</target>
-      </segment>
-    </unit>
-    <unit id="vJwSCBO" name="title.contentlisting">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:58</note>
-      </notes>
-      <segment>
-        <source>title.contentlisting</source>
-        <target>Inhaltsauflistung</target>
-      </segment>
-    </unit>
-    <unit id="wQ0WYAT" name="listing.title_sortby">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:69</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:70</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:190</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:191</note>
-      </notes>
-      <segment>
-        <source>listing.title_sortby</source>
-        <target>Sortieren nach</target>
-      </segment>
-    </unit>
-    <unit id="hp554Ds" name="listing.option_select_sortby">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:72</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:193</note>
-      </notes>
-      <segment>
-        <source>listing.option_select_sortby</source>
-        <target>Feld zum Sortieren auswählen</target>
-      </segment>
-    </unit>
-    <unit id="IWbf2by" name="listing.title_filterby">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:104</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:207</note>
-      </notes>
-      <segment>
-        <source>listing.title_filterby</source>
-        <target>Filtern nach</target>
-      </segment>
-    </unit>
-    <unit id="pn22p7q" name="listing.placeholder_filter">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:106</note>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:106</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:214</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:215</note>
-      </notes>
-      <segment>
-        <source>listing.placeholder_filter</source>
-        <target>Schlüsselwort zum Filtern ...</target>
-      </segment>
-    </unit>
-    <unit id="n.3JZvX" name="title.contentType">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:136</note>
-      </notes>
-      <segment>
-        <source>title.contentType</source>
-        <target>Inhaltstyp</target>
-      </segment>
-    </unit>
-    <unit id="9UKAP.V" name="listing_details_box.showing_records">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:149</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.showing_records</source>
-        <target>Anzeige Records %current% von %total%</target>
-      </segment>
-    </unit>
-    <unit id="UrywY0R" name="listing_details_box.name">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:155</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.name</source>
-        <target>Name: %name% (singular: %singularName%)</target>
-      </segment>
-    </unit>
-    <unit id=".l3zbrq" name="listing_details_box.slug">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:161</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.slug</source>
-        <target>Slug: %slug% (Singular: %singularSlug%)</target>
-      </segment>
-    </unit>
-    <unit id="eJ9YbdG" name="listing_details_box.record_template">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:167</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.record_template</source>
-        <target>Record template: %template%</target>
-      </segment>
-    </unit>
-    <unit id="tsc7_G3" name="listing_details_box.listing_template">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:173</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.listing_template</source>
-        <target>Listing template: %template% (%listingRecords% Einträge)</target>
-      </segment>
-    </unit>
-    <unit id="pPz9Ocx" name="listing_details_box.locales">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/listing.html.twig:187</note>
-      </notes>
-      <segment>
-        <source>listing_details_box.locales</source>
-        <target>Lokalisierungen: %locales%</target>
-      </segment>
-    </unit>
-    <unit id="UNBaDz." name="general.phrase.edit">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:60</note>
-      </notes>
-      <segment>
-        <source>general.phrase.edit</source>
-        <target>Bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="37kJiIe" name="view_locales.badge_default">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:99</note>
-      </notes>
-      <segment>
-        <source>view_locales.badge_default</source>
-        <target>Standard</target>
-      </segment>
-    </unit>
-    <unit id="ufFUPp7" name="view_locales.badge_missing">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:101</note>
-      </notes>
-      <segment>
-        <source>view_locales.badge_missing</source>
-        <target>Fehlt</target>
-      </segment>
-    </unit>
-    <unit id="SGlj7K2" name="view_locales.badge_empty">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:103</note>
-      </notes>
-      <segment>
-        <source>view_locales.badge_empty</source>
-        <target>Leer</target>
-      </segment>
-    </unit>
-    <unit id="JTRCo_U" name="view_locales.badge_ok">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/content/view_locales.html.twig:105</note>
-      </notes>
-      <segment>
-        <source>view_locales.badge_ok</source>
-        <target>Ok</target>
-      </segment>
-    </unit>
-    <unit id="a6Xhtq0" name="folder.create_new">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_createfolder.html.twig:13</note>
-      </notes>
-      <segment>
-        <source>folder.create_new</source>
-        <target>Neuer Ordner</target>
-      </segment>
-    </unit>
-    <unit id="QQvRJe." name="files_cards.button_toggle">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:10</note>
-      </notes>
-      <segment>
-        <source>files_cards.button_toggle</source>
-        <target>Dropdown umschalten</target>
-      </segment>
-    </unit>
-    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:17</note>
-      </notes>
-      <segment>
-        <source>files_cards.action_edit_image_info</source>
-        <target>Bild Metadaten bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:19</note>
-      </notes>
-      <segment>
-        <source>files_cards.action_edit_file</source>
-        <target>Datei im Editor bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="H1pgP94" name="files_cards.action_view_original">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:25</note>
-      </notes>
-      <segment>
-        <source>files_cards.action_view_original</source>
-        <target>Original ansehen</target>
-      </segment>
-    </unit>
-    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:29</note>
-      </notes>
-      <segment>
-        <source>files_cards.copy_to_clipboard</source>
-        <target>Link zu Datei kopieren</target>
-      </segment>
-    </unit>
-    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:36</note>
-      </notes>
-      <segment>
-        <source>files_cards.action_duplicate</source>
-        <target>Duplizieren</target>
-      </segment>
-    </unit>
-    <unit id="wHPoBzP" name="file.delete_confirm">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:42</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:43</note>
-      </notes>
-      <segment>
-        <source>file.delete_confirm</source>
-        <target>Sind Sie sicher, dass Sie diese Datei löschen möchten?</target>
-      </segment>
-    </unit>
-    <unit id="JjU6ZQP" name="files_cards.action_delete">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:49</note>
-      </notes>
-      <segment>
-        <source>files_cards.action_delete</source>
-        <target>Löschen</target>
-      </segment>
-    </unit>
-    <unit id="3jdNwuk" name="files_cards.label_filename">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:56</note>
-      </notes>
-      <segment>
-        <source>files_cards.label_filename</source>
-        <target>Dateiname:</target>
-      </segment>
-    </unit>
-    <unit id="Y90_Pn1" name="files_cards.label_title">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:63</note>
-      </notes>
-      <segment>
-        <source>files_cards.label_title</source>
-        <target>Titel:</target>
-      </segment>
-    </unit>
-    <unit id="EdCfIKX" name="files_cards.label_dimensions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:70</note>
-      </notes>
-      <segment>
-        <source>files_cards.label_dimensions</source>
-        <target>Abmessungen:</target>
-      </segment>
-    </unit>
-    <unit id="eQBhceV" name="files_cards.label_filesize">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:76</note>
-      </notes>
-      <segment>
-        <source>files_cards.label_filesize</source>
-        <target>Dateigröße:</target>
-      </segment>
-    </unit>
-    <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_actions.html.twig:81</note>
-      </notes>
-      <segment>
-        <source>files_cards.label_created_on</source>
-        <target>Erstellt am:</target>
-      </segment>
-    </unit>
-    <unit id="8JeahIj" name="files_cards.message_no_files">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_cards.html.twig:48</note>
-      </notes>
-      <segment>
-        <source>files_cards.message_no_files</source>
-        <target>In diesem Ordner sind keine Dateien vorhanden. Wählen Sie auf der rechten Seite einen Ordner aus, zu dem Sie navigieren möchten.</target>
-      </segment>
-    </unit>
-    <unit id="_XSgfqS" name="filename">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>filename</source>
-        <target>Dateiname</target>
-      </segment>
-    </unit>
-    <unit id="gPYflhh" name="thumbnail">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:7</note>
-      </notes>
-      <segment>
-        <source>thumbnail</source>
-        <target>Vorschaubild</target>
-      </segment>
-    </unit>
-    <unit id="zNy_hG8" name="size">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:8</note>
-      </notes>
-      <segment>
-        <source>size</source>
-        <target>Größe</target>
-      </segment>
-    </unit>
-    <unit id="DodjLNR" name="date">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:9</note>
-      </notes>
-      <segment>
-        <source>date</source>
-        <target>Datum</target>
-      </segment>
-    </unit>
-    <unit id="Kw3N1AA" name="actions">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:10</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_folders.html.twig:7</note>
-      </notes>
-      <segment>
-        <source>actions</source>
-        <target>Optionen</target>
-      </segment>
-    </unit>
-    <unit id=".fL0AbE" name="files_list.remark">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_files_list.html.twig:75</note>
-      </notes>
-      <segment>
-        <source>files_list.remark</source>
-        <target>Keine Dateien im Ordner vorhanden, bitte wählen Sie ein Verzeichnis aus!</target>
-      </segment>
-    </unit>
-    <unit id="KHvGNGW" name="directoryname">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_folders.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>directoryname</source>
-        <target>Verzeichnisname</target>
-      </segment>
-    </unit>
-    <unit id="v6cfPyt" name="quickselect.title_select">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_quickselect.html.twig:5</note>
-      </notes>
-      <segment>
-        <source>quickselect.title_select</source>
-        <target>Datei auswählen</target>
-      </segment>
-    </unit>
-    <unit id="C15MbYY" name="form.quick_select_file">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_quickselect.html.twig:9</note>
-      </notes>
-      <segment>
-        <source>form.quick_select_file</source>
-        <target>Datei Schnellauswahl</target>
-      </segment>
-    </unit>
-    <unit id="QZYjRy0" name="caption.file_uploader">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_uploader.html.twig:8</note>
-      </notes>
-      <segment>
-        <source>caption.file_uploader</source>
-        <target>Datei hochladen</target>
-      </segment>
-    </unit>
-    <unit id="283aB_E" name="caption.file_upload.upload_text">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/_uploader.html.twig:17</note>
-      </notes>
-      <segment>
-        <source>caption.file_upload.upload_text</source>
-        <target>Legen Sie Dateien hier ab, um sie hochzuladen</target>
-      </segment>
-    </unit>
-    <unit id="P1FHg3Q" name="caption.edit_file">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/editfile.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>caption.edit_file</source>
-        <target>Datei bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="FSroufa" name="caption.path">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/editfile.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:40</note>
-      </notes>
-      <segment>
-        <source>caption.path</source>
-        <target>Pfad</target>
-      </segment>
-    </unit>
-    <unit id="HLtdhYw" name="action.save">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/editfile.html.twig:38</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:111</note>
-      </notes>
-      <segment>
-        <source>action.save</source>
-        <target>Speichern</target>
-      </segment>
-    </unit>
-    <unit id="LaDIuZA" name="caption.meta_information">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:38</note>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:105</note>
-      </notes>
-      <segment>
-        <source>caption.meta_information</source>
-        <target>Metadaten</target>
-      </segment>
-    </unit>
-    <unit id="73A2bWM" name="finder.label_view">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:41</note>
-      </notes>
-      <segment>
-        <source>finder.label_view</source>
-        <target>Ansicht:</target>
-      </segment>
-    </unit>
-    <unit id="m3tNvJb" name="finder.button_list">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:45</note>
-      </notes>
-      <segment>
-        <source>finder.button_list</source>
-        <target>Listenansicht</target>
-      </segment>
-    </unit>
-    <unit id="tRLgeoX" name="finder.button_cards">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/finder/finder.html.twig:49</note>
-      </notes>
-      <segment>
-        <source>finder.button_cards</source>
-        <target>Kartenansicht</target>
-      </segment>
-    </unit>
-    <unit id="AMxTho9" name="pager.previous">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_basic.html.twig:30</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_bootstrap.html.twig:33</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_bulma.html.twig:28</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_tailwind.html.twig:29</note>
-      </notes>
-      <segment>
-        <source>pager.previous</source>
-        <target>Zurück</target>
-      </segment>
-    </unit>
-    <unit id="L_YQKUn" name="pager.next">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_basic.html.twig:66</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_bootstrap.html.twig:74</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_bulma.html.twig:34</note>
-        <note category="file-source" priority="1">bolt-core/templates/helpers/_pager_tailwind.html.twig:69</note>
-      </notes>
-      <segment>
-        <source>pager.next</source>
-        <target>Vor</target>
-      </segment>
-    </unit>
-    <unit id="TtIlBDd" name="caption.edit_image">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>caption.edit_image</source>
-        <target>Bild bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="y5otxEK" name="caption.filename">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:30</note>
-      </notes>
-      <segment>
-        <source>caption.filename</source>
-        <target>Dateiname</target>
+        <source>field.title</source>
+        <target>Titel</target>
       </segment>
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:45</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -2351,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:51</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -2360,106 +201,85 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:58</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
         <target>Originaler Dateiname</target>
       </segment>
     </unit>
-    <unit id="fLOd6Zd" name="field.cropX">
+    <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:70</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
-        <source>field.cropX</source>
-        <target>Breite zuschneiden</target>
+        <source>field.width</source>
+        <target>Breite</target>
       </segment>
     </unit>
-    <unit id="Sd_AbmV" name="field.cropXPostfix">
+    <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:73</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
-        <source>field.cropXPostfix</source>
-        <target>Mögliche Positionen der X-Achse sind 0-100.</target>
-      </segment>
-    </unit>
-    <unit id="hi98HIj" name="field.cropY">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:77</note>
-      </notes>
-      <segment>
-        <source>field.cropY</source>
-        <target>Höhe zuschneiden</target>
-      </segment>
-    </unit>
-    <unit id="BQBmQHT" name="field.cropYPostfix">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:80</note>
-      </notes>
-      <segment>
-        <source>field.cropYPostfix</source>
-        <target>Mögliche Positionen der Y-Achse sind 0-100.</target>
-      </segment>
-    </unit>
-    <unit id="PHOpD5y" name="field.cropZoom">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:84</note>
-      </notes>
-      <segment>
-        <source>field.cropZoom</source>
-        <target>Zoomfaktor</target>
-      </segment>
-    </unit>
-    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:87</note>
-      </notes>
-      <segment>
-        <source>field.cropZoomPostfix</source>
-        <target>Möglicher Zoomfaktor ist 0-10.</target>
-      </segment>
-    </unit>
-    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:114</note>
-      </notes>
-      <segment>
-        <source>label.predominant_colors__in_image</source>
-        <target>Vorherrschende Farben</target>
+        <source>field.height</source>
+        <target>Höhe</target>
       </segment>
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/media/edit.html.twig:142</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
         <target>Dateigröße</target>
       </segment>
     </unit>
-    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+    <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:11</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
-        <source>caption.bolt_payoff</source>
-        <target>Anspruchsvolles, leichtes und einfaches CMS</target>
+        <source>label.username_or_email</source>
+        <target>Username oder Email</target>
       </segment>
     </unit>
-    <unit id="QVRwwK4" name="about.system_info">
+    <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:21</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
-        <source>about.system_info</source>
-        <target>Systeminformationen</target>
+        <source>label.rememberme</source>
+        <target>Angemeldet bleiben?</target>
+      </segment>
+    </unit>
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>about.visit_bolt</source>
+        <target>Besucht Boltcms.io</target>
+      </segment>
+    </unit>
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
+      <segment>
+        <source>about.bolt_documentation</source>
+        <target>Bolt Dokumentation</target>
       </segment>
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:69</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -2468,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:73</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -2477,28 +297,1419 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/about.html.twig:75</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Unten aufgelistetete Libraries werden von Bolt verwendet.</target>
       </segment>
     </unit>
-    <unit id="munFS0n" name="title.filtered_by">
+    <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/dashboard.html.twig:12</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
-        <source>title.filtered_by</source>
-        <target><![CDATA[Gesamter Inhalt, gefiltert nach <em>'%filter%'</em>.]]></target>
+        <source>label.email</source>
+        <target>E-Mail-Adresse</target>
+      </segment>
+    </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Über mich</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
+        <source>user.updated_successfully</source>
+        <target>Erfolgreich aktualisiert</target>
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
+        <source>content.updated_successfully</source>
+        <target>Inhalt erfolgreich aktualisiert</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Mediendatei wurde erfolgreich erstellt!</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>Datei konnte nicht gespeichert werden</target>
+      </segment>
+    </unit>
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
+        <source>label.locale</source>
+        <target>Sprache</target>
+      </segment>
+    </unit>
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
+        <source>The Default theme</source>
+        <target>Das Standard-Theme</target>
+      </segment>
+    </unit>
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>The Default Dark theme</source>
+        <target>Das dunkle Standard-Theme</target>
+      </segment>
+    </unit>
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Sieht irgendwie aus wie dieses andere CMS</target>
+      </segment>
+    </unit>
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.dashboard</source>
+        <target>Bolt-Dashboard</target>
+      </segment>
+    </unit>
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>caption.clear_cache</source>
+        <target>Cache leeren</target>
+      </segment>
+    </unit>
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
+        <source>caption.menu_setup</source>
+        <target>Menü</target>
+      </segment>
+    </unit>
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
+        <source>caption.taxonomies</source>
+        <target>Taxonomien</target>
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
+        <source>caption.contenttypes</source>
+        <target>Inhaltstypen</target>
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
+        <source>caption.main_configuration</source>
+        <target>Hauptkonfiguration</target>
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
+        <source>caption.users_permissions</source>
+        <target><![CDATA[Benutzer & Rechte]]></target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Konfiguration</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Einstellungen</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Inhalte</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Dateiverwaltung</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Erweiterungen</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target>Templates verwalten</target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Hochgeladene Dateien</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Routen</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Übersetzungen</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>Über Bolt</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target>Anspruchsvolles, leichtes und einfaches CMS</target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>caption.file_uploader</source>
+        <target>Datei hochladen</target>
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>caption.meta_information</source>
+        <target>Metadaten</target>
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
+        <source>date</source>
+        <target>Datum</target>
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>size</source>
+        <target>Größe</target>
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>thumbnail</source>
+        <target>Vorschaubild</target>
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
+        <source>filename</source>
+        <target>Dateiname</target>
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>actions</source>
+        <target>Optionen</target>
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>directoryname</source>
+        <target>Verzeichnisname</target>
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>form.quick_select_file</source>
+        <target>Datei Schnellauswahl</target>
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>caption.path</source>
+        <target>Pfad</target>
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>caption.filename</source>
+        <target>Dateiname</target>
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>action.create_new</source>
+        <target>Anlegen</target>
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Hallo, %name%!</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Ausloggen</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Profil bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>Schließen</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>API</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Konfigurationsdateien</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Wartung</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Datei bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Aktuelle Sprache</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Sprache wechseln zu</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Autor</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Unbekannt</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Geschrieben von %name% am %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>Die Seite „Über“ fehlt</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Der Block „Über“ fehlt</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>Neueste %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>...</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Suche</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Übersicht von %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Keine aktuellen %contenttype% gefunden</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Menü</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Suche</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Permalink</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>Der Cache wurde erfolgreich geleert!</target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Testumgebung</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Suchergebnisse für „%search%“.</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>Keine Suchergebnisse für „%search%“ gefunden.</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Bitte geben Sie einen Suchbegriff ein, um relevante Ergebnisse anzuzeigen.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Mehr anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Diese Webseite wurde erstellt mit <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Bolt</a>. ]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Neueste Bolt Neuigkeiten</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Vorschau</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Gespeicherte Version anschauen</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Anzeigename</target>
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.duplicate</source>
+        <target>Kopieren</target>
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
+        <source>label.new_password</source>
+        <target>Neues Passwort</target>
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
+        <source>editfile.updated_successfully</source>
+        <target>Datei erfolgreich aktualisiert!</target>
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
+        <source>action.add_user</source>
+        <target>Benutzer hinzufügen</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Erfolg!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>Benutzer erfolgreich aktualisiert!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Rollen</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Neuen Benutzer anlegen</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Ansehen</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Deaktiviert</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Erzeugt aus:</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Hochladen</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Aus der Bibliothek</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Veröffentlichen</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Festhalten</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Als Vorlage markieren</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Duplizieren</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Löschen</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Erstellt am</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Veröffentlicht am</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Zuletzt bearbeitet am</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Ausgewählt</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>URL des einzubettenden Inhalts</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL des Inhalts von Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Höhe</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>Pixel</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Zugeordnete Einbettung</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Vorschau</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Größe</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Dateiname (neue Datei hochladen oder vorhandene auswählen)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Alternativer Text</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Titel</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Menü umschalten</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[Menü<span class="sr-only"> umschalten</span>]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Umschalten</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Benachrichtigung</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Übersetzungsstatus</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Sortieren nach</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Schlüsselwort zum Filtern ...</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filtern</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Sortierung/Filter zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Standard</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>Ok</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Fehlt</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Dropdown umschalten</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Bild Metadaten bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Datei im Editor bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Original ansehen</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Duplizieren</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Löschen</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Dateiname:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Titel:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Abmessungen:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Dateigröße:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Erstellt am:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Keine Dateien im Ordner vorhanden, bitte wählen Sie ein Verzeichnis aus!</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Datei auswählen</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Listenansicht</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Kartenansicht</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:24</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:51</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:27</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:44</note>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
       </notes>
       <segment>
         <source>extensions.title_desc</source>
@@ -2507,8 +1718,8 @@
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:29</note>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
       </notes>
       <segment>
         <source>extensions.title_author</source>
@@ -2517,56 +1728,28 @@
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:28</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:31</note>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
       </notes>
       <segment>
         <source>extensions.title_package</source>
-        <target>Package / Class name:</target>
-      </segment>
-    </unit>
-    <unit id="hgNZLwW" name="extensions.title_configuration">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:31</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:34</note>
-      </notes>
-      <segment>
-        <source>extensions.title_configuration</source>
-        <target>Konfigurationsdatei</target>
+        <target>Paket-/Klassenname:</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:34</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:37</note>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
       </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Version:</target>
       </segment>
     </unit>
-    <unit id="LfwezhR" name="extensions.title_dependencies">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:36</note>
-      </notes>
-      <segment>
-        <source>extensions.title_dependencies</source>
-        <target>Abhängigkeiten</target>
-      </segment>
-    </unit>
-    <unit id="60xy4WG" name="extensions.no_dependencies">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:39</note>
-      </notes>
-      <segment>
-        <source>extensions.no_dependencies</source>
-        <target>Keine bekannten Abhängigkeiten</target>
-      </segment>
-    </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:52</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:45</note>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
       </notes>
       <segment>
         <source>extensions.info_not_installed</source>
@@ -2575,8 +1758,8 @@
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:53</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:46</note>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
       </notes>
       <segment>
         <source>extensions.title_class</source>
@@ -2585,8 +1768,8 @@
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:62</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:58</note>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
       </notes>
       <segment>
         <source>extensions.button_configuration</source>
@@ -2595,34 +1778,18 @@
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:67</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:63</note>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
       </notes>
       <segment>
         <source>extensions.button_source</source>
-        <target>Source</target>
-      </segment>
-    </unit>
-    <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:72</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:73</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:84</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:85</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:68</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:69</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:79</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:80</note>
-      </notes>
-      <segment>
-        <source>extensions.message_not_implemented</source>
-        <target>Entschuldigung! Noch nicht implementiert!</target>
+        <target>Quelle</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:79</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:74</note>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
       </notes>
       <segment>
         <source>extensions.button_remove</source>
@@ -2631,285 +1798,133 @@
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extension_details.html.twig:91</note>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:86</note>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
       </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Erweiterung deaktivieren</target>
       </segment>
     </unit>
-    <unit id="BFARQEU" name="extensions.button_detailed_view">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/extensions.html.twig:54</note>
-      </notes>
-      <segment>
-        <source>extensions.button_detailed_view</source>
-        <target>Details ansehen</target>
-      </segment>
-    </unit>
-    <unit id="rCKtTo5" name="caption.redirection_page">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/pages/menupage.html.twig:13</note>
-      </notes>
-      <segment>
-        <source>caption.redirection_page</source>
-        <target>Weiterleitungsseite</target>
-      </segment>
-    </unit>
-    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/check_email.html.twig:4</note>
-      </notes>
-      <segment>
-        <source>reset_password.check_email_sent_header</source>
-        <target>Passwort Reset Email versendet</target>
-      </segment>
-    </unit>
-    <unit id="y.dIywE" name="reset_password.request_header">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/check_email.html.twig:32</note>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/request.html.twig:4</note>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/request.html.twig:36</note>
-      </notes>
-      <segment>
-        <source>reset_password.request_header</source>
-        <target>Passwort zurücksetzen</target>
-      </segment>
-    </unit>
-    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/check_email.html.twig:35</note>
-      </notes>
-      <segment>
-        <source>reset_password.check_email_sent_text_1</source>
-        <target>Es wurde eine Email versandt, die einen Link enthält, auf den Sie klicken können, um Ihr Passwort zurückzusetzen. Dieser Link wird in %Stunden% Stunde(n) ablaufen.</target>
-      </segment>
-    </unit>
-    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/check_email.html.twig:36</note>
-      </notes>
-      <segment>
-        <source>reset_password.check_email_sent_text_2</source>
-        <target>Wenn Sie keine E-Mail erhalten, überprüfen Sie bitte Ihren Spam-Ordner oder versuchen Sie es erneut.</target>
-      </segment>
-    </unit>
-    <unit id="dp42qbF" name="reset_password.email_title">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/email.html.twig:1</note>
-      </notes>
-      <segment>
-        <source>reset_password.email_title</source>
-        <target>Hallo!</target>
-      </segment>
-    </unit>
-    <unit id="xS2vvXw" name="reset_password.email_description">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/email.html.twig:3</note>
-      </notes>
-      <segment>
-        <source>reset_password.email_description</source>
-        <target>Um Ihr Passwort zurückzusetzen, besuchen Sie bitte den folgenden Link</target>
-      </segment>
-    </unit>
-    <unit id="apkSD11" name="reset_password.email_expire">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/email.html.twig:7</note>
-      </notes>
-      <segment>
-        <source>reset_password.email_expire</source>
-        <target>Dieser Link wird in %hours% Stunde(n) ablaufen.</target>
-      </segment>
-    </unit>
-    <unit id="_gg3hPE" name="reset_password.email_thanks">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/email.html.twig:9</note>
-      </notes>
-      <segment>
-        <source>reset_password.email_thanks</source>
-        <target>Danke!</target>
-      </segment>
-    </unit>
-    <unit id="SwOgM7K" name="reset_password.request_description">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/request.html.twig:42</note>
-      </notes>
-      <segment>
-        <source>reset_password.request_description</source>
-        <target>Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts.</target>
-      </segment>
-    </unit>
-    <unit id="RX0Iuzi" name="reset_password.request_send">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/request.html.twig:44</note>
-      </notes>
-      <segment>
-        <source>reset_password.request_send</source>
-        <target>Absenden</target>
-      </segment>
-    </unit>
-    <unit id="k9hekeu" name="reset_password.back-to-login">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/request.html.twig:47</note>
-      </notes>
-      <segment>
-        <source>reset_password.back-to-login</source>
-        <target>Zurück zum Login</target>
-      </segment>
-    </unit>
-    <unit id="gVc0Uf4" name="reset_password.reset_header">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/reset.html.twig:4</note>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/reset.html.twig:32</note>
-      </notes>
-      <segment>
-        <source>reset_password.reset_header</source>
-        <target>Setze dein Passwort zurück</target>
-      </segment>
-    </unit>
-    <unit id="QpUMHfK" name="reset_password.reset_btn">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/reset_password/reset.html.twig:37</note>
-      </notes>
-      <segment>
-        <source>reset_password.reset_btn</source>
-        <target>Passwort zurücksetzen</target>
-      </segment>
-    </unit>
-    <unit id="80JoLd0" name="title.login">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/security/login.html.twig:4</note>
-      </notes>
-      <segment>
-        <source>title.login</source>
-        <target>In Bolt anmelden</target>
-      </segment>
-    </unit>
     <unit id="beqzCkE" name="login.header_login">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/security/login.html.twig:40</note>
+        <note>templates/security/login.html.twig:40</note>
       </notes>
       <segment>
         <source>login.header_login</source>
-        <target>Bolt » Login</target>
+        <target>Bolt » Anmeldung</target>
       </segment>
     </unit>
-    <unit id="gLN0C81" name="action.log_in">
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/security/login.html.twig:60</note>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
       </notes>
       <segment>
-        <source>action.log_in</source>
-        <target>Einloggen</target>
+        <source>extensions.message_not_implemented</source>
+        <target>Entschuldigung! Noch nicht implementiert!</target>
       </segment>
     </unit>
-    <unit id="i37ZNqN" name="login.forgotpassword">
+    <unit id="Hlf9c1s" name="listing.title_overview">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/security/login.html.twig:64</note>
+        <note>templates/content/listing.html.twig:6</note>
       </notes>
       <segment>
-        <source>login.forgotpassword</source>
-        <target>Passwort vergessen</target>
+        <source>listing.title_overview</source>
+        <target>Übersicht für</target>
       </segment>
     </unit>
-    <unit id="LDhDPrF" name="label.username">
+    <unit id="8JeahIj" name="files_cards.message_no_files">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:10</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:24</note>
+        <note>templates/finder/_files_cards.html.twig:48</note>
       </notes>
       <segment>
-        <source>label.username</source>
-        <target>Benutzername</target>
+        <source>files_cards.message_no_files</source>
+        <target>In diesem Ordner sind keine Dateien vorhanden. Wählen Sie auf der rechten Seite einen Ordner aus, zu dem Sie navigieren möchten.</target>
       </segment>
     </unit>
-    <unit id="SeTqePC" name="label.display_name">
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:26</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:33</note>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
       </notes>
       <segment>
-        <source>label.display_name</source>
-        <target>Anzeigename</target>
+        <source>listing_filter.button_compact</source>
+        <target>Kompakteansicht</target>
       </segment>
     </unit>
-    <unit id="hiE9jap" name="password.suggested">
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:44</note>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
       </notes>
       <segment>
-        <source>password.suggested</source>
-        <target><![CDATA[<![CDATA[Vorgeschlagenes sicheres Passwort: <code>%password%</code>]]]]><![CDATA[>]]></target>
+        <source>listing_filter.button_expanded</source>
+        <target>Detailansicht</target>
       </segment>
     </unit>
-    <unit id="mEDsKHk" name="label.locale">
+    <unit id="73A2bWM" name="finder.label_view">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:95</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:72</note>
+        <note>templates/finder/finder.html.twig:41</note>
       </notes>
       <segment>
-        <source>label.locale</source>
-        <target>Sprache</target>
+        <source>finder.label_view</source>
+        <target>Ansicht:</target>
       </segment>
     </unit>
-    <unit id="iD6CNOO" name="label.roles">
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:124</note>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
       </notes>
       <segment>
-        <source>label.roles</source>
-        <target>Rollen</target>
+        <source>listing_table.actions.button_edit</source>
+        <target>Bearbeiten</target>
       </segment>
     </unit>
-    <unit id="nWMH_Nr" name="label.avatar">
+    <unit id="Iy4HXCU" name="controller.user.title">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/_form.html.twig:172</note>
+        <note>src/Controller/Backend/UserController.php:50</note>
       </notes>
       <segment>
-        <source>label.avatar</source>
-        <target>Avatar</target>
+        <source>controller.user.title</source>
+        <target><![CDATA[Benutzer & Rechte]]></target>
       </segment>
     </unit>
-    <unit id="3zlZmRK" name="action.add_user">
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/add.html.twig:6</note>
+        <note>src/Controller/Backend/UserController.php:51</note>
       </notes>
       <segment>
-        <source>action.add_user</source>
-        <target>Benutzer hinzufügen</target>
-      </segment>
-    </unit>
-    <unit id="1sstKF9" name="title.edit_user">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/edit.html.twig:6</note>
-      </notes>
-      <segment>
-        <source>title.edit_user</source>
-        <target>Benutzer bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="Ay7xZ2h" name="listing.title_username">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:19</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:122</note>
-      </notes>
-      <segment>
-        <source>listing.title_username</source>
-        <target>Benutzername</target>
+        <source>controller.user.subtitle</source>
+        <target>Benutzer und Rechte bearbeiten</target>
       </segment>
     </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:20</note>
+        <note>templates/users/listing.html.twig:20</note>
       </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>Anzeigename</target>
       </segment>
     </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Benutzername</target>
+      </segment>
+    </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:20</note>
+        <note>templates/users/listing.html.twig:20</note>
       </notes>
       <segment>
         <source>listing.title_email</source>
@@ -2918,7 +1933,7 @@
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:21</note>
+        <note>templates/users/listing.html.twig:21</note>
       </notes>
       <segment>
         <source>listing.title_roles</source>
@@ -2927,8 +1942,8 @@
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:22</note>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
       </notes>
       <segment>
         <source>listing.title_last_seen</source>
@@ -2937,7 +1952,7 @@
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:23</note>
+        <note>templates/users/listing.html.twig:23</note>
       </notes>
       <segment>
         <source>listing.title_last_ip</source>
@@ -2946,25 +1961,249 @@
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:24</note>
+        <note>templates/users/listing.html.twig:24</note>
       </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Optionen</target>
       </segment>
     </unit>
-    <unit id="eJG2.4P" name="listing.current_sessions_header">
+    <unit id="TpGxDI3" name="user.unknown_user">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:117</note>
+        <note>templates/users/profile.html.twig:11</note>
       </notes>
       <segment>
-        <source>listing.current_sessions_header</source>
-        <target>Aktuelle Sitzungen</target>
+        <source>user.unknown_user</source>
+        <target>Unbekannter Benutzer</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Vorherrschende Farben</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Übersicht für „%slug%“</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Verwandte Inhalte</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Suchen</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>%contenttype% anlegen</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>Unbenannte(r) %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Benutzerprofil bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Weiterleitungsseite</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Bild bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Vorgeschlagenes sicheres Passwort: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Breite zuschneiden</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Mögliche Positionen der X-Achse sind 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Mögliche Positionen der Y-Achse sind 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Höhe zuschneiden</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Zoomfaktor</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Möglicher Zoomfaktor ist 0-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Inhaltstyp</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Keine Ergebnisse gefunden. Erweitern Sie die Filterkriterien oder fügen Sie weitere Inhalte hinzu.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Feld zum Sortieren auswählen</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Primäre Aktionen</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Optionen</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Löschen</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Aktivieren</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Deaktivieren</target>
       </segment>
     </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:124</note>
+        <note>templates/users/listing.html.twig:124</note>
       </notes>
       <segment>
         <source>listing.title_session_expires</source>
@@ -2973,7 +2212,7 @@
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:125</note>
+        <note>templates/users/listing.html.twig:125</note>
       </notes>
       <segment>
         <source>listing.title_ip_address</source>
@@ -2982,394 +2221,189 @@
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:126</note>
       </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Browser / Betriebssystem</target>
       </segment>
     </unit>
-    <unit id="Dgtkgju" name="title.edit_user_profile">
+    <unit id="FqVh1Hv" name="image.button_remove">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/users/profile.html.twig:6</note>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
       </notes>
       <segment>
-        <source>title.edit_user_profile</source>
-        <target>Benutzerprofil bearbeiten</target>
+        <source>image.button_remove</source>
+        <target>Entfernen</target>
       </segment>
     </unit>
-    <unit id="qlucRr7" name="maintenance.activated_warning">
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
       <notes>
-        <note category="file-source" priority="1">bolt-core/templates/widget/maintenance_mode.twig:25</note>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
       </notes>
       <segment>
-        <source>maintenance.activated_warning</source>
-        <target>Maintenance Modus ist aktiviert</target>
+        <source>image.button_edit_attributes</source>
+        <target>Attribute bearbeiten</target>
       </segment>
     </unit>
-    <unit id="TpGxDI3" name="user.unknown_user">
+    <unit id="Oj2UZ5J" name="image.add_new_image">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
       </notes>
       <segment>
-        <source>user.unknown_user</source>
-        <target>Unbekannter Benutzer</target>
+        <source>image.add_new_image</source>
+        <target>Neues Bild hinzufügen</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
+    <unit id="8Q4FxVw" name="file.add_new_file">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
       </notes>
       <segment>
-        <source>caption.installation_checks</source>
-        <target>Installation prüfen</target>
+        <source>file.add_new_file</source>
+        <target>Neue Datei hinzufügen</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
+    <unit id=".t1ICS7" name="collection.remove_item">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
       </notes>
       <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Beispielinhalte</target>
+        <source>collection.remove_item</source>
+        <target>Objekt entfernen</target>
       </segment>
     </unit>
-    <unit id="KfVJho2" name="action.create_new">
+    <unit id="0C9.Vmh" name="collection.add_item">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
       </notes>
       <segment>
-        <source>action.create_new</source>
-        <target>Anlegen</target>
+        <source>collection.add_item</source>
+        <target>Objekt zu %name% hinzufügen </target>
       </segment>
     </unit>
-    <unit id="dQIY7_J" name="action.preview">
+    <unit id="ApPu4P_" name="collection.move_item_up">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
       </notes>
       <segment>
-        <source>action.preview</source>
-        <target>Vorschau</target>
+        <source>collection.move_item_up</source>
+        <target>Hoch bewegen</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
+    <unit id="KzBtfHi" name="collection.move_item_down">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
       </notes>
       <segment>
-        <source>buttons.button_toggle</source>
-        <target>Dropdown anzeigen</target>
+        <source>collection.move_item_down</source>
+        <target>Runter bewegen</target>
       </segment>
     </unit>
-    <unit id="ok6YulQ" name="action.view_saved">
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/extensions.html.twig:54</note>
       </notes>
       <segment>
-        <source>action.view_saved</source>
-        <target>Gespeicherte Version anschauen</target>
+        <source>extensions.button_detailed_view</source>
+        <target>Details ansehen</target>
       </segment>
     </unit>
-    <unit id="odDw0du" name="action.search">
+    <unit id="hgNZLwW" name="extensions.title_configuration">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
       </notes>
       <segment>
-        <source>action.search</source>
-        <target>Suchen</target>
+        <source>extensions.title_configuration</source>
+        <target>Konfigurationsdatei</target>
       </segment>
     </unit>
-    <unit id="Pily_qo" name="general.phrase.read-more">
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/finder/_uploader.html.twig:17</note>
       </notes>
       <segment>
-        <source>general.phrase.read-more</source>
-        <target>Mehr anzeigen</target>
+        <source>caption.file_upload.upload_text</source>
+        <target>Legen Sie Dateien hier ab, um sie hochzuladen</target>
       </segment>
     </unit>
-    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+    <unit id="L_YQKUn" name="pager.next">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
       </notes>
       <segment>
-        <source>contenttypes.generic.overview</source>
-        <target>Seitenübersicht</target>
+        <source>pager.next</source>
+        <target>Vor</target>
       </segment>
     </unit>
-    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+    <unit id="AMxTho9" name="pager.previous">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
       </notes>
       <segment>
-        <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Diese Webseite wurde erstellt mit <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Bolt</a>. ]]></target>
+        <source>pager.previous</source>
+        <target>Zurück</target>
       </segment>
     </unit>
-    <unit id="AGegYAN" name="contenttypes.generic.recent">
+    <unit id="7aSD0Qr" name="image.button_up">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
       </notes>
       <segment>
-        <source>contenttypes.generic.recent</source>
-        <target>Neueste Seiten</target>
+        <source>image.button_up</source>
+        <target>Hoch</target>
       </segment>
     </unit>
-    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+    <unit id="WihD8Y5" name="image.button_down">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
       </notes>
       <segment>
-        <source>general.phrase.search-ellipsis</source>
-        <target>...</target>
+        <source>image.button_down</source>
+        <target>Runter</target>
       </segment>
     </unit>
-    <unit id="a2vzLi7" name="action.do_something">
+    <unit id="fon6eNN" name="general.phrase.download">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/helpers/_field_blocks.twig:28</note>
       </notes>
       <segment>
-        <source>action.do_something</source>
-        <target>Beispieltext</target>
+        <source>general.phrase.download</source>
+        <target>Herunterladen</target>
       </segment>
     </unit>
-    <unit id="cH6rDCP" name="Button">
+    <unit id="2MtT_h0" name="caption.logviewer">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
       </notes>
       <segment>
-        <source>Button</source>
-        <target>Button</target>
-      </segment>
-    </unit>
-    <unit id="RaGzSx5" name="57d589f">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>57d589f</source>
-        <target><![CDATA[<strong>Achtung!</strong> Diese Warnung benötigt Ihre Aufmerksamkeit, ist aber nicht besonders wichtig.]]></target>
-      </segment>
-    </unit>
-    <unit id="Bicbr0l" name="info">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>info</source>
-        <target>Information</target>
-      </segment>
-    </unit>
-    <unit id="S9k1S7Z" name="warning">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>warning</source>
-        <target>Warnung</target>
-      </segment>
-    </unit>
-    <unit id="Ej.WZqo" name="danger">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>danger</source>
-        <target>Achtung</target>
-      </segment>
-    </unit>
-    <unit id="ypPzS03" name="localeswitcher.button_info">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>localeswitcher.button_info</source>
-        <target>Übersetzungsstatus</target>
-      </segment>
-    </unit>
-    <unit id="n.jOrkg" name="caption.untitled_contenttype">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>caption.untitled_contenttype</source>
-        <target>Unbenannte(r) %contenttype%</target>
-      </segment>
-    </unit>
-    <unit id="QoeqyPT" name="caption.new_contenttype">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>caption.new_contenttype</source>
-        <target>%contenttype% anlegen</target>
-      </segment>
-    </unit>
-    <unit id="Iy4HXCU" name="controller.user.title">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>controller.user.title</source>
-        <target><![CDATA[Benutzer & Rechte]]></target>
-      </segment>
-    </unit>
-    <unit id="ovKkXwU" name="action.edit">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>action.edit</source>
-        <target>Bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="ryXZRAu" name="action.disable">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>action.disable</source>
-        <target>Deaktivieren</target>
-      </segment>
-    </unit>
-    <unit id="HBwIQ9b" name="controller.user.subtitle">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>controller.user.subtitle</source>
-        <target>Benutzer und Rechte bearbeiten</target>
-      </segment>
-    </unit>
-    <unit id="7whLbH8" name="user.new_user">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>user.new_user</source>
-        <target>Neuen Benutzer anlegen</target>
-      </segment>
-    </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>caption.folders</source>
-        <target>Ordner</target>
-      </segment>
-    </unit>
-    <unit id="5IxD63c" name="general.latest_bolt_news">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>general.latest_bolt_news</source>
-        <target>Neueste Bolt Neuigkeiten</target>
-      </segment>
-    </unit>
-    <unit id=".I3mIHo" name="label.current_status">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.current_status</source>
-        <target>Aktueller Status</target>
-      </segment>
-    </unit>
-    <unit id="utGAKaQ" name="status.published">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>status.published</source>
-        <target>Veröffentlicht</target>
-      </segment>
-    </unit>
-    <unit id="oxqDDuK" name="status.held">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>status.held</source>
-        <target>Gehalten</target>
-      </segment>
-    </unit>
-    <unit id="h7dP3WY" name="status.timed">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>status.timed</source>
-        <target>Terminiert</target>
-      </segment>
-    </unit>
-    <unit id="HJbHjee" name="status.draft">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>status.draft</source>
-        <target>Entwurf</target>
-      </segment>
-    </unit>
-    <unit id="hAysbHB" name="label.translatable">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.translatable</source>
-        <target>Dieses Feld ist übersetzbar</target>
-      </segment>
-    </unit>
-    <unit id="ni4zApC" name="listing.button_filter">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>listing.button_filter</source>
-        <target>Filtern</target>
-      </segment>
-    </unit>
-    <unit id="txRonia" name="label.id">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.id</source>
-        <target>ID</target>
-      </segment>
-    </unit>
-    <unit id="IwLLxxx" name="label.level">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.level</source>
-        <target>Level</target>
-      </segment>
-    </unit>
-    <unit id="51OQi14" name="label.message">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.message</source>
-        <target>Nachricht</target>
-      </segment>
-    </unit>
-    <unit id="S0f6iTL" name="label.timestamp">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>label.timestamp</source>
-        <target>Zeit</target>
+        <source>caption.logviewer</source>
+        <target>Protokolle</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/logviewer.html.twig:39</note>
       </notes>
       <segment>
         <source>label.request</source>
@@ -3378,7 +2412,7 @@
     </unit>
     <unit id="l71Tprl" name="label.trace">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/logviewer.html.twig:53</note>
       </notes>
       <segment>
         <source>label.trace</source>
@@ -3387,29 +2421,1018 @@
     </unit>
     <unit id="29ZEo1r" name="label.context">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/logviewer.html.twig:71</note>
       </notes>
       <segment>
         <source>label.context</source>
         <target>Kontext</target>
       </segment>
     </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Stufe</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Nachricht</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Zeit</target>
+      </segment>
+    </unit>
     <unit id="O2X4xZH" name="label.user">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/pages/logviewer.html.twig:86</note>
       </notes>
       <segment>
         <source>label.user</source>
         <target>Benutzer</target>
       </segment>
     </unit>
-    <unit id="Hr2E9Oa" name="listing_table.no_results">
+    <unit id="3MuwWwe" name="listing.disabled">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>templates/users/listing.html.twig:33</note>
       </notes>
       <segment>
-        <source>listing_table.no_results</source>
-        <target>Keine Ergebnisse gefunden. Erweitern Sie die Filterkriterien oder fügen Sie weitere Inhalte hinzu.</target>
+        <source>listing.disabled</source>
+        <target>Deaktiviert</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Entsperrt</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Kein Inhalt gefunden</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Keine</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Leer</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>auf alle anwenden</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Systeminformationen</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Sind Sie sicher, dass Sie diesen Inhalt löschen möchten?
+</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>Usernamen oder Email eingeben</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>Ihr Passwort</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Andere Inhalte</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>Das Speichern ist deaktiviert, da die Zieldatei nicht beschreibbar ist.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Dieses Feld ist übersetzbar</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Inhalt</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>Datei erfolgreich gelöscht!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Sind Sie sicher, dass Sie diese Datei löschen möchten?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Filtern nach</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Status erfolgreich geändert</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Inhalt erfolgreich gelöscht</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Aktueller Status</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Veröffentlicht</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Entwurf</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Terminiert</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Gehalten</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Sind Sie sicher, dass Sie dieses Kollektionsobjekt löschen möchten?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Erlaubte Dateiformate</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Maximale Dateigröße</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Nach Schlüsselwörtern suchen ...</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Gesamter Inhalt, gefiltert nach <em>'%filter%'</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Website ansehen</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Neu</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Keine bekannten Abhängigkeiten</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Abhängigkeiten</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Alles einblenden</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Alles ausblenden</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>Die Definition für diesen ContentType fehlt! Die Bearbeitung dieses Datensatzes wird nicht wie erwartet funktionieren. Bitte überprüfen Sie Ihre contenttypes.yaml, um sicherzustellen, dass sie %contenttype% enthält.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Auswählen ...</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Bitte Usernamen oder Email-Adresse eingeben</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Bitte Passwort eingeben</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Bitte Email-Adresse eingeben</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Nach Feld filtern</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Von einer URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Link zu Datei kopieren</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Warnung</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Ordner existiert bereits</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Ordner konnte nicht erstellt werden</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Ordner wurde erfolgreich erstellt.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Ordner erfolgreich gelöscht</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Neuer Ordner</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Passwort vergessen</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Passwort zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Absenden</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-Mail</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Zurück zum Login</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Setze dein Passwort zurück</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Passwort Reset Email versendet</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Es wurde eine Email versandt, die einen Link enthält, auf den Sie klicken können, um Ihr Passwort zurückzusetzen. Dieser Link wird in %hours% Stunde(n) ablaufen.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Wenn Sie keine E-Mail erhalten, überprüfen Sie bitte Ihren Spam-Ordner oder %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Passwort zurücksetzen</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Hallo!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Um Ihr Passwort zurückzusetzen, besuchen Sie bitte den folgenden Link</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Dieser Link wird in %hours% Stunde(n) ablaufen.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Danke!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Bitte ein Passwort eingeben</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Passwort wiederholen</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Die Passwortfelder stimmen nicht überein.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Ihr Passwort sollte mindestens %s Zeichen lang sein</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>In der URL oder in der Sitzung wurde kein Token zum Zurücksetzen des Passworts gefunden.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Passwort Reset war erfolgreich.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Es gab ein Problem bei der Bearbeitung Ihrer Anfrage zum Zurücksetzen des Passworts - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>gefiltert nach</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Sicheren Vorschau-Link teilen</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Impersonierung beenden</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Identität annehmen</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Maintenance Modus ist aktiviert</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Neu laden</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Anzeige Records %current% von %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Name: %name% (Singular: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (Singular: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Datensatz-Vorlage: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Listing template: %template% (%listingRecords% Einträge)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Lokalisierungen: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Berechtigungen bearbeiten</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Suche</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Bildvorschau anzeigen</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Alle auswählen</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Angemeldet bleiben? (%duration% Tage)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Aktuelle Sitzungen</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Upload Optionen</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Reihenfolge</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>Ihre Email-Adresse</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Datei auswählen</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Bild auswählen</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Von URL hochladen</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Wird geladen …</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Speichern</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Schließen</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.el.xlf
+++ b/translations/messages.el.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="messages.en">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Μη διαθέσιμο</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Σφάλμα %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>Παρουσιάστηκε άγνωστο σφάλμα (HTTP %status_code%) που εμπόδισε την ολοκλήρωση του αιτήματός σας.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Δοκιμάστε να φορτώσετε ξανά αυτήν τη σελίδα σε λίγα λεπτά ή <a href="%url%">επιστρέψτε στην αρχική σελίδα</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>Δεν έχετε άδεια πρόσβασης σε αυτόν τον πόρο.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Ζητήστε από τον διαχειριστή του συστήματος να σας παραχωρήσει πρόσβαση σε αυτόν τον πόρο.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>Δεν ήταν δυνατή η εύρεση της σελίδας που ζητήσατε.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Ελέγξτε τυχόν ορθογραφικά λάθη στη διεύθυνση URL ή <a href="%url%">επιστρέψτε στην αρχική σελίδα</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>Παρουσιάστηκε εσωτερικό σφάλμα.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Δοκιμάστε να φορτώσετε ξανά αυτήν τη σελίδα σε λίγα λεπτά ή <a href="%url%">επιστρέψτε στην αρχική σελίδα</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Ο πηγαίος κώδικας χρησιμοποιείται για την απόδοση αυτής της σελίδας</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Controller code</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig template code</target>
-      </segment>
-    </unit>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="el">
+  <file id="messages.el">
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Επεξεργασία χρήστη</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Εμφάνιση κωδικα</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Κάνε κάτι</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Επεξεργασία χρήστη</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Επεξεργασία</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Όνομα χρήστη</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[Click on this button to show the source code of the <strong>Controller</strong> and <strong>template</strong> used to render this page.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>Αφού αλλάξετε τον κωδικό πρόσβασής σας, θα αποσυνδεθείτε από την εφαρμογή.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
-        <target>Contentlisting</target>
-      </segment>
-    </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Αλλαξε κωδικό πρόσβασης</target>
+        <target>Λίστα περιεχομένου</target>
       </segment>
     </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,25 +268,27 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
-        <target>Bolt Documentation</target>
+        <target>Τεκμηρίωση Bolt</target>
       </segment>
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
-        <target>Bolt on Github</target>
+        <target>Το Bolt στο Github</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,37 +297,36 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Ακολουθούν οι βιβλιοθήκες τρίτων που χρησιμοποιούνται απο το Bolt.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>Νεο</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Πλήρες όνομα</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>Νεο</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>Ήλ. Διέυθυνση</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Σχετικά</target>
+      </segment>
+    </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>Νεο</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -460,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>Νεο</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -471,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>Νεο</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -481,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>Νεο</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -490,512 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>Γλώσσα</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Θέμα</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Προεπιλεγμένο θέμα</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>Προεπιλεγμένο θέμα Σκοτεινό</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
-        <target>WoordPers: Kinda looks like that other CMS</target>
+        <target>WoordPers: Μοιάζει λιγάκι με εκείνο το άλλο CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Πίνακας Διαχείρισης</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>μεταφράσεις: μηνύματα</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Εκκαθαρίστε την προσωρινή μνήμη</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Ελέγξτε τη βάση δεδομένων</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>caption.routing Διαχείριση</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Διαχείριση Μενου</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Ταξινομίες</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Τύποι περιεχομένου</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Κύρια διαμόρφωση</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
-        <target><![CDATA[Χρήστες και δικαιώματα]]></target>
+        <target>Χρήστες και δικαιώματα</target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Διαμόρφωση</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Ρυθμίσεις</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Περιεχομένο</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Διαχείριση Πολυμέσων</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Επεκτάσεις</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
-        <target><![CDATA[Προβολή και επεξεργασία προτύπων]]></target>
+        <target>Προβολή και επεξεργασία προτύπων</target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Μεταφορτωμένα αρχεία</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Διαμόρφωση δρομολόγησης</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Μεταφράσεις / Ετικέτες</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>Σχετικά με Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
         <target><![CDATA[Εξελιγμένο, ελαφρύ & απλό CMS]]></target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Επεξεργασία</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Μεταφόρτωση αρχείων</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Μετα-πληροφορίες</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Ημερομηνία</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Μέγεθος</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
         <target>Mικρή εικόνα</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Ονομα αρχείου</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Ενέργειες</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Όνομα καταλόγου</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Go</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Γρήγορη Επεξεργασία Αρχειου…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Γρήγορη επιλογή</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Μονοπάτι</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Ονομα αρχείου</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Επισκέψου την ιστοσελίδα</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Δημιούργησε ένα νέο</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Γειά, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Αποσύνδεση</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Επεξεργασία προφίλ</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>Κλείσιμο</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Όλα τα αρχεία διαμόρφωσης</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Συντήρηση</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Προεπιλεγμενο (Περιεχομένο για επίδειξη)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Επεξεργασία αρχείου</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Έλεγχοι εγκατάστασης</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Επιλέξτε γλώσσα</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Γλώσσα</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Επιλεγμένη Γλώσσα</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Επιλογή Γλώσσας</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Συντάκτης</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Επεξεργασία</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Αγνωστο</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Γραμμένο από %name% στις %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>Λείπει η σελίδα "About"</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>Το "About" μπλοκ λείπει.</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>Πρόσφατα %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Αναζήτηση</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='%url%' target='_blank' title='
-Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>Επισκόπηση %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Δεν βρέθηκαν πρόσφατα %contenttype%</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>Μενού</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Αναζήτηση</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Μόνιμος σύνδεσμος</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Όνομα εμφάνισης</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>Η προσωρινή μνήμη εκκαθαρίστηκε με επιτυχία!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
         <target>Νεροχύτης</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': παραμέτροι</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Αποτελέσματα αναζήτησης για '%search%'.</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': παραμέτροι</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1004,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': παραμέτροι</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1013,1359 +1018,2420 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Καταχωρίστε έναν όρο αναζήτησης, για να εμφανίσετε σχετικά αποτελέσματα.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Περισσότερα</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='%url%' target='_blank' title='Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
+        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='https://boltcms.io' target='_blank' title='Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Τελευταία Νέα</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>Προεπισκόπηση</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>Προβολή αποθηκευμένης έκδοσης</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Εμφανιζόμενο όνομα</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Αντίγραφη</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>κωδικός πρόσβασης</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>Νέος κωδικός πρόσβασης</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>Νέος κωδικός πρόσβασης (επιβεβαίωση)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>Το αρχείο ενημερώθηκε με επιτυχία!</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Πρόσθεσε χρήστη</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Επιτυχία!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>Το προφίλ χρήστη ενημερώθηκε!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Ρόλοι</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>Πρόσθεσε χρήστη</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>Προβολή</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Φάκελοι</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>Κλειδωμένο</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>Επεξεργασία</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>Δημιουργία από:</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>Μεταφόρτωση</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
         <target>Από βιβλιοθήκη</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>Προβολή στον ιστότοπο</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Αλλαγή κατάστασης σε "δημοσίευση"</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Αλλαγή κατάστασης σε "σε αναμονή"</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Αλλαγή κατάστασης σε "πρόχειρο"</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
       <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Αντίγραφο</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>Διαγράφη</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>Δημιουργήθηκε στις</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>Δημοσιεύτηκε στις</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Τελευταία τροποποίηση στις</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Επιλεγμένο</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>Ταυτότητες Επιλεγμένης εγγραφής</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(these can be used with something like axios to bulk modify/delete)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>Διεύθυνση URL περιεχομένου προς ενσωμάτωση</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL περιεχομένου στο Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Ύψος</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>pixel</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Ενσωμάτωση</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>Προεπισκόπηση</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Μέγεθος</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>Όνομα αρχείου (ανεβάστε ένα νέο αρχείο ή επιλέξτε ένα υπάρχον)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Χαρακτηριστικό Alt</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>Χαρακτηριστικό τίτλου</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>Εναλλαγή πλάτους Μενου</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
       <segment>
         <source>admin_sidebar_toggler.toggle</source>
-        <target><![CDATA[<span class="sr-only">Toggle </span>menu]]></target>
+        <target><![CDATA[<span class="sr-only">Εναλλαγή </span>μενού]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
       <segment>
         <source>editor_date.toggle</source>
         <target>Εναλλαγή</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Ονομα αρχείου</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Τίτλος</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>Προβολή εικόνας</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Ανεβάστε μια εικόνα</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>image</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>imagelist</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Γεωγραφική τοποθεσία:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Αναζήτηση διευθύνσεων</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>Οδός, ταχυδρομικός κώδικας, πόλη ή άλλη τοποθεσία…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Γεωγραφικό πλάτος</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Αντιστοιχισμένη διεύθυνση</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>Τοποθέτηση δείκτη</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>Τραβήξτε στην πλησιέστερη διεύθυνση</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Γεωγραφικό μήκος</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Σημείωση: Αυτό το πεδίο είναι σχεδόν το ίδιο με το <code>filelist</code>-field.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>Γνωστοποίηση</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Εναλλαγή αναπτυσσόμενου μενού</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
       <segment>
         <source>localeswitcher.button_info</source>
         <target>Δείτε πληροφορίες τοπικής προσαρμογής</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Ταξινόμηση κατά</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Επιλέξτε αντικείμενο</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Τίτλος</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Λέξη-κλειδί για φιλτράρισμα…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Φίλτρο</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
       <segment>
         <source>listing.button_clear</source>
         <target>Εκκαθάριση ταξινόμησης / φίλτρου</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>Προκαθορισμένο</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
         <target>Λείπει</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Εναλλαγή αναπτυσσόμενου μενού</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Επεξεργασία πληροφοριών εικόνας</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>Επεξεργασία αρχείου</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>Προβολή πρωτότυπου</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
       <segment>
         <source>files_cards.action_duplicate</source>
         <target>Αντίγραφη</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>Διαγραφή</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>Ονομα αρχείου:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>Τίτλος:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>Διαστάσεις:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>Μέγεθος αρχείου:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>Δημιουργήθηκε:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>Δεν υπάρχουν αρχεία σε αυτόν τον φάκελο. Επιλέξτε ένα φάκελο για πλοήγηση στο.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>Επιλέξτε ένα αρχείο:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>Λίστα</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>Καρτέλες</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>Περιγραφή:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>Συντάκτης:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
         <target>Όνομα πακέτου / κλάσης:</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Εκδοχή:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>Αυτό είναι ένα τοπικό πακέτο, δεν εγκαθίσταται μέσω του Composer</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Όνομα κλάσης:</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>Διαμόρφωση</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
         <target>Πηγή</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>Κατάργηση επέκτασης</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Απενεργοποίηση επέκτασης</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
-        <target>Bolt » Login</target>
+        <target>Bolt » Σύνδεση</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
       <segment>
         <source>extensions.message_not_implemented</source>
         <target>Δεν έχει ακόμη εφαρμοστεί. Συγνώμη!</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>Επισκόπηση για</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>Δεν υπάρχουν αρχεία σε αυτόν τον φάκελο. Επιλέξτε έναν φάκελο για πλοήγηση προς, στη δεξιά πλευρά.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>listing_filter.button_compact</source>
         <target>Συμπαγής</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
       <segment>
         <source>listing_filter.button_expanded</source>
         <target>Αναπτυγμένο</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>Προβολή:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Επεξεργασία</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
-        <target><![CDATA[Χρήστες και δικαιώματα]]></target>
+        <target>Χρήστες και δικαιώματα</target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>Για να επεξεργαστείτε τους χρήστες και τα δικαιώματά τους</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Έλεγχος βάσης δεδομένων</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>Για να ελέγξετε τη βάση δεδομένων</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Ενημέρωση βάσης δεδομένων</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>Για να ενημερώσετε τη βάση δεδομένων</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>Για να κάνετε αναζήτηση, με ολοκλήρωτικο τρόπο</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>Εμφανιζόμενο όνομα</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>Όνομα χρήστη</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
         <target>Ηλ. Διευθηνση</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>Ρόλοι</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
-        <target>Session age</target>
+        <target>Διάρκεια συνεδρίας</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
         <target>Τελευταία IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Ενέργειες</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Ακυρο ηλ. ταχυδρομείο</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Λανθασμένος κωδικός. Ο κωδικός πρόσβασης πρέπει να περιέχει τουλάχιστον 6 χαρακτήρες.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>Αγνωστος χρήστης</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Κυρίαρχα χρώματα στην εικόνα</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>Επισκόπηση για '%slug%'</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>Σχετικό περιεχόμενο</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>Αναζήτηση</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>Νέο %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>%contenttype% Χωρίς τίτλο</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>Επεξεργασία προφίλ χρήστη</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>Σελίδα ανακατεύθυνσης</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>Επεξεργασία εικόνας</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>Επιλέξτε γλώσσα</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[Προτεινόμενος ασφαλής κωδικός πρόσβασης: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
-        <target>Crop X</target>
+        <target>Περικοπή X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Θεση για κοψιμο στο X-axis, εύρος 0-100. </target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Θεση για κοψιμο στο Y-axis, εύρος 0-100. </target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>κοψιμο Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>κοψιμο συντελεστής μεγενθυνσης</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>συντελεστής κοψιματος, εύρος 1-10. </target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>Τύπος περιεχομένου</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>Ταξινόμηση</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>Δεν βρέθηκαν αποτελέσματα. Διευρύνετε τα κριτήρια φιλτραρίσματος ή προσθέστε λίγο περισσότερο περιεχόμενο.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>Επιλέξτε Πεδίο για ταξινόμηση κατά…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>Πρωτογενείς δράσεις</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>Επιλογές</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Διαγραφή</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Ενεργοποιηση</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>Απενεργοποίηση</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>Ο χρήστης έχει ενεργοποιηθεί με επιτυχία!</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment>
-        <source>user.disabled_successfully</source>
-        <target>Ο χρήστης απενεργοποιήθηκε με επιτυχία!</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Το Session Ληγει</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>IP διεύθυνση</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Πρόγραμμα περιήγησης / πλατφόρμα</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>Αφαιρεση</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>Επεξεργασία χαρακτηριστικών</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>Μετακινηση Πανω</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>Μετακινηση Κατω</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Προσθήκη νέας εικόνας</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Προσθήκη νέου αρχείου</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>Κατάργηση στοιχείου</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>Προσθέστε ένα νέο στοιχείο στο '%name%'</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>Μετακινηση Πανω</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>Μετακινηση Κατω</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>Δείτε λεπτομέρειες</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>Αρχείο διαμόρφωσης</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Αποθέστε αρχεία εδώ για μεταφόρτωση</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>Επόμενο</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>Προηγούμενο</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>Πάνω</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
         <target>Κάτω</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>Κατεβάστε</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>προβολή αρχείων καταγραφής</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
         <target>Αίτηση</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>Ιχνος</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>πλαίσιο</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>Επίπεδο</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>Μήνυμα</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
       <segment>
         <source>label.timestamp</source>
         <target>Χρονική σήμανση</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>Χρήστης</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing.disabled</source>
         <target>Απενεργοποίημενο</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>Ξεκλειδωτο</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>Δεν βρέθηκε περιεχόμενο</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>Φαίνεται ότι η βάση δεδομένων είναι κενή. Γράψτε κάποιο περιεχόμενο στο Bolt backend ή εκτελέστε την εντολή για να προσθέσετε κάποια στοιχεία (dummy content). </target>
+        <source>general.phrase.none</source>
+        <target>Κανένα</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
         <target>Αδειο</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>Εφαρμόστε σε όλα</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>Πληροφορίες συστήματος</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Μη έγκυρο εμφανιζόμενο όνομα</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτό το περιεχόμενο;</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>το όνομα χρήστη ή το email σας</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>ο κωδικός σας</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Άλλο περιεχόμενο</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>Η αποθήκευση είναι απενεργοποιημένη, επειδή το αρχείο προορισμού δεν είναι εγγράψιμο.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>Αυτό το πεδίο είναι μεταφράσιμο</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>Περιεχόμενο</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
         <source>file.delete_success</source>
         <target>Το αρχείο διαγράφηκε με επιτυχία!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτό το αρχείο?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>Αναζήτηση / Φιλτράρισμα κατά</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
       <segment>
         <source>content.status_changed_successfully</source>
         <target>Η κατάσταση άλλαξε με επιτυχία</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
       <segment>
         <source>content.deleted_successfully</source>
         <target>Το περιεχόμενο διαγράφηκε με επιτυχία</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>Τρέχουσα κατάσταση</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>Δημοσιεύτηκε</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>Προσχέδιο</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>Χρονισμένο</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>Κατακρατηση</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτό το στοιχείο συλλογής?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
       <segment>
         <source>upload.allow_file_types</source>
         <target>Επιτρέπομενοι τύποι αρχείων για μεταφόρτωση</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>Μέγιστο μέγεθος μεταφόρτωσης</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>Αναζήτηση για λέξη-κλειδί…</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[Ολο το περιεχόμενο, φιλτραρισμένο κατά <em>'%filter%'</em>.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>Δείτε τον ιστότοπο</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>Νέο</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>Δεν υπάρχουν γνωστές εξαρτήσεις</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>εξαρτήσεις</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Ανάπτυξη όλων</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Σύμπτυξη όλων</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
         <target>Λείπει ο ορισμός για αυτόν τον τύπο περιεχομένου! Η επεξεργασία αυτής της εγγραφής δεν θα λειτουργήσει όπως αναμενόταν. Ελέγξτε το contenttypes.yaml για να βεβαιωθείτε ότι περιέχει %contenttype%.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>Επιλογή …</target>
       </segment>
     </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Παρακαλώ εισάγετε το όνομα χρήστη ή το email σας</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Παρακαλώ εισάγετε τον κωδικό πρόσβασής σας</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Παρακαλώ εισάγετε το email σας</target>
+      </segment>
+    </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Φιλτράρισμα ανά πεδίο</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Από URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Αντιγραφή συνδέσμου αρχείου</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Προειδοποίηση</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Ο φάκελος υπάρχει ήδη</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Δεν ήταν δυνατή η δημιουργία του φακέλου</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Ο φάκελος δημιουργήθηκε με επιτυχία.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Ο φάκελος διαγράφηκε με επιτυχία</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Νέος φάκελος</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Άβαταρ</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Ξεχάσατε τον κωδικό;</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Επαναφορά κωδικού</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Εισάγετε τη διεύθυνση email σας και θα σας στείλουμε έναν σύνδεσμο για την επαναφορά του κωδικού σας.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Υποβολή</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Email</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Επιστροφή στη σύνδεση</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Επαναφορά του κωδικού σας</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Το email επαναφοράς κωδικού στάλθηκε</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Στάλθηκε ένα email που περιέχει έναν σύνδεσμο στον οποίο μπορείτε να κάνετε κλικ για να επαναφέρετε τον κωδικό σας. Αυτός ο σύνδεσμος θα λήξει σε %hours% ώρες.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Αν δεν λάβετε email, ελέγξτε τον φάκελο ανεπιθύμητης αλληλογραφίας ή %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Επαναφορά κωδικού</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Γεια σας!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Για να επαναφέρετε τον κωδικό σας, επισκεφθείτε τον παρακάτω σύνδεσμο</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Αυτός ο σύνδεσμος θα λήξει σε %hours% ώρες.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Ευχαριστούμε!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Παρακαλώ εισάγετε έναν κωδικό</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Επανάληψη κωδικού</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Τα πεδία κωδικού πρέπει να ταιριάζουν.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Ο κωδικός σας πρέπει να έχει τουλάχιστον %s χαρακτήρες</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Δεν βρέθηκε διακριτικό επαναφοράς κωδικού στη διεύθυνση URL ή στη συνεδρία.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Ο κωδικός σας επαναφέρθηκε με επιτυχία.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Παρουσιάστηκε πρόβλημα κατά τον χειρισμό του αιτήματος επαναφοράς κωδικού - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>Φιλτραρισμένο κατά</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Κοινοποίηση ασφαλούς συνδέσμου προεπισκόπησης</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Διακοπή υπόδυσης χρήστη</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Υπόδυση χρήστη</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Η λειτουργία συντήρησης είναι ενεργοποιημένη</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Ανανέωση</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Εμφάνιση εγγραφών %current% από %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Όνομα: %name% (ενικός: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (ενικός: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Πρότυπο εγγραφής: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Πρότυπο λίστας: %template% (%listingRecords% εγγραφές)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Τοπικές ρυθμίσεις: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Επεξεργασία δικαιωμάτων</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Αναζήτηση</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Προεπισκόπηση της εικόνας</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Επιλογή όλων</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Να με θυμάσαι; (%duration% ημέρες)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Τρέχουσες συνεδρίες</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Επιλογές μεταφόρτωσης</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Σειρά</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>το email σας</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Επιλέξτε ένα αρχείο</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Επιλέξτε μια εικόνα</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Μεταφόρτωση από URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Φόρτωση...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Αποθήκευση</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Κλείσιμο</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="messages.en">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Not available</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Error %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>There was an unknown error (HTTP %status_code%) that prevented your request being completed.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Try loading this page again in a few minutes or <a href="%url%">go back to the homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>You don't have permission to access this resource.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Ask your manager or system administrator to grant you access to this resource.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>We couldn't find the page you requested.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Check for any misspelling in the URL or <a href="%url%">go back to the homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>There was an internal server error.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Try loading this page again in a few minutes or <a href="%url%">go back to the homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Source code used to render this page</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Controller code</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig template code</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Edit user</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Show code</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Do Something</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Edit user</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Edit</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Username</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[Click on this button to show the source code of the <strong>Controller</strong> and <strong>template</strong> used to render this page.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>After changing your password, you will be logged out of the application.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>Contentlisting</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Change password</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -412,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,27 +297,18 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Below are the third party libraries that are used by Bolt.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Full name</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
@@ -450,8 +317,7 @@
     </unit>
     <unit id="D2N7_cP" name="label.about">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>templates/users/_form.html.twig:185</note>
       </notes>
       <segment>
         <source>label.about</source>
@@ -460,8 +326,7 @@
     </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -470,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -481,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -491,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -500,505 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>Locale</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Backend theme</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>The Default theme</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>The Default Dark theme</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Kinda looks like that other CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Bolt Dashboard</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>caption.translations: messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Clear the cache</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Check Database</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>caption.routing set up</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Menu set up</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Taxonomies</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Content Types</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Main Configuration</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Users & Permissions]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Configuration</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Settings</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Content</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>File management</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Extensions</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
         <target><![CDATA[View & edit templates]]></target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Uploaded files</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Routing configuration</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Translations / Labels</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>About Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
         <target><![CDATA[Sophisticated, lightweight & simple CMS]]></target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Edit</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>File uploader</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Meta information</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Date</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Size</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
         <target>Thumbnail</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Filename</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Actions</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Directory name</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Go</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Quickly select a file to edit…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Quick select</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Path</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Filename</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Visit website</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Create a new</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Hey, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Logout</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Edit Profile</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>Close</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>All configuration files</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Maintenance</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fixtures (Dummy Content)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Edit File</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Installation checks</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Select language</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Current locale</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Switch to locale</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Author</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Edit</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Unknown</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Written by %name% on %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>The "About" page is missing</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>The "About" block is missing</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>Recent %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Search</target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>Overview of %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>No recent %contenttype% found</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>Menu</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Search</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Permalink</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Displayname</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>Cache cleared successfully!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
         <target>The Kitchensink</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Search results for '%search%'.</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1007,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1016,1740 +1018,2417 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Please provide a search term, in order to display relevant results.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Read More</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
         <target><![CDATA[This website is <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Latest Bolt News</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>Preview</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>View saved version</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Display Name</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Duplicate</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>Current Password</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>New Password</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>New Password (confirm)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>File updated successfully!</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Add User</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Success!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>User Profile has been updated!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Roles</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>New User</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>View</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Folders</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>Locked</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>Edit</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>Generate from:</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>Upload</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
         <target>From library</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>View on Site</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Change status to 'publish'</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Change status to 'held'</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Change status to 'draft'</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
       <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Duplicate</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>Delete</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>Created on</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>Published on</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Last modified on</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Selected</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>selected record ids passed</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(these can be used with something like axios to bulk modify/delete)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>URL of content to embed</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL of content on Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Height</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>pixel</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Matched Embed</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>Preview</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Size</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>Filename (upload a new file, or select an existing one)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Alt attribute</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>Title attribute</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>Toggle sidebar width</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
       <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[<span class="sr-only">Toggle </span>menu]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
       <segment>
         <source>editor_date.toggle</source>
         <target>Toggle</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Filename</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Title</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>View image</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Upload an image</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>image</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>imagelist</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Geolocation:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Address lookup</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>Street, ZIP code, city or other location…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Latitude</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Matched address</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>Marker placement</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>Snap to nearest address</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Longitude</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>filelist</code>-field.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>Notification</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Toggle Dropdown</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
       <segment>
         <source>localeswitcher.button_info</source>
         <target>See Localization info</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Sort by</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Select item</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Title</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Keyword to filter on…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Filter</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
       <segment>
         <source>listing.button_clear</source>
         <target>Clear sort/filter</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>Default</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
         <target>Missing</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Toggle Dropdown</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Edit image information</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>Edit file in editor</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>View original</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
       <segment>
         <source>files_cards.action_duplicate</source>
         <target>Duplicate</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>Delete</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>Filename:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>Title:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>Dimensions:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>Filesize:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>Created on:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>No files are present in this folder. Select a folder to navigate to.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>Select a file:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>List</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>Cards</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>Description:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>Author:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
         <target>Package / Class name:</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Version:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>This is a local package, not installed through Composer</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Class name:</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>Configuration</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
         <target>Source</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>Remove extension</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Disable extension</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
         <target>Bolt » Login</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
       <segment>
         <source>extensions.message_not_implemented</source>
         <target>Not yet implemented. Sorry!</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>Overview for</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>No files are present in this folder. Select a folder to navigate to, on the right-hand side.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>listing_filter.button_compact</source>
         <target>Compact</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
       <segment>
         <source>listing_filter.button_expanded</source>
         <target>Expanded</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>View:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Edit</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
         <target><![CDATA[Users & Permissions]]></target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>To edit users and their permissions</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Database Check</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>To check the Database</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Database Update</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>To update the Database</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>To search, in an omni-like fashion</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>Display name</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>Username</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
         <target>Email</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>Roles</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
         <target>Session age</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
         <target>Last IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Actions</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Invalid email</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Invalid password. The password should contain at least 6 characters.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>Unknown user</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Predominant colors in image</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>Overview for '%slug%'</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>Related content</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>Search</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>New %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>Untitled %contenttype%</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>Edit user profile</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>Redirection page</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>Edit Image</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>Select Language</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[Suggested secure password: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
         <target>Crop X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Position of crop on X-axis, range 0-100. </target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Position of crop on Y-axis, range 0-100. </target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>Crop Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>Crop zoomfactor</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>Zoom-level of crop, range 1-10. </target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>Content Type</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>Taxonomy</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>No results found. Broaden the filtering criteria, or add some more content.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>Select Field to sort by…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>Primary Actions</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>Options</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Delete</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Enable</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>Disable</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>User has been enabled successfully!</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment>
-        <source>user.disabled_successfully</source>
-        <target>User has been disabled successfully!</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Session expires</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>IP address</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Browser / platform</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>Remove</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>Edit attributes</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>Move up</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>Move down</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Add new image</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Add new file</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>Remove item</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>Add a new item to '%name%'</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>Move up</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>Move down</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>View details</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>Configuration file</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Drop files here to upload</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>Next</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>Previous</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>Up</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
         <target>Down</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>Download</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>Log Viewer</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
         <target>Request</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>Trace</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>Context</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>Level</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>Message</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
       <segment>
         <source>label.timestamp</source>
         <target>Timestamp</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>User</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing.disabled</source>
         <target>Disabled</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>Unlocked</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>No content found</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>It looks like the database is empty. Write some content in the Bolt backend, or run the command to add some fixtures (dummy content). </target>
+        <source>general.phrase.none</source>
+        <target>None</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
         <target>Empty</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>Apply to all</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>System Information</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Invalid display name</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>Are you sure you wish to delete this content?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>your username or email</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>your password</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Other Content</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>Saving is disabled, because the target file is not writable.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>This field is translatable</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>Content</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
         <source>file.delete_success</source>
         <target>File deleted successfully!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Are you sure you wish to delete this file?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>Search / Filter by</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
       <segment>
         <source>content.status_changed_successfully</source>
         <target>Status changed successfully</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
       <segment>
         <source>content.deleted_successfully</source>
         <target>Content deleted successfully</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>Current status</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>Published</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>Draft</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>Timed</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>Held</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>Are you sure you wish to delete this collection item?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
       <segment>
         <source>upload.allow_file_types</source>
         <target>File types allowed for upload</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>Maximum upload size</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>Search for keyword …</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[All content, filtered by <em>'%filter%'</em>.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>View website</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>New</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>No known dependencies</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>Dependencies</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Expand all</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Collapse all</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
         <target>The definition for this ContentType is missing! Editing this record will not work as expected. Please check your contenttypes.yaml to make sure that it contains %contenttype%.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>Select …</target>
       </segment>
     </unit>
     <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
       <segment>
         <source>form.empty_username_email</source>
         <target>Please enter your username or email</target>
       </segment>
     </unit>
     <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
       <segment>
         <source>form.empty_password</source>
         <target>Please enter your password</target>
       </segment>
     </unit>
     <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
       <segment>
         <source>form.empty_email</source>
         <target>Please enter your email</target>
       </segment>
     </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Filter by field</target>
       </segment>
     </unit>
     <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
       <segment>
         <source>image.button_from_url</source>
         <target>From URL</target>
       </segment>
     </unit>
     <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
       <segment>
         <source>files_cards.copy_to_clipboard</source>
         <target>Copy link to file</target>
       </segment>
     </unit>
     <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
       <segment>
         <source>warning</source>
         <target>Warning</target>
       </segment>
     </unit>
     <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_already_exists</source>
         <target>Folder already exists</target>
       </segment>
     </unit>
     <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_error</source>
         <target>Could not create folder</target>
       </segment>
     </unit>
     <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_success</source>
         <target>Folder created successfully.</target>
       </segment>
     </unit>
     <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
       <segment>
         <source>filemanager.delete_folder_successful</source>
         <target>Folder deleted successfully</target>
       </segment>
     </unit>
     <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
       <segment>
         <source>folder.create_new</source>
         <target>New folder</target>
       </segment>
     </unit>
-    <unit id="FcXvWL8" name="title.add_user">
-      <segment>
-        <source>title.add_user</source>
-        <target>Add User</target>
-      </segment>
-    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>Avatar</target>
       </segment>
     </unit>
     <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
       <segment>
         <source>login.forgotpassword</source>
         <target>Forgot Password</target>
       </segment>
     </unit>
     <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.request_header</source>
         <target>Reset Password</target>
       </segment>
     </unit>
     <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
       <segment>
         <source>reset_password.request_description</source>
         <target>Enter your email address and we will send you a link to reset your password.</target>
       </segment>
     </unit>
     <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
       <segment>
         <source>reset_password.request_send</source>
         <target>Submit</target>
       </segment>
     </unit>
     <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
       <segment>
         <source>Email</source>
         <target>Email</target>
       </segment>
     </unit>
     <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
       <segment>
         <source>reset_password.back-to-login</source>
         <target>Back to Login</target>
       </segment>
     </unit>
     <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
       <segment>
         <source>reset_password.reset_header</source>
         <target>Reset your password</target>
       </segment>
     </unit>
     <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_header</source>
         <target>Password Reset Email Sent</target>
       </segment>
     </unit>
     <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_1</source>
         <target>An email has been sent that contains a link you can click to reset your password. This link will expire in %hours% hour(s).</target>
       </segment>
     </unit>
     <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_2</source>
         <target>If you don't receive an email please check your spam folder or %tryagain%.</target>
       </segment>
     </unit>
     <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
       <segment>
         <source>reset_password.reset_btn</source>
         <target>Reset Password</target>
       </segment>
     </unit>
     <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
       <segment>
         <source>reset_password.email_title</source>
         <target>Hi!</target>
       </segment>
     </unit>
     <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
       <segment>
         <source>reset_password.email_description</source>
         <target>To reset your password, please visit the following link</target>
       </segment>
     </unit>
     <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
       <segment>
         <source>reset_password.email_expire</source>
         <target>This link will expire in %hours% hour(s).</target>
       </segment>
     </unit>
     <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
       <segment>
         <source>reset_password.email_thanks</source>
         <target>Cheers!</target>
       </segment>
     </unit>
     <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
       <segment>
         <source>reset_password.enter_pwd</source>
         <target>Please enter a password</target>
       </segment>
     </unit>
     <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
       <segment>
         <source>label.repeat_password</source>
         <target>Repeat Password</target>
       </segment>
     </unit>
     <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
       <segment>
         <source>reset_password.not_matching_pwds</source>
         <target>The password fields must match.</target>
       </segment>
     </unit>
     <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
       <segment>
         <source>reset_password.minimum_length</source>
         <target>Your password should be at least %s characters</target>
       </segment>
     </unit>
     <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
       <segment>
         <source>reset_password.no_token</source>
         <target>No reset password token found in the URL or in the session.</target>
       </segment>
     </unit>
     <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
       <segment>
         <source>reset_password.reset_successful</source>
         <target>Your password has been reset successfully.</target>
       </segment>
     </unit>
     <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
       <segment>
         <source>reset_password.problem_with_request</source>
         <target>There was a problem handling your password reset request - %s</target>
       </segment>
     </unit>
     <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>label.filtered_by</source>
         <target>filtered by</target>
       </segment>
     </unit>
     <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
       <segment>
         <source>action.preview_secure_share</source>
         <target>Share secure preview link</target>
       </segment>
     </unit>
     <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
       <segment>
         <source>action.stop_impersonating</source>
         <target>stop impersonating</target>
       </segment>
     </unit>
     <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
       <segment>
         <source>action.impersonate</source>
         <target>impersonate</target>
       </segment>
     </unit>
     <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
       <segment>
         <source>maintenance.activated_warning</source>
         <target>Maintenance mode is activated</target>
       </segment>
     </unit>
     <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
       <segment>
         <source>action.refresh</source>
         <target>Refresh</target>
       </segment>
     </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
       <segment>
         <source>listing_details_box.showing_records</source>
         <target>Showing records %current% of %total%</target>
       </segment>
     </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
       <segment>
         <source>listing_details_box.name</source>
         <target>Name: %name% (singular: %singularName%)</target>
       </segment>
     </unit>
     <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
       <segment>
         <source>listing_details_box.slug</source>
         <target>Slug: %slug% (singular: %singularSlug%)</target>
       </segment>
     </unit>
     <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
       <segment>
         <source>listing_details_box.record_template</source>
         <target>Record template: %template%</target>
       </segment>
     </unit>
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
       <segment>
         <source>listing_details_box.listing_template</source>
         <target>Listing template: %template% (%listingRecords% records)</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
       <segment>
         <source>listing_details_box.locales</source>
         <target>Locales: %locales%</target>
       </segment>
     </unit>
     <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
       <segment>
         <source>action.edit_permissions</source>
         <target>Edit Permissions</target>
       </segment>
     </unit>
     <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
       <segment>
         <source>general.label.search</source>
         <target>Search</target>
       </segment>
     </unit>
     <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.image_preview</source>
         <target>Preview the image</target>
       </segment>
     </unit>
     <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
       <segment>
         <source>listing_table.actions.select_all</source>
         <target>Select all</target>
       </segment>
     </unit>
     <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
       <segment>
         <source>label.remembermeduration</source>
         <target>Remember me? (%duration% days)</target>
       </segment>
     </unit>
     <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
       <segment>
         <source>listing.current_sessions_header</source>
         <target>Current sessions</target>
       </segment>
     </unit>
     <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
       <segment>
         <source>image.button_upload_options</source>
         <target>Upload Options</target>
       </segment>
     </unit>
-    <unit id="hKmDb7q" name="Share secure preview link">
-      <segment>
-        <source>Share secure preview link</source>
-        <target>Share secure preview link</target>
-      </segment>
-    </unit>
     <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
       <segment>
         <source>Order</source>
         <target>Order</target>
       </segment>
     </unit>
     <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
       <segment>
         <source>placeholder.email</source>
         <target>your email</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>You have to login in order to access this page.</target>
-      </segment>
-    </unit>
     <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>modal.title.file_field</source>
         <target>Select a file</target>
       </segment>
     </unit>
     <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
       <segment>
         <source>modal.title.image_field</source>
         <target>Select an image</target>
       </segment>
     </unit>
     <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
       <segment>
         <source>modal.title.upload_from_url</source>
         <target>Upload from URL</target>
       </segment>
     </unit>
     <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
       <segment>
         <source>modal.text.loading</source>
         <target>Loading...</target>
       </segment>
     </unit>
     <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
       <segment>
         <source>modal.button_save</source>
         <target>Save</target>
       </segment>
     </unit>
     <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
       <segment>
         <source>modal.button_deny</source>
         <target>Close</target>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -3,16 +3,263 @@
   <file id="messages.es">
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Editar Usuario</target>
       </segment>
     </unit>
+    <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
+      <segment>
+        <source>action.save</source>
+        <target>Guardar</target>
+      </segment>
+    </unit>
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>action.do_something</source>
+        <target>Haz algo</target>
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>action.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="LDhDPrF" name="label.username">
+      <notes>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>label.username</source>
+        <target>Nombre de usuario</target>
+      </segment>
+    </unit>
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>title.login</source>
+        <target>Inicio de sesión</target>
+      </segment>
+    </unit>
+    <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>label.password</source>
+        <target>Contraseña</target>
+      </segment>
+    </unit>
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>action.log_in</source>
+        <target>Iniciar sesión</target>
+      </segment>
+    </unit>
+    <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>title.contentlisting</source>
+        <target>Listado de contenido</target>
+      </segment>
+    </unit>
+    <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
+      <segment>
+        <source>field.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
+      <segment>
+        <source>field.status</source>
+        <target>Estado</target>
+      </segment>
+    </unit>
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
+      <segment>
+        <source>field.createdAt</source>
+        <target>Fecha de creación</target>
+      </segment>
+    </unit>
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
+      <segment>
+        <source>field.modifiedAt</source>
+        <target>Fecha de modificación</target>
+      </segment>
+    </unit>
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>field.publishedAt</source>
+        <target>Fecha de publicación</target>
+      </segment>
+    </unit>
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>field.depublishedAt</source>
+        <target>Fecha de retirada de la publicación </target>
+      </segment>
+    </unit>
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>field.title</source>
+        <target>Título</target>
+      </segment>
+    </unit>
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>field.description</source>
+        <target>Descripción</target>
+      </segment>
+    </unit>
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
+      <segment>
+        <source>field.copyright</source>
+        <target>Derechos de autor</target>
+      </segment>
+    </unit>
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>field.originalFilename</source>
+        <target>Nombre original del archivo</target>
+      </segment>
+    </unit>
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
+      <segment>
+        <source>field.width</source>
+        <target>Ancho</target>
+      </segment>
+    </unit>
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
+      <segment>
+        <source>field.height</source>
+        <target>Alto</target>
+      </segment>
+    </unit>
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
+      <segment>
+        <source>field.filesize</source>
+        <target>Tamaño del archivo</target>
+      </segment>
+    </unit>
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
+      <segment>
+        <source>label.username_or_email</source>
+        <target>Usuario o correo electrónico</target>
+      </segment>
+    </unit>
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.rememberme</source>
+        <target>Recordarme</target>
+      </segment>
+    </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -21,1490 +268,3167 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
         <target>Documentación de Bolt</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Visitar Sitio</target>
-      </segment>
-    </unit>
-    <unit id="KfVJho2" name="action.create_new">
-      <segment>
-        <source>action.create_new</source>
-        <target>Crear Nuevo</target>
-      </segment>
-    </unit>
-    <unit id="b_RPpcB" name="general.greeting">
-      <segment>
-        <source>general.greeting</source>
-        <target>Hola %name%</target>
-      </segment>
-    </unit>
-    <unit id="bmdn3u9" name="action.logout">
-      <segment>
-        <source>action.logout</source>
-        <target>Cerrar Sesión</target>
-      </segment>
-    </unit>
-    <unit id="zOfpTLD" name="action.edit_profile">
-      <segment>
-        <source>action.edit_profile</source>
-        <target>Editar Perfil</target>
-      </segment>
-    </unit>
-    <unit id="N_0yRcH" name="action.close_alert">
-      <segment>
-        <source>action.close_alert</source>
-        <target>Cerrar</target>
-      </segment>
-    </unit>
-    <unit id="TpGxDI3" name="user.unknown_user">
-      <segment>
-        <source>user.unknown_user</source>
-        <target>Usuario desconocido</target>
-      </segment>
-    </unit>
-    <unit id="5IxD63c" name="general.latest_bolt_news">
-      <segment>
-        <source>general.latest_bolt_news</source>
-        <target>Últimas noticias de Bolt</target>
-      </segment>
-    </unit>
-    <unit id="Pily_qo" name="general.phrase.read-more">
-      <segment>
-        <source>general.phrase.read-more</source>
-        <target>Leer más</target>
-      </segment>
-    </unit>
-    <unit id="1xlE8ex" name="caption.content">
-      <segment>
-        <source>caption.content</source>
-        <target>Contenido</target>
-      </segment>
-    </unit>
-    <unit id="ZO.uqIZ" name="caption.settings">
-      <segment>
-        <source>caption.settings</source>
-        <target>Opciones</target>
-      </segment>
-    </unit>
-    <unit id="zOLL.7E" name="caption.configuration">
-      <segment>
-        <source>caption.configuration</source>
-        <target>Configuración</target>
-      </segment>
-    </unit>
-    <unit id="ipmA6Ah" name="caption.users_permissions">
-      <segment>
-        <source>caption.users_permissions</source>
-        <target>Usuarios y permisos</target>
-      </segment>
-    </unit>
-    <unit id="kXNBV9S" name="caption.main_configuration">
-      <segment>
-        <source>caption.main_configuration</source>
-        <target>Configuración principal</target>
-      </segment>
-    </unit>
-    <unit id="_w7J5rZ" name="caption.contenttypes">
-      <segment>
-        <source>caption.contenttypes</source>
-        <target>Tipos de Contenido</target>
-      </segment>
-    </unit>
-    <unit id="drK.0GZ" name="caption.taxonomies">
-      <segment>
-        <source>caption.taxonomies</source>
-        <target>Taxonomías</target>
-      </segment>
-    </unit>
-    <unit id="2RUXD4A" name="caption.menu_setup">
-      <segment>
-        <source>caption.menu_setup</source>
-        <target>Configurar menú</target>
-      </segment>
-    </unit>
-    <unit id="wBKDkwl" name="caption.routing_setup">
-      <segment>
-        <source>caption.routing_setup</source>
-        <target>Configurar enrutamiento</target>
-      </segment>
-    </unit>
-    <unit id="i4cbdta" name="caption.all_configuration_files">
-      <segment>
-        <source>caption.all_configuration_files</source>
-        <target>Archivos de configuración</target>
-      </segment>
-    </unit>
-    <unit id="OpKTKAL" name="caption.maintenance">
-      <segment>
-        <source>caption.maintenance</source>
-        <target>Mantenimiento</target>
-      </segment>
-    </unit>
-    <unit id="mfvtHPQ" name="caption.extensions">
-      <segment>
-        <source>caption.extensions</source>
-        <target>Extensiones</target>
-      </segment>
-    </unit>
-    <unit id="2MtT_h0" name="caption.logviewer">
-      <segment>
-        <source>caption.logviewer</source>
-        <target>Registro</target>
-      </segment>
-    </unit>
-    <unit id="Dvu2HQx" name="caption.api">
-      <segment>
-        <source>caption.api</source>
-        <target>API</target>
-      </segment>
-    </unit>
-    <unit id="K6TmK4B" name="caption.clear_cache">
-      <segment>
-        <source>caption.clear_cache</source>
-        <target>Borrar caché</target>
-      </segment>
-    </unit>
-    <unit id="Wou02nK" name="caption.kitchensink">
-      <segment>
-        <source>caption.kitchensink</source>
-        <target>Demonstración</target>
-      </segment>
-    </unit>
-    <unit id="wLaDaK5" name="caption.about_bolt">
-      <segment>
-        <source>caption.about_bolt</source>
-        <target>Sobre Bolt</target>
-      </segment>
-    </unit>
-    <unit id="l4yt0BE" name="caption.file_management">
-      <segment>
-        <source>caption.file_management</source>
-        <target>Gestión de archivos</target>
-      </segment>
-    </unit>
-    <unit id="bq6bSf4" name="caption.uploaded_files">
-      <segment>
-        <source>caption.uploaded_files</source>
-        <target>Archivos subidos</target>
-      </segment>
-    </unit>
-    <unit id="K4D568R" name="caption.view_edit_templates">
-      <segment>
-        <source>caption.view_edit_templates</source>
-        <target>Ver y editar plantillas</target>
-      </segment>
-    </unit>
-    <unit id="TtmWqX3" name="action.view">
-      <segment>
-        <source>action.view</source>
-        <target>Ver sitio web</target>
-      </segment>
-    </unit>
-    <unit id="wGlnx8X" name="general.phrase.search">
-      <segment>
-        <source>general.phrase.search</source>
-        <target>Buscar</target>
-      </segment>
-    </unit>
-    <unit id="O_m7mx1" name="listing.placeholder_search">
-      <segment>
-        <source>listing.placeholder_search</source>
-        <target>Buscar por palabra clave...</target>
-      </segment>
-    </unit>
-    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment>
-        <source>admin_sidebar_toggler.toggle</source>
-        <target>Menú</target>
-      </segment>
-    </unit>
-    <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <segment>
-        <source>admin_sidebar.toggler</source>
-        <target>Alternar el ancho de la barra lateral</target>
-      </segment>
-    </unit>
-    <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment>
-        <source>listing_filter.button_compact</source>
-        <target>Ampliado</target>
-      </segment>
-    </unit>
-    <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment>
-        <source>listing_filter.button_expanded</source>
-        <target>Reducido</target>
-      </segment>
-    </unit>
-    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <segment>
-        <source>listing_table.actions.view_on_site</source>
-        <target>Ver en sitio web</target>
-      </segment>
-    </unit>
-    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment>
-        <source>listing_table.actions.status_to_publish</source>
-        <target>Cambiar estado a 'publicado'</target>
-      </segment>
-    </unit>
-    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment>
-        <source>listing_table.actions.status_to_held</source>
-        <target>Cambiar estado a 'pendiente'</target>
-      </segment>
-    </unit>
-    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment>
-        <source>listing_table.actions.status_to_draft</source>
-        <target>Cambiar estado a 'borrador'</target>
-      </segment>
-    </unit>
-    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment>
-        <source>listing_table.actions.duplicate</source>
-        <target>Duplicar</target>
-      </segment>
-    </unit>
-    <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <segment>
-        <source>listing_table.actions.delete</source>
-        <target>Eliminar</target>
-      </segment>
-    </unit>
-    <unit id="5zbX1vo" name="listing_table.actions.slug">
-      <segment>
-        <source>listing_table.actions.slug</source>
-        <target>Slug</target>
-      </segment>
-    </unit>
-    <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <segment>
-        <source>listing_table.actions.created_on</source>
-        <target>Fecha de creación</target>
-      </segment>
-    </unit>
-    <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <segment>
-        <source>listing_table.actions.published_on</source>
-        <target>Fecha de publicación</target>
-      </segment>
-    </unit>
-    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment>
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Fecha de modificación</target>
-      </segment>
-    </unit>
-    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <segment>
-        <source>listing_table.actions.button_edit</source>
-        <target>Editar</target>
-      </segment>
-    </unit>
-    <unit id="AMxTho9" name="pager.previous">
-      <segment>
-        <source>pager.previous</source>
-        <target>Anterior</target>
-      </segment>
-    </unit>
-    <unit id="L_YQKUn" name="pager.next">
-      <segment>
-        <source>pager.next</source>
-        <target>Siguiente</target>
-      </segment>
-    </unit>
-    <unit id="dd5MzCM" name="caption.translations">
-      <segment>
-        <source>caption.translations</source>
-        <target>Traducciones/ Etiquetas</target>
-      </segment>
-    </unit>
-    <unit id="7aLIA3c" name="caption.dashboard">
-      <segment>
-        <source>caption.dashboard</source>
-        <target>Bolt Dashboard</target>
-      </segment>
-    </unit>
-    <unit id="JEnqOi." name="title.primary_actions">
-      <segment>
-        <source>title.primary_actions</source>
-        <target>Acciones principales</target>
-      </segment>
-    </unit>
-    <unit id="HLtdhYw" name="action.save">
-      <segment>
-        <source>action.save</source>
-        <target>Guardar</target>
-      </segment>
-    </unit>
-    <unit id="dQIY7_J" name="action.preview">
-      <segment>
-        <source>action.preview</source>
-        <target>Vista previa</target>
-      </segment>
-    </unit>
-    <unit id=".I3mIHo" name="label.current_status">
-      <segment>
-        <source>label.current_status</source>
-        <target>Estado actual</target>
-      </segment>
-    </unit>
-    <unit id="utGAKaQ" name="status.published">
-      <segment>
-        <source>status.published</source>
-        <target>Publicado</target>
-      </segment>
-    </unit>
-    <unit id="eVkSIKu" name="field.modifiedAt">
-      <segment>
-        <source>field.modifiedAt</source>
-        <target>Fecha de modificación</target>
-      </segment>
-    </unit>
-    <unit id="n.jOrkg" name="caption.untitled_contenttype">
-      <segment>
-        <source>caption.untitled_contenttype</source>
-        <target>%contenttype% sin título</target>
-      </segment>
-    </unit>
-    <unit id="ok6YulQ" name="action.view_saved">
-      <segment>
-        <source>action.view_saved</source>
-        <target>Ver versión guardada</target>
-      </segment>
-    </unit>
-    <unit id="6Gw1lsE" name="action.confirm_delete">
-      <segment>
-        <source>action.confirm_delete</source>
-        <target>¿Está seguro de que desea eliminar este contenido?</target>
-      </segment>
-    </unit>
-    <unit id="hTKWQ6g" name="action.delete">
-      <segment>
-        <source>action.delete</source>
-        <target>Eliminar</target>
-      </segment>
-    </unit>
-    <unit id="8zEzq8N" name="field.current_locale">
-      <segment>
-        <source>field.current_locale</source>
-        <target>Idioma seleccionado</target>
-      </segment>
-    </unit>
-    <unit id="ahZvOJz" name="field.switch_to_locale">
-      <segment>
-        <source>field.switch_to_locale</source>
-        <target>Cambiar idioma</target>
-      </segment>
-    </unit>
-    <unit id="ypPzS03" name="localeswitcher.button_info">
-      <segment>
-        <source>localeswitcher.button_info</source>
-        <target>Ver información de localización de idiomas</target>
-      </segment>
-    </unit>
-    <unit id="7616Os4" name="title.options">
-      <segment>
-        <source>title.options</source>
-        <target>Opciones</target>
-      </segment>
-    </unit>
-    <unit id="FuCyk5C" name="field.status">
-      <segment>
-        <source>field.status</source>
-        <target>Estado</target>
-      </segment>
-    </unit>
-    <unit id="oxqDDuK" name="status.held">
-      <segment>
-        <source>status.held</source>
-        <target>Pendiente</target>
-      </segment>
-    </unit>
-    <unit id="h7dP3WY" name="status.timed">
-      <segment>
-        <source>status.timed</source>
-        <target>Programado</target>
-      </segment>
-    </unit>
-    <unit id="HJbHjee" name="status.draft">
-      <segment>
-        <source>status.draft</source>
-        <target>Borrador</target>
-      </segment>
-    </unit>
-    <unit id="3gdi1dy" name="field.publishedAt">
-      <segment>
-        <source>field.publishedAt</source>
-        <target>Fecha de publicación</target>
-      </segment>
-    </unit>
-    <unit id="eN7IfEL" name="field.depublishedAt">
-      <segment>
-        <source>field.depublishedAt</source>
-        <target>Fecha de retirada de la publicación </target>
-      </segment>
-    </unit>
-    <unit id="aQX4Emy" name="field.author">
-      <segment>
-        <source>field.author</source>
-        <target>Autor</target>
-      </segment>
-    </unit>
-    <unit id="O9wtVOp" name="field.createdAt">
-      <segment>
-        <source>field.createdAt</source>
-        <target>Fecha de creación</target>
-      </segment>
-    </unit>
-    <unit id="SNELzJ2" name="field.id">
-      <segment>
-        <source>field.id</source>
-        <target>ID</target>
-      </segment>
-    </unit>
-    <unit id="HK7XTUX" name="caption.edit">
-      <segment>
-        <source>caption.edit</source>
-        <target>Editar</target>
-      </segment>
-    </unit>
-    <unit id="hAysbHB" name="label.translatable">
-      <segment>
-        <source>label.translatable</source>
-        <target>Este campo es traducible</target>
-      </segment>
-    </unit>
-    <unit id="noOf4ML" name="upload.max_size">
-      <segment>
-        <source>upload.max_size</source>
-        <target>Tamaño máximo de subida</target>
-      </segment>
-    </unit>
-    <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <segment>
-        <source>upload.allow_file_types</source>
-        <target>Tipos de archivos permitidos para subir</target>
-      </segment>
-    </unit>
-    <unit id="vptPhch" name="image.button_upload">
-      <segment>
-        <source>image.button_upload</source>
-        <target>Subir</target>
-      </segment>
-    </unit>
-    <unit id="FqVh1Hv" name="image.button_remove">
-      <segment>
-        <source>image.button_remove</source>
-        <target>Eliminar</target>
-      </segment>
-    </unit>
-    <unit id="vIVO1lU" name="image.button_from_library">
-      <segment>
-        <source>image.button_from_library</source>
-        <target>De la librería</target>
-      </segment>
-    </unit>
-    <unit id="oOuVKRv" name="image.placeholder_filename">
-      <segment>
-        <source>image.placeholder_filename</source>
-        <target>Nombre de archivo (cargar un archivo nuevo o seleccionar uno existente) </target>
-      </segment>
-    </unit>
-    <unit id="BWubOnS" name="image.placeholder_alt_text">
-      <segment>
-        <source>image.placeholder_alt_text</source>
-        <target>Atributo Alt</target>
-      </segment>
-    </unit>
-    <unit id="eHV6ZJB" name="image.button_edit_attributes">
-      <segment>
-        <source>image.button_edit_attributes</source>
-        <target>Editar atributos</target>
-      </segment>
-    </unit>
-    <unit id="XQ2U6fN" name="slug.button_unlocked">
-      <segment>
-        <source>slug.button_unlocked</source>
-        <target>Desbloqueado</target>
-      </segment>
-    </unit>
-    <unit id="kaK5Wdr" name="slug.button_locked">
-      <segment>
-        <source>slug.button_locked</source>
-        <target>Bloqueado</target>
-      </segment>
-    </unit>
-    <unit id="qcDEz5O" name="slug.button_edit">
-      <segment>
-        <source>slug.button_edit</source>
-        <target>Editar</target>
-      </segment>
-    </unit>
-    <unit id="raO5QSf" name="slug.generate_from">
-      <segment>
-        <source>slug.generate_from</source>
-        <target>Generar a partir de</target>
-      </segment>
-    </unit>
-    <unit id="BINgtmK" name="editor_date.toggle">
-      <segment>
-        <source>editor_date.toggle</source>
-        <target>Alternar</target>
-      </segment>
-    </unit>
-    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <segment>
-        <source>listing_select_box.card_header.selected</source>
-        <target>Seleccionado</target>
-      </segment>
-    </unit>
-    <unit id="WeJxw6Z" name="action.update_all">
-      <segment>
-        <source>action.update_all</source>
-        <target>Aplicar a todo</target>
-      </segment>
-    </unit>
-    <unit id="vJwSCBO" name="title.contentlisting">
-      <segment>
-        <source>title.contentlisting</source>
-        <target>Listado de contenido</target>
-      </segment>
-    </unit>
-    <unit id="wQ0WYAT" name="listing.title_sortby">
-      <segment>
-        <source>listing.title_sortby</source>
-        <target>Ordenar por</target>
-      </segment>
-    </unit>
-    <unit id="IWbf2by" name="listing.title_filterby">
-      <segment>
-        <source>listing.title_filterby</source>
-        <target>Buscar / Filtrar por</target>
-      </segment>
-    </unit>
-    <unit id="hp554Ds" name="listing.option_select_sortby">
-      <segment>
-        <source>listing.option_select_sortby</source>
-        <target>Seleccione el campo de ordenación...</target>
-      </segment>
-    </unit>
-    <unit id="pn22p7q" name="listing.placeholder_filter">
-      <segment>
-        <source>listing.placeholder_filter</source>
-        <target>Palabra clave para filtrar...</target>
-      </segment>
-    </unit>
-    <unit id="ni4zApC" name="listing.button_filter">
-      <segment>
-        <source>listing.button_filter</source>
-        <target>Filtrar</target>
-      </segment>
-    </unit>
-    <unit id="Hlf9c1s" name="listing.title_overview">
-      <segment>
-        <source>listing.title_overview</source>
-        <target>Vista general</target>
-      </segment>
-    </unit>
-    <unit id="n.3JZvX" name="title.contentType">
-      <segment>
-        <source>title.contentType</source>
-        <target>Tipo de Contenido</target>
-      </segment>
-    </unit>
-    <unit id="ufFUPp7" name="view_locales.badge_missing">
-      <segment>
-        <source>view_locales.badge_missing</source>
-        <target>Falta</target>
-      </segment>
-    </unit>
-    <unit id="JTRCo_U" name="view_locales.badge_ok">
-      <segment>
-        <source>view_locales.badge_ok</source>
-        <target>Bien</target>
-      </segment>
-    </unit>
-    <unit id="37kJiIe" name="view_locales.badge_default">
-      <segment>
-        <source>view_locales.badge_default</source>
-        <target>Predeterminado</target>
-      </segment>
-    </unit>
-    <unit id="UNBaDz." name="general.phrase.edit">
-      <segment>
-        <source>general.phrase.edit</source>
-        <target>Editar</target>
-      </segment>
-    </unit>
-    <unit id="kHeY93_" name="editor_embed.content_url">
-      <segment>
-        <source>editor_embed.content_url</source>
-        <target>URL del contenido a insertar</target>
-      </segment>
-    </unit>
-    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-      <segment>
-        <source>editor_embed.placeholder_content_url</source>
-        <target>URL del contenido en Facebook, Twitter, Soundcloud, Youtube, Vimeo… </target>
-      </segment>
-    </unit>
-    <unit id="1.Eb1GS" name="editor_embed.label_height">
-      <segment>
-        <source>editor_embed.label_height</source>
-        <target>Alto</target>
-      </segment>
-    </unit>
-    <unit id="eWLSFJs" name="editor_embed.label_pixel">
-      <segment>
-        <source>editor_embed.label_pixel</source>
-        <target>píxeles</target>
-      </segment>
-    </unit>
-    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
-      <segment>
-        <source>editor_embed.label_matched_embed</source>
-        <target>Contenido encontrado</target>
-      </segment>
-    </unit>
-    <unit id="zATju4V" name="editor_embed.label_preview">
-      <segment>
-        <source>editor_embed.label_preview</source>
-        <target>Vista previa</target>
-      </segment>
-    </unit>
-    <unit id="9SQ0oaR" name="editor_embed.label_size">
-      <segment>
-        <source>editor_embed.label_size</source>
-        <target>Dimensiones</target>
-      </segment>
-    </unit>
-    <unit id="7aSD0Qr" name="image.button_up">
-      <segment>
-        <source>image.button_up</source>
-        <target>Arriba</target>
-      </segment>
-    </unit>
-    <unit id="WihD8Y5" name="image.button_down">
-      <segment>
-        <source>image.button_down</source>
-        <target>Abajo</target>
-      </segment>
-    </unit>
-    <unit id="Oj2UZ5J" name="image.add_new_image">
-      <segment>
-        <source>image.add_new_image</source>
-        <target>Añadir nueva imagen </target>
-      </segment>
-    </unit>
-    <unit id="VPV0lFM" name="image.placeholder_title">
-      <segment>
-        <source>image.placeholder_title</source>
-        <target>Atributo title</target>
-      </segment>
-    </unit>
-    <unit id="8Q4FxVw" name="file.add_new_file">
-      <segment>
-        <source>file.add_new_file</source>
-        <target>Añadir nuevo archivo</target>
-      </segment>
-    </unit>
-    <unit id="0C9.Vmh" name="collection.add_item">
-      <segment>
-        <source>collection.add_item</source>
-        <target>Añadir elemento</target>
-      </segment>
-    </unit>
-    <unit id="ApPu4P_" name="collection.move_item_up">
-      <segment>
-        <source>collection.move_item_up</source>
-        <target>Subir</target>
-      </segment>
-    </unit>
-    <unit id="KzBtfHi" name="collection.move_item_down">
-      <segment>
-        <source>collection.move_item_down</source>
-        <target>Bajar</target>
-      </segment>
-    </unit>
-    <unit id=".t1ICS7" name="collection.remove_item">
-      <segment>
-        <source>collection.remove_item</source>
-        <target>Eliminar</target>
-      </segment>
-    </unit>
-    <unit id="JpJFIFq" name="collection.confirm_delete">
-      <segment>
-        <source>collection.confirm_delete</source>
-        <target>¿Está seguro de que desea eliminar este elemento de la Colección? </target>
-      </segment>
-    </unit>
-    <unit id="Iy4HXCU" name="controller.user.title">
-      <segment>
-        <source>controller.user.title</source>
-        <target>Usuarios y permisos</target>
-      </segment>
-    </unit>
-    <unit id="7cXqH5s" name="listing.title_display_name">
-      <segment>
-        <source>listing.title_display_name</source>
-        <target>Nombre a mostrar</target>
-      </segment>
-    </unit>
-    <unit id="Ay7xZ2h" name="listing.title_username">
-      <segment>
-        <source>listing.title_username</source>
-        <target>Nombre de usuario</target>
-      </segment>
-    </unit>
-    <unit id="RN1tdtJ" name="listing.title_email">
-      <segment>
-        <source>listing.title_email</source>
-        <target>Correo electrónico</target>
-      </segment>
-    </unit>
-    <unit id="HBwIQ9b" name="controller.user.subtitle">
-      <segment>
-        <source>controller.user.subtitle</source>
-        <target>Gestionar usuarios y permisos</target>
-      </segment>
-    </unit>
-    <unit id="0pjZ.GV" name="listing.title_roles">
-      <segment>
-        <source>listing.title_roles</source>
-        <target>Roles</target>
-      </segment>
-    </unit>
-    <unit id="hXEFV1n" name="listing.title_last_seen">
-      <segment>
-        <source>listing.title_last_seen</source>
-        <target>Sesión creada</target>
-      </segment>
-    </unit>
-    <unit id="pn7kE17" name="listing.title_last_ip">
-      <segment>
-        <source>listing.title_last_ip</source>
-        <target>Última dirección IP</target>
-      </segment>
-    </unit>
-    <unit id="GZ65uOC" name="listing.title_actions">
-      <segment>
-        <source>listing.title_actions</source>
-        <target>Acciones</target>
-      </segment>
-    </unit>
-    <unit id="ovKkXwU" name="action.edit">
-      <segment>
-        <source>action.edit</source>
-        <target>Editar</target>
-      </segment>
-    </unit>
-    <unit id="ryXZRAu" name="action.disable">
-      <segment>
-        <source>action.disable</source>
-        <target>Desactivar</target>
-      </segment>
-    </unit>
-    <unit id="3zlZmRK" name="action.add_user">
-      <segment>
-        <source>action.add_user</source>
-        <target>Añadir usuario</target>
-      </segment>
-    </unit>
-    <unit id="Npkio79" name="listing.title_session_expires">
-      <segment>
-        <source>listing.title_session_expires</source>
-        <target>Sesión expira</target>
-      </segment>
-    </unit>
-    <unit id="mmUDcto" name="listing.title_ip_address">
-      <segment>
-        <source>listing.title_ip_address</source>
-        <target>Dirección IP</target>
-      </segment>
-    </unit>
-    <unit id="x9qAwrz" name="listing.title_browser">
-      <segment>
-        <source>listing.title_browser</source>
-        <target>Navegador / Sistema Operativo</target>
-      </segment>
-    </unit>
-    <unit id="FSroufa" name="caption.path">
-      <segment>
-        <source>caption.path</source>
-        <target>Ruta</target>
-      </segment>
-    </unit>
-    <unit id="P1FHg3Q" name="caption.edit_file">
-      <segment>
-        <source>caption.edit_file</source>
-        <target>Editar archivo</target>
-      </segment>
-    </unit>
-    <unit id="LaDIuZA" name="caption.meta_information">
-      <segment>
-        <source>caption.meta_information</source>
-        <target>Información de metadatos</target>
-      </segment>
-    </unit>
-    <unit id="73A2bWM" name="finder.label_view">
-      <segment>
-        <source>finder.label_view</source>
-        <target>Tipo de vista</target>
-      </segment>
-    </unit>
-    <unit id="m3tNvJb" name="finder.button_list">
-      <segment>
-        <source>finder.button_list</source>
-        <target>Lista</target>
-      </segment>
-    </unit>
-    <unit id="tRLgeoX" name="finder.button_cards">
-      <segment>
-        <source>finder.button_cards</source>
-        <target>Tarjetas</target>
-      </segment>
-    </unit>
-    <unit id="QZYjRy0" name="caption.file_uploader">
-      <segment>
-        <source>caption.file_uploader</source>
-        <target>Cargador de archivos</target>
-      </segment>
-    </unit>
-    <unit id="283aB_E" name="caption.file_upload.upload_text">
-      <segment>
-        <source>caption.file_upload.upload_text</source>
-        <target>Arrastrar y soltar archivos para subir</target>
-      </segment>
-    </unit>
-    <unit id="v6cfPyt" name="quickselect.title_select">
-      <segment>
-        <source>quickselect.title_select</source>
-        <target>Seleccione un archivo</target>
-      </segment>
-    </unit>
-    <unit id="C15MbYY" name="form.quick_select_file">
-      <segment>
-        <source>form.quick_select_file</source>
-        <target>Seleccione rápidamente un archivo para editar... </target>
-      </segment>
-    </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Carpetas</target>
-      </segment>
-    </unit>
-    <unit id="KHvGNGW" name="directoryname">
-      <segment>
-        <source>directoryname</source>
-        <target>Directorio</target>
-      </segment>
-    </unit>
-    <unit id="Kw3N1AA" name="actions">
-      <segment>
-        <source>actions</source>
-        <target>Acciones</target>
-      </segment>
-    </unit>
-    <unit id="_XSgfqS" name="filename">
-      <segment>
-        <source>filename</source>
-        <target>Nombre del archivo</target>
-      </segment>
-    </unit>
-    <unit id="gPYflhh" name="thumbnail">
-      <segment>
-        <source>thumbnail</source>
-        <target>Miniatura</target>
-      </segment>
-    </unit>
-    <unit id="zNy_hG8" name="size">
-      <segment>
-        <source>size</source>
-        <target>Tamaño</target>
-      </segment>
-    </unit>
-    <unit id="DodjLNR" name="date">
-      <segment>
-        <source>date</source>
-        <target>Fecha de creación</target>
-      </segment>
-    </unit>
-    <unit id="QQvRJe." name="files_cards.button_toggle">
-      <segment>
-        <source>files_cards.button_toggle</source>
-        <target>Alternar lista desplegable</target>
-      </segment>
-    </unit>
-    <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <segment>
-        <source>files_cards.action_edit_file</source>
-        <target>Editar archivo</target>
-      </segment>
-    </unit>
-    <unit id="H1pgP94" name="files_cards.action_view_original">
-      <segment>
-        <source>files_cards.action_view_original</source>
-        <target>Ver original</target>
-      </segment>
-    </unit>
-    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <segment>
-        <source>files_cards.action_duplicate</source>
-        <target>Duplicar</target>
-      </segment>
-    </unit>
-    <unit id="wHPoBzP" name="file.delete_confirm">
-      <segment>
-        <source>file.delete_confirm</source>
-        <target>¿Está seguro de que desea eliminar este archivo?</target>
-      </segment>
-    </unit>
-    <unit id="JjU6ZQP" name="files_cards.action_delete">
-      <segment>
-        <source>files_cards.action_delete</source>
-        <target>Eliminar</target>
-      </segment>
-    </unit>
-    <unit id="3jdNwuk" name="files_cards.label_filename">
-      <segment>
-        <source>files_cards.label_filename</source>
-        <target>Nombre del archivo</target>
-      </segment>
-    </unit>
-    <unit id="eQBhceV" name="files_cards.label_filesize">
-      <segment>
-        <source>files_cards.label_filesize</source>
-        <target>Tamaño del archivo</target>
-      </segment>
-    </unit>
-    <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <segment>
-        <source>files_cards.label_created_on</source>
-        <target>Fecha de creación</target>
-      </segment>
-    </unit>
-    <unit id="nrWBJNm" name="extensions.title_desc">
-      <segment>
-        <source>extensions.title_desc</source>
-        <target>Descripción</target>
-      </segment>
-    </unit>
-    <unit id="7raDJAR" name="extensions.title_author">
-      <segment>
-        <source>extensions.title_author</source>
-        <target>Autor</target>
-      </segment>
-    </unit>
-    <unit id="UP8pNGy" name="extensions.title_package">
-      <segment>
-        <source>extensions.title_package</source>
-        <target>Paquete / Nombre de la Clase</target>
-      </segment>
-    </unit>
-    <unit id="hgNZLwW" name="extensions.title_configuration">
-      <segment>
-        <source>extensions.title_configuration</source>
-        <target>Archivo de configuración:</target>
-      </segment>
-    </unit>
-    <unit id="QFQ1uTC" name="extensions.title_version">
-      <segment>
-        <source>extensions.title_version</source>
-        <target>Version</target>
-      </segment>
-    </unit>
-    <unit id="BFARQEU" name="extensions.button_detailed_view">
-      <segment>
-        <source>extensions.button_detailed_view</source>
-        <target>Vista detallada</target>
-      </segment>
-    </unit>
-    <unit id="mjhFljb" name="extensions.button_configuration">
-      <segment>
-        <source>extensions.button_configuration</source>
-        <target>Configuración</target>
-      </segment>
-    </unit>
-    <unit id="r3ryNTG" name="extensions.button_source">
-      <segment>
-        <source>extensions.button_source</source>
-        <target>Origen</target>
-      </segment>
-    </unit>
-    <unit id="qc3rFkZ" name="extensions.button_remove">
-      <segment>
-        <source>extensions.button_remove</source>
-        <target>Eliminar Extensión</target>
-      </segment>
-    </unit>
-    <unit id="SLZyVzU" name="extensions.button_disable">
-      <segment>
-        <source>extensions.button_disable</source>
-        <target>Desactivar Extensión</target>
-      </segment>
-    </unit>
-    <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment>
-        <source>extensions.message_not_implemented</source>
-        <target>Aún no se ha implementado. ¡Lo siento! </target>
-      </segment>
-    </unit>
-    <unit id="txRonia" name="label.id">
-      <segment>
-        <source>label.id</source>
-        <target>ID</target>
-      </segment>
-    </unit>
-    <unit id="51OQi14" name="label.message">
-      <segment>
-        <source>label.message</source>
-        <target>Mensaje</target>
-      </segment>
-    </unit>
-    <unit id="S0f6iTL" name="label.timestamp">
-      <segment>
-        <source>label.timestamp</source>
-        <target>Marca temporal</target>
-      </segment>
-    </unit>
-    <unit id="IwLLxxx" name="label.level">
-      <segment>
-        <source>label.level</source>
-        <target>Nivel</target>
-      </segment>
-    </unit>
-    <unit id="FlGE3qB" name="label.request">
-      <segment>
-        <source>label.request</source>
-        <target>Petición</target>
-      </segment>
-    </unit>
-    <unit id="l71Tprl" name="label.trace">
-      <segment>
-        <source>label.trace</source>
-        <target>Rastro</target>
-      </segment>
-    </unit>
-    <unit id="29ZEo1r" name="label.context">
-      <segment>
-        <source>label.context</source>
-        <target>Contexto</target>
-      </segment>
-    </unit>
-    <unit id="O2X4xZH" name="label.user">
-      <segment>
-        <source>label.user</source>
-        <target>Usuario</target>
-      </segment>
-    </unit>
-    <unit id="z2AgHGp" name="flash_messages.notification">
-      <segment>
-        <source>flash_messages.notification</source>
-        <target>Notificación</target>
-      </segment>
-    </unit>
-    <unit id="2MMvCKK" name="label.cache_cleared">
-      <segment>
-        <source>label.cache_cleared</source>
-        <target>¡Caché borrada correctamente! </target>
-      </segment>
-    </unit>
-    <unit id="ruQIhH0" name="success">
-      <segment>
-        <source>success</source>
-        <target>Con éxito</target>
-      </segment>
-    </unit>
-    <unit id="cH6rDCP" name="Button">
-      <segment>
-        <source>Button</source>
-        <target>Botón</target>
-      </segment>
-    </unit>
-    <unit id="1LzKCXS" name="&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.">
-      <segment>
-        <source>&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.</source>
-        <target><![CDATA[<strong>¡Bien hecho!</strong>  Ha leído correctamente este importante mensaje de alerta.]]></target>
-      </segment>
-    </unit>
-    <unit id="Bicbr0l" name="info">
-      <segment>
-        <source>info</source>
-        <target>Información</target>
-      </segment>
-    </unit>
-    <unit id="S9k1S7Z" name="warning">
-      <segment>
-        <source>warning</source>
-        <target>Advertencia</target>
-      </segment>
-    </unit>
-    <unit id="Ej.WZqo" name="danger">
-      <segment>
-        <source>danger</source>
-        <target>Peligro</target>
-      </segment>
-    </unit>
-    <unit id="RaGzSx5" name="57d589f">
-      <segment>
-        <source>57d589f</source>
-        <target><![CDATA[<strong>¡Atención!</strong> Esta alerta necesita su atención, pero no es muy importante.]]></target>
-      </segment>
-    </unit>
-    <unit id="JYILFeM" name="&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.">
-      <segment>
-        <source>&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.</source>
-        <target><![CDATA[<strong>¡Atención!</strong> Compruebe que todo está en orden, algo ha podido ir mal.]]></target>
-      </segment>
-    </unit>
-    <unit id="a2vzLi7" name="action.do_something">
-      <segment>
-        <source>action.do_something</source>
-        <target>Haz algo</target>
-      </segment>
-    </unit>
-    <unit id="OGd6iOm" name="&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.">
-      <segment>
-        <source>&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.</source>
-        <target><![CDATA[<strong>¡Vaya!</strong> Haga algunos cambios e inténtelo de nuevo.]]></target>
-      </segment>
-    </unit>
-    <unit id="xN1kSQQ" name="caption.bolt_payoff">
-      <segment>
-        <source>caption.bolt_payoff</source>
-        <target>CMS sofisticado, ligero y simple</target>
-      </segment>
-    </unit>
-    <unit id="QVRwwK4" name="about.system_info">
-      <segment>
-        <source>about.system_info</source>
-        <target>Información del sistema</target>
-      </segment>
-    </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
       <segment>
         <source>about.bolt_on_github</source>
         <target>Bolt en Github</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
       <segment>
         <source>about.used_libraries</source>
         <target>Librerías / Componentes utilizados</target>
       </segment>
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>A continuación se muestran las bibliotecas de terceros que utiliza Bolt.</target>
       </segment>
     </unit>
-    <unit id="rCKtTo5" name="caption.redirection_page">
-      <segment>
-        <source>caption.redirection_page</source>
-        <target>Página de redirección</target>
-      </segment>
-    </unit>
-    <unit id="EdCfIKX" name="files_cards.label_dimensions">
-      <segment>
-        <source>files_cards.label_dimensions</source>
-        <target>Dimensiones</target>
-      </segment>
-    </unit>
-    <unit id="Y90_Pn1" name="files_cards.label_title">
-      <segment>
-        <source>files_cards.label_title</source>
-        <target>Título</target>
-      </segment>
-    </unit>
-    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-      <segment>
-        <source>files_cards.action_edit_image_info</source>
-        <target>Editar la información de la imagen</target>
-      </segment>
-    </unit>
-    <unit id=".fL0AbE" name="files_list.remark">
-      <segment>
-        <source>files_list.remark</source>
-        <target>No hay archivos presentes en esta carpeta. Seleccione una carpeta a la que navegar.</target>
-      </segment>
-    </unit>
-    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
-      <segment>
-        <source>label.predominant_colors__in_image</source>
-        <target>Colores predominantes en la imagen</target>
-      </segment>
-    </unit>
-    <unit id="vlRe8Tx" name="field.width">
-      <segment>
-        <source>field.width</source>
-        <target>Ancho</target>
-      </segment>
-    </unit>
-    <unit id="CZbXbM_" name="field.height">
-      <segment>
-        <source>field.height</source>
-        <target>Alto</target>
-      </segment>
-    </unit>
-    <unit id="Sz_u.OS" name="field.filesize">
-      <segment>
-        <source>field.filesize</source>
-        <target>Tamaño del archivo</target>
-      </segment>
-    </unit>
-    <unit id="TtIlBDd" name="caption.edit_image">
-      <segment>
-        <source>caption.edit_image</source>
-        <target>Editar imagen</target>
-      </segment>
-    </unit>
-    <unit id="y5otxEK" name="caption.filename">
-      <segment>
-        <source>caption.filename</source>
-        <target>Nombre del archivo</target>
-      </segment>
-    </unit>
-    <unit id="VKhfRZB" name="field.title">
-      <segment>
-        <source>field.title</source>
-        <target>Título</target>
-      </segment>
-    </unit>
-    <unit id="7_wwX8J" name="field.description">
-      <segment>
-        <source>field.description</source>
-        <target>Descripción</target>
-      </segment>
-    </unit>
-    <unit id="hjDmcPC" name="field.copyright">
-      <segment>
-        <source>field.copyright</source>
-        <target>Derechos de autor</target>
-      </segment>
-    </unit>
-    <unit id="v0sitU8" name="field.originalFilename">
-      <segment>
-        <source>field.originalFilename</source>
-        <target>Nombre original del archivo</target>
-      </segment>
-    </unit>
-    <unit id="fLOd6Zd" name="field.cropX">
-      <segment>
-        <source>field.cropX</source>
-        <target>Recortar ancho de la imagen</target>
-      </segment>
-    </unit>
-    <unit id="Sd_AbmV" name="field.cropXPostfix">
-      <segment>
-        <source>field.cropXPostfix</source>
-        <target>Posición de recorte en el eje horizontal, rango 0-100</target>
-      </segment>
-    </unit>
-    <unit id="hi98HIj" name="field.cropY">
-      <segment>
-        <source>field.cropY</source>
-        <target>Recortar alto de la imagen</target>
-      </segment>
-    </unit>
-    <unit id="BQBmQHT" name="field.cropYPostfix">
-      <segment>
-        <source>field.cropYPostfix</source>
-        <target>Posición de recorte en el eje vertical, rango 0-100</target>
-      </segment>
-    </unit>
-    <unit id="PHOpD5y" name="field.cropZoom">
-      <segment>
-        <source>field.cropZoom</source>
-        <target>Enfoque para el recorte</target>
-      </segment>
-    </unit>
-    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
-      <segment>
-        <source>field.cropZoomPostfix</source>
-        <target>Nivel de enfoque para el recorte, rango 1-10.</target>
-      </segment>
-    </unit>
-    <unit id="IB0mNQh" name="content.created_successfully">
-      <segment>
-        <source>content.created_successfully</source>
-        <target>Contenido multimedia creado correctamente</target>
-      </segment>
-    </unit>
-    <unit id="Dgtkgju" name="title.edit_user_profile">
-      <segment>
-        <source>title.edit_user_profile</source>
-        <target>title.edit_user_profile</target>
-      </segment>
-    </unit>
-    <unit id="LDhDPrF" name="label.username">
-      <segment>
-        <source>label.username</source>
-        <target>Nombre de usuario</target>
-      </segment>
-    </unit>
-    <unit id="SeTqePC" name="label.display_name">
-      <segment>
-        <source>label.display_name</source>
-        <target>Nombre a mostrar</target>
-      </segment>
-    </unit>
-    <unit id="9pvowqn" name="label.password">
-      <segment>
-        <source>label.password</source>
-        <target>Contraseña</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
       <segment>
         <source>label.email</source>
         <target>Correo electrónico</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Acerca de</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
+        <source>user.updated_successfully</source>
+        <target>Actualizado correctamente</target>
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
+        <source>content.updated_successfully</source>
+        <target>Contenido actualizado correctamente</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Contenido multimedia creado correctamente</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>No se pudo escribir el elemento multimedia</target>
+      </segment>
+    </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>Región</target>
       </segment>
     </unit>
-    <unit id="7whLbH8" name="user.new_user">
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
-        <source>user.new_user</source>
-        <target>Usuario nuevo</target>
+        <source>The Default theme</source>
+        <target>El tema predeterminado</target>
       </segment>
     </unit>
-    <unit id="iD6CNOO" name="label.roles">
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
-        <source>label.roles</source>
-        <target>Roles</target>
+        <source>The Default Dark theme</source>
+        <target>El tema oscuro predeterminado</target>
       </segment>
     </unit>
-    <unit id="hiE9jap" name="password.suggested">
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
-        <source>password.suggested</source>
-        <target><![CDATA[Contraseña segura sugerida <code>%password%</code> ]]></target>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Se parece un poco a ese otro CMS</target>
       </segment>
     </unit>
-    <unit id="80JoLd0" name="title.login">
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
-        <source>title.login</source>
-        <target>Inicio de sesión</target>
+        <source>caption.dashboard</source>
+        <target>Panel de Bolt</target>
       </segment>
     </unit>
-    <unit id="beqzCkE" name="login.header_login">
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
-        <source>login.header_login</source>
-        <target>Bolt » Inicio de sesión</target>
+        <source>caption.clear_cache</source>
+        <target>Borrar caché</target>
       </segment>
     </unit>
-    <unit id="RMPnq6o" name="label.username_or_email">
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
-        <source>label.username_or_email</source>
-        <target>Usuario o correo electrónico</target>
+        <source>caption.menu_setup</source>
+        <target>Configurar menú</target>
       </segment>
     </unit>
-    <unit id="z_tOHwq" name="placeholder.username_or_email">
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
-        <source>placeholder.username_or_email</source>
-        <target>Usuario o correo electrónico de su cuenta</target>
+        <source>caption.taxonomies</source>
+        <target>Taxonomías</target>
       </segment>
     </unit>
-    <unit id="xgYhRkc" name="placeholder.password">
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
-        <source>placeholder.password</source>
-        <target>Introduzca contraseña de su cuenta</target>
+        <source>caption.contenttypes</source>
+        <target>Tipos de Contenido</target>
       </segment>
     </unit>
-    <unit id="gLN0C81" name="action.log_in">
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
-        <source>action.log_in</source>
-        <target>Iniciar sesión</target>
+        <source>caption.main_configuration</source>
+        <target>Configuración principal</target>
       </segment>
     </unit>
-    <unit id="IaF1MjB" name="label.rememberme">
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
-        <source>label.rememberme</source>
-        <target>Recordarme</target>
+        <source>caption.users_permissions</source>
+        <target>Usuarios y permisos</target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Configuración</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Opciones</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Contenido</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Gestión de archivos</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Extensiones</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target>Ver y editar plantillas</target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Archivos subidos</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Configurar enrutamiento</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Traducciones/ Etiquetas</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>Sobre Bolt</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target>CMS sofisticado, ligero y simple</target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>caption.file_uploader</source>
+        <target>Cargador de archivos</target>
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>caption.meta_information</source>
+        <target>Información de metadatos</target>
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
+        <source>date</source>
+        <target>Fecha de creación</target>
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>size</source>
+        <target>Tamaño</target>
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>thumbnail</source>
+        <target>Miniatura</target>
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
+        <source>filename</source>
+        <target>Nombre del archivo</target>
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>actions</source>
+        <target>Acciones</target>
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>directoryname</source>
+        <target>Directorio</target>
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>form.quick_select_file</source>
+        <target>Seleccione rápidamente un archivo para editar... </target>
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>caption.path</source>
+        <target>Ruta</target>
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>caption.filename</source>
+        <target>Nombre del archivo</target>
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>action.create_new</source>
+        <target>Crear Nuevo</target>
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Hola %name%</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Cerrar Sesión</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Editar Perfil</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>Cerrar</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>API</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Archivos de configuración</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Mantenimiento</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Editar archivo</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Idioma seleccionado</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Cambiar idioma</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Autor</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Desconocido</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Escrito por %name% el %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>Falta la página «Acerca de»</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Falta el bloque «Acerca de»</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>%contenttypes% recientes</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>…</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Buscar</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Resumen de %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>No se encontraron %contenttype% recientes</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Menú</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Buscar</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Enlace permanente</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>¡Caché borrada correctamente! </target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Demonstración</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Resultados de búsqueda para «%search%».</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>No se encontraron resultados de búsqueda para «%search%».</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Introduzca un término de búsqueda para mostrar resultados relevantes.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Leer más</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Este sitio web está <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>construido con Bolt</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Últimas noticias de Bolt</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Vista previa</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Ver versión guardada</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Nombre a mostrar</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Duplicar</target>
       </segment>
     </unit>
-    <unit id="SGlj7K2" name="view_locales.badge_empty">
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
-        <source>view_locales.badge_empty</source>
-        <target>Vacío</target>
+        <source>label.new_password</source>
+        <target>Nueva contraseña</target>
       </segment>
     </unit>
-    <unit id="8JeahIj" name="files_cards.message_no_files">
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
-        <source>files_cards.message_no_files</source>
-        <target>No hay archivos en esta carpeta. Seleccione una carpeta a la que navegar en la parte derecha.</target>
+        <source>editfile.updated_successfully</source>
+        <target>¡Archivo actualizado correctamente!</target>
       </segment>
     </unit>
-    <unit id="munFS0n" name="title.filtered_by">
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
-        <source>title.filtered_by</source>
-        <target><![CDATA[Todo el contenido, filtrado por <em>'%filter%'</em>.]]></target>
+        <source>action.add_user</source>
+        <target>Añadir usuario</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Con éxito</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>¡El perfil de usuario se ha actualizado!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Roles</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Usuario nuevo</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Ver sitio web</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Bloqueado</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Generar a partir de</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Subir</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>De la librería</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Ver en sitio web</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Cambiar estado a 'publicado'</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Cambiar estado a 'pendiente'</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Cambiar estado a 'borrador'</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Duplicar</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Eliminar</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Fecha de creación</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Fecha de publicación</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Fecha de modificación</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Seleccionado</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>URL del contenido a insertar</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL del contenido en Facebook, Twitter, Soundcloud, Youtube, Vimeo… </target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Alto</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>píxeles</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Contenido encontrado</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Vista previa</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Dimensiones</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Nombre de archivo (cargar un archivo nuevo o seleccionar uno existente) </target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Atributo Alt</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Atributo title</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Alternar el ancho de la barra lateral</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Alternar </span>menú]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Alternar</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Notificación</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Ver información de localización de idiomas</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Ordenar por</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Palabra clave para filtrar...</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filtrar</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Limpiar orden/filtro</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Predeterminado</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>Bien</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Falta</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Alternar lista desplegable</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Editar la información de la imagen</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Editar archivo</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Ver original</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Duplicar</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Eliminar</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Nombre del archivo</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Título</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Dimensiones</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Tamaño del archivo</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Fecha de creación</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>No hay archivos presentes en esta carpeta. Seleccione una carpeta a la que navegar.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Seleccione un archivo</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Lista</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Tarjetas</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Descripción</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Autor</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Paquete / Nombre de la Clase</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Versión:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>Este es un paquete local, instalado sin utilizar Composer</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Nombre de la Clase:</target>
       </segment>
     </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Configuración</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Origen</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Eliminar Extensión</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Desactivar Extensión</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Inicio de sesión</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Aún no se ha implementado. ¡Lo siento! </target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Vista general</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>No hay archivos en esta carpeta. Seleccione una carpeta a la que navegar en la parte derecha.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Ampliado</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Reducido</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Tipo de vista</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target>Usuarios y permisos</target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>Gestionar usuarios y permisos</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Nombre a mostrar</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Nombre de usuario</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>Correo electrónico</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Roles</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Sesión creada</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Última dirección IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Acciones</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Usuario desconocido</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Colores predominantes en la imagen</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Resumen de «%slug%»</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Contenido relacionado</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Buscar</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Nuevo %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>%contenttype% sin título</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Editar perfil de usuario</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Página de redirección</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Editar imagen</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Contraseña segura sugerida: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Recortar ancho de la imagen</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Posición de recorte en el eje horizontal, rango 0-100</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Posición de recorte en el eje vertical, rango 0-100</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Recortar alto de la imagen</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Enfoque para el recorte</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Nivel de enfoque para el recorte, rango 1-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Tipo de Contenido</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>No se encontraron resultados. Amplíe los criterios de filtrado o añada más contenido.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Seleccione el campo de ordenación...</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Acciones principales</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opciones</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Eliminar</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Activar</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Desactivar</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>Sesión expira</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>Dirección IP</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Navegador / Sistema Operativo</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Eliminar</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Editar atributos</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Añadir nueva imagen </target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Añadir nuevo archivo</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Eliminar</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Añadir un elemento nuevo a '%name%'</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Subir</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Bajar</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Vista detallada</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Archivo de configuración:</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Arrastrar y soltar archivos para subir</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Siguiente</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Anterior</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Arriba</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Abajo</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Descargar</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Registro</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Petición</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Rastro</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Contexto</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Nivel</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Mensaje</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Marca temporal</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Usuario</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Desactivado</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Desbloqueado</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>No se encontró contenido</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Ninguno</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Vacío</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Aplicar a todo</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Información del sistema</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>¿Está seguro de que desea eliminar este contenido?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>Usuario o correo electrónico de su cuenta</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>Introduzca contraseña de su cuenta</target>
+      </segment>
+    </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Otro Contenido</target>
       </segment>
     </unit>
-    <unit id="wIX8O_z" name="status.">
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
-        <source>status.</source>
-        <target>Estado.</target>
+        <source>editfile.target_not_writable</source>
+        <target>El guardado está deshabilitado porque el archivo de destino no admite escritura.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Este campo es traducible</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Contenido</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>¡Archivo eliminado correctamente!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>¿Está seguro de que desea eliminar este archivo?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Buscar / Filtrar por</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Estado cambiado correctamente</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Contenido eliminado correctamente</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Estado actual</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Publicado</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Borrador</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Programado</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Pendiente</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>¿Está seguro de que desea eliminar este elemento de la Colección? </target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Tipos de archivos permitidos para subir</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Tamaño máximo de subida</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Buscar por palabra clave...</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Todo el contenido, filtrado por <em>'%filter%'</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Ver sitio web</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Nuevo</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Sin dependencias conocidas</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Dependencias</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Expandir todo</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Contraer todo</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>¡Falta la definición de este ContentType! La edición de este registro no funcionará como se espera. Compruebe su archivo contenttypes.yaml para asegurarse de que contiene %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Seleccionar …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Introduzca su nombre de usuario o correo electrónico</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Introduzca su contraseña</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Introduzca su correo electrónico</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filtrar por campo</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Desde URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Copiar enlace al archivo</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Advertencia</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>La carpeta ya existe</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>No se pudo crear la carpeta</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Carpeta creada correctamente.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Carpeta eliminada correctamente</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Nueva carpeta</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Contraseña olvidada</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Restablecer contraseña</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Introduzca su dirección de correo electrónico y le enviaremos un enlace para restablecer su contraseña.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Enviar</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Correo electrónico</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Volver al inicio de sesión</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Restablezca su contraseña</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Correo de restablecimiento de contraseña enviado</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Se ha enviado un correo electrónico que contiene un enlace en el que puede hacer clic para restablecer su contraseña. Este enlace caducará en %hours% hora(s).</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Si no recibe el correo electrónico, compruebe su carpeta de spam o %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Restablecer contraseña</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>¡Hola!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Para restablecer su contraseña, visite el siguiente enlace</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Este enlace caducará en %hours% hora(s).</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>¡Saludos!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Introduzca una contraseña</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Repita la contraseña</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Los campos de contraseña deben coincidir.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Su contraseña debe tener al menos %s caracteres</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>No se encontró ningún token de restablecimiento de contraseña en la URL ni en la sesión.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Su contraseña se ha restablecido correctamente.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Hubo un problema al procesar su solicitud de restablecimiento de contraseña - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>filtrado por</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Compartir enlace de vista previa seguro</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>dejar de suplantar</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>suplantar</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>El modo de mantenimiento está activado</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Actualizar</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Mostrando registros %current% de %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Nombre: %name% (singular: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (singular: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Plantilla de registro: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Plantilla de listado: %template% (%listingRecords% registros)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Idiomas: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Editar permisos</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Buscar</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Vista previa de la imagen</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Seleccionar todo</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>¿Recordarme? (%duration% días)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Sesiones actuales</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Opciones de subida</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Orden</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>su correo electrónico</target>
       </segment>
     </unit>
     <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>modal.title.file_field</source>
         <target>Elige un archivo</target>
       </segment>
     </unit>
     <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
       <segment>
         <source>modal.title.image_field</source>
         <target>Elige una imagen</target>
       </segment>
     </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Subir desde URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Cargando…</target>
+      </segment>
+    </unit>
     <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
       <segment>
         <source>modal.button_save</source>
         <target>Guardar</target>
       </segment>
     </unit>
     <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
       <segment>
         <source>modal.button_deny</source>
         <target>Cerrar</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
   <file id="messages.fr">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Non disponible</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Erreur %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>Une erreur inconnue (HTTP %status_code%) a empêché de terminer votre demande.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Essayez de re-charger cette page dans quelques minutes ou <a href="%url%">retournez à la page d'acceuil</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>Vous n'êtes pas autorisé à accéder à cette ressource.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Demandez à votre responsable ou à votre administrateur système de vous accorder l'accès à cette ressource.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>Nous n'avons pas trouvé la page que vous avez demandée.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Vérifiez toute faute d'orthographe ou de frappe dans l'URL ou <a href="%url%">revenez à la page d'accueil</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>Une erreur du serveur interne s'est produite.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Essayez de re-charger cette page dans quelques minutes ou <a href="%url%">retournez à la page d'acceuil</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Code source utilisé pour afficher cette page</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Code controller</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Modèle du code Twig</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Modifier l'utilisateur</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Montrer le code</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Faire quelque chose</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Modifier l'utilisateur</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Modifier</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Nom d'utilisateur</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[Cliquez sur ce bouton pour afficher le code source du <strong>Contrôleur</strong> et du <strong>Modèle</strong> utilisés pour afficher cette page.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>Après avoir changé votre mot de passe, vous serez déconnecté de l'application.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>Liste de contenu</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Changer le mot de passe</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -412,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,37 +297,27 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Vous trouverez ci-dessous les bibliothèques tierces utilisées par Bolt.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Nom complet</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>Adresse Email</target>
       </segment>
     </unit>
-    <unit id="D2N6_cP" name="label.about">
+    <unit id="D2N7_cP" name="label.about">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>templates/users/_form.html.twig:185</note>
       </notes>
       <segment>
         <source>label.about</source>
@@ -460,8 +326,7 @@
     </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -470,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -481,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -491,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -500,511 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Theme de l'administration</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>Anglais (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Néerlandais (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Espagnole (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>Français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Allemand (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Polonais (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Portuguais Brésilien (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italien (Italian, it)</target>
+        <target>Langue</target>
       </segment>
     </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Le thème par défaut</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>Le thème sombre par défaut</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers : Kinda ressemble à cet autre CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Tableau de bord</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>caption.translations : messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Vider le cache</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Vérifier la base de données</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>Configuration du routage</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Paramètres du menu</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Taxonomies</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Type de contenu</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Configuration principale</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Utilisateurs & Permissions]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Configuration</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Paramètres</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Contenu</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Gestion de fichiers</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Extensions</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
-        <target><![CDATA[Afficher et modifier les modèles]]></target>
+        <target>Afficher et modifier les modèles</target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Fichiers téléchargés</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Configuration du routage</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Traductions</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>À propos de Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
-        <target><![CDATA[Un CMS sophistiqué, léger et simple]]></target>
+        <target>Un CMS sophistiqué, léger et simple</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Modifier</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Téléchargeur de fichiers</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Méta-information</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Date</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Taille</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
         <target>Vignette</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Nom du fichier</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Actions</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Nom du répertoire</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Aller</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Sélectionnez rapidement un fichier à modifier…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Selection rapide</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Chemin</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Nom du fichier</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Visitez le site Web</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Créer un nouveau</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Salut, %name% !</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Se déconnecter</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Editer le profil</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>Fermer</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Tous les fichiers de configuration</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Maintenance</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Agencement (Contenu factice)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Modifier le fichier</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Contrôles de l'installation</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Choisir la langue</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Paramètres locale actuels</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Passer aux paramètres locale</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Auteur</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Éditer</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Inconnu</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Écrit par %name% le %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>La page "À propos" est manquante</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>Le bloc "À propos" est manquant</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>Récent %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Recherche</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[Ce site est <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Construit avec Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>Vue générale de %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Aucun %contenttype% récent trouvé</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>Menu</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Rechercher</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Permalien</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Afficher le nom</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>Cache effacé avec succès !</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
         <target>L'évier de la cuisine</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Résultats de la recherche pour'%search%'.</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1013,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1022,1740 +1018,2417 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Veuillez fournir un terme de recherche afin d'afficher des résultats pertinents.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Lire la suite</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
         <target><![CDATA[Ce site Web est <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Construit avec Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Dernières nouvelles de Bolt</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>Aperçu</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>Afficher la version enregistrée</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Afficher le nom</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Dupliquer</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>Mot de passe actuel</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>Nouveau mot de passe</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>Nouveau mot de passe (confirmer)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>Fichier mis à jour avec succès !</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Ajouter un utilisateur</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Succès !</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>Le profil utilisateur a été mis à jour !</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Rôles</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>Nouvel utilisateur</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>Vue</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Dossiers</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>Fermé</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>Éditer</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>Générer à partir de :</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>Télécharger</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
         <target>De la bibliothèque</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>Voir sur le site</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Changer le statut en "publier"</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Changer le statut en "en attente"</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Changer le statut en "brouillon"</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
       <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Dupliquer</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>Supprimer</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>Créé sur</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>Publié le</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Dernière modification le</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Sélectionné</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>ID d'enregistrement sélectionné transmis</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(ceux-ci peuvent être utilisés avec, entre autre, axios pour modifier / supprimer en bloc)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>URL du contenu à intégrer</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL du contenu sur Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Hauteur</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>pixel</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Intégration correspondante</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>Aperçu</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Taille</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>Nom du fichier (téléchargez un nouveau fichier ou sélectionnez-en un existant)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Attribut Alt</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>Attribut Titre</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>Basculer la largeur de la barre latérale</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
       <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[<span class="sr-only">Montrer le </span>menu]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
       <segment>
         <source>editor_date.toggle</source>
         <target>Basculer</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Nom du fichier</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Titre</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>Voir l'image</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Télécharger une image</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Remarque: ce champ est pratiquement le même que le champ <code>image</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Remarque: ce champ est pratiquement le même que le champ <code>imagelist</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Geolocalisation :</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Recherche d'adresse</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>Rue, code postal, ville ou autre emplacement…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Latitude</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Adresse correspondante</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>Placement des marqueurs</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>S'aligner sur l'adresse la plus proche</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Longitude</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Remarque: ce champ est pratiquement le même que le champ <code>filelist</code>.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>Notification</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Basculer la liste déroulante</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
       <segment>
         <source>localeswitcher.button_info</source>
         <target>Voir les informations de localisation</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Trier par</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Sélectionner l'article</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Titre</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Mot clé avec lequel filtrer…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Filtrer</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
       <segment>
         <source>listing.button_clear</source>
         <target>Effacer le tri / filtre</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>Défaut</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
         <target>Manquant</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Basculer la liste déroulante</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Modifier les informations sur l'image</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>Modifier le fichier dans l'éditeur</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>Voir l'original</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
       <segment>
         <source>files_cards.action_duplicate</source>
         <target>Dupliquer</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>Supprimer</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>Nom du fichier :</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>Titre :</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>Dimensions :</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>Taille du fichier :</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>Créé le :</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>Aucun fichier n'est présent dans ce dossier. Sélectionnez un dossier vers lequel naviguer.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>Sélectionner un fichier :</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>Liste</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>Cartes</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>Description :</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>Auteur :</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
         <target>Nom du package / classe :</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Version :</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>Ceci est un package local, non installé via Composer</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Nom de la classe :</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>Configuration</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
         <target>Source</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>Supprimer l'extension</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Désactiver l'extension</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
         <target>Bolt » Connexion</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
       <segment>
         <source>extensions.message_not_implemented</source>
         <target>Pas encore implémenté. Désolé !</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>Aperçu pour</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>Aucun fichier n'est présent dans ce dossier. Sélectionnez un dossier, sur le côté droit, vers lequel naviguer.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>listing_filter.button_compact</source>
         <target>Compact</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
       <segment>
         <source>listing_filter.button_expanded</source>
         <target>Étendu</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>Vue :</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Éditer</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
         <target><![CDATA[Utilisateurs & Permissions]]></target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>Pour modifier les utilisateurs et leurs autorisations</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Vérification de la base de données</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>Pour vérifier la base de données</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Mise à jour de la base de données</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>Pour mettre à jour la base de données</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>Rechercher, de manière omniprésente</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
-        <target>Afficher le nom</target>
+        <target>Nom affiché</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>Nom d'utilisateur</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
         <target>Email</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>Rôles</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
         <target>Âge de la session</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
         <target>Dernière IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Actions</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Email invalide</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Mot de passe incorrect. Le mot de passe doit contenir au moins 6 caractères.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>Utilisateur inconnu</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Couleurs prédominantes dans l'image</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>Aperçu pour '%slug%'</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>Contenus associés</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>Recherche</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>Nouveau %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>Sans titre %contenttype%</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>Modifier le profil utilisateur</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>Page de redirection</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>Éditer l'image</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>Choisir la langue</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[Mot de passe sécurisé suggéré: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
         <target>Recadrer X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Position du cadrage sur l'axe X, plage 0-100.</target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Position du cadrage sur l'axe Y, plage de 0 à 100.</target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>Recadrer Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>Recadrer zoomfactor</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>Niveau de zoom du recadrage, plage 1-10.</target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>Type de contenus</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>Taxonomie</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>Aucun résultat trouvé. Élargissez les critères de filtrage ou ajoutez du contenu supplémentaire.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>Sélectionnez un champ pour trier par…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>Actions principales</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>Options</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Supprimer</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Activer</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>Désactiver</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>L'utilisateur a été activé avec succès !</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment>
-        <source>user.disabled_successfully</source>
-        <target>L'utilisateur a été désactivé avec succès !</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>La session a expiré</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>Adresse IP</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Navigateur / plateforme</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>Retirer</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>Modifier les attributs</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>Déplacer vers le haut</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>Déplacer vers le bas</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Ajouter une nouvelle image</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Ajouter un nouveaux fichier</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>Retirer l'élément</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>Ajouter un nouvel élément à '%name%'</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>Déplacer vers le haut</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>Déplacer vers le bas</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>Voir les détails</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>Fichier de configuration</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Déposer des fichiers ici pour les télécharger</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>Suivant</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>Précédent</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>Haut</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
         <target>Bas</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>Télécharger</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>Logs</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
         <target>Demande</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>Trace</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>Contexte</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>Niveau</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>Message</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
       <segment>
         <source>label.timestamp</source>
         <target>Horodatage</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>Utilisateur</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing.disabled</source>
         <target>Désactiver</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>Débloquer</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>Aucun contenu trouvé</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>Il semble que la base de données soit vide. Écrivez du contenu dans le backend Bolt ou exécutez la commande pour ajouter des données (contenu factice). </target>
+        <source>general.phrase.none</source>
+        <target>Aucun</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
         <target>Vide</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>Appliquer à tous</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>Informations système</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Nom d'affichage non valide</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>Voulez-vous vraiment supprimer ce contenu ?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>Votre nom d'utilisateur ou email</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>Votre mot de passe</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Autre contenu</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>L'enregistrement est désactivé, car le fichier cible n'est pas accessible en écriture.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>Ce champ est traduisible</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>Contenu</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
         <source>file.delete_success</source>
         <target>Fichier supprimé avec succès !</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Êtes-vous sûr de vouloir supprimer ce fichier ?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>Rechercher / Filtrer par</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
       <segment>
         <source>content.status_changed_successfully</source>
         <target>Statut changé avec succès</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
       <segment>
         <source>content.deleted_successfully</source>
         <target>Contenu supprimé avec succès</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>Statut actuel</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>Publié</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>Brouillon</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>Publication planifiée</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>Non publié</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>Êtes-vous sûr de vouloir supprimer cet élément de la collection ?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
       <segment>
         <source>upload.allow_file_types</source>
         <target>Types de fichiers autorisés pour le téléchargement</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>Taille maximale de téléchargement</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>Rechercher un mot-clé …</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[Tout le contenu, filtré par <em>'%filter%'</em>.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>Voir le site Web</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>Nouveau</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>Aucune dépendance connue</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>Dépendance</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Tout développer</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Tout réduire</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
         <target>La définition de ce ContentType est manquante ! La modification de cet enregistrement ne fonctionnera pas comme prévu. Veuillez vérifier votre contenttypes.yaml pour vous assurer qu'il contient %contenttype%.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>Sélectionnez…</target>
       </segment>
     </unit>
     <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
       <segment>
         <source>form.empty_username_email</source>
         <target>Veuillez saisir votre nom d'utilisateur ou votre email</target>
       </segment>
     </unit>
     <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
       <segment>
         <source>form.empty_password</source>
         <target>Veuillez saisir votre mot de passe</target>
       </segment>
     </unit>
-    <unit id="o2f3RiO" name="form.empty_email">
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
       <segment>
         <source>form.empty_email</source>
         <target>Veuillez saisir votre email</target>
       </segment>
     </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Filtrer par champ</target>
       </segment>
     </unit>
     <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
       <segment>
         <source>image.button_from_url</source>
         <target>De l'URL</target>
       </segment>
     </unit>
     <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
       <segment>
         <source>files_cards.copy_to_clipboard</source>
         <target>Copier le lien dans le fichier</target>
       </segment>
     </unit>
     <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
       <segment>
         <source>warning</source>
         <target>Attention</target>
       </segment>
     </unit>
     <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_already_exists</source>
         <target>Le dossier existe déjà</target>
       </segment>
     </unit>
     <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_error</source>
         <target>Impossible de créer le dossier</target>
       </segment>
     </unit>
     <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_success</source>
         <target>Dossier créé avec succès.</target>
       </segment>
     </unit>
     <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
       <segment>
         <source>filemanager.delete_folder_successful</source>
         <target>Dossier supprimé avec succès</target>
       </segment>
     </unit>
     <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
       <segment>
         <source>folder.create_new</source>
         <target>Nouveau dossier</target>
       </segment>
     </unit>
-    <unit id="FcXvWL8" name="title.add_user">
-      <segment>
-        <source>title.add_user</source>
-        <target>Ajouter un utilisateur</target>
-      </segment>
-    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>Avatar</target>
       </segment>
     </unit>
     <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
       <segment>
         <source>login.forgotpassword</source>
         <target>Mot de passe oublié</target>
       </segment>
     </unit>
     <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.request_header</source>
         <target>Réinitialiser le mot de passe</target>
       </segment>
     </unit>
     <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
       <segment>
         <source>reset_password.request_description</source>
         <target>Entrez votre adresse e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe.</target>
       </segment>
     </unit>
     <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
       <segment>
         <source>reset_password.request_send</source>
         <target>Soumettre</target>
       </segment>
     </unit>
     <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
       <segment>
         <source>Email</source>
         <target>Email</target>
       </segment>
     </unit>
     <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
       <segment>
         <source>reset_password.back-to-login</source>
         <target>Retour à la page de connexion</target>
       </segment>
     </unit>
     <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
       <segment>
         <source>reset_password.reset_header</source>
         <target>Réinitialisez votre mot de passe</target>
       </segment>
     </unit>
     <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_header</source>
         <target>Email de réinitialisation du mot de passe envoyé</target>
       </segment>
     </unit>
     <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_1</source>
         <target>Un e-mail a été envoyé contenant un lien sur lequel vous pouvez cliquer pour réinitialiser votre mot de passe. Ce lien expirera dans %hours% heure(s).</target>
       </segment>
     </unit>
     <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_2</source>
         <target>Si vous ne recevez pas d'e-mail, veuillez vérifier votre dossier spam ou %tryagain%.</target>
       </segment>
     </unit>
     <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
       <segment>
         <source>reset_password.reset_btn</source>
         <target>Réinitialiser le mot de passe</target>
       </segment>
     </unit>
-    <unit id="3prMgfK" name="reset_password.email_title">
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
       <segment>
         <source>reset_password.email_title</source>
         <target>Bonjour !</target>
       </segment>
     </unit>
-    <unit id="oaRkfvE" name="reset_password.email_description">
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
       <segment>
         <source>reset_password.email_description</source>
         <target>Pour réinitialiser votre mot de passe, veuillez visiter le lien suivant</target>
       </segment>
     </unit>
-    <unit id="Afb4dal" name="reset_password.email_expire">
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
       <segment>
         <source>reset_password.email_expire</source>
         <target>Ce lien expirera dans %hours% heure(s).</target>
       </segment>
     </unit>
-    <unit id="9ga3FlV" name="reset_password.email_thanks">
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
       <segment>
         <source>reset_password.email_thanks</source>
         <target>Merci !</target>
       </segment>
     </unit>
-    <unit id="7d24Grt" name="reset_password.enter_pwd">
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
       <segment>
         <source>reset_password.enter_pwd</source>
         <target>Veuillez saisir un mot de passe</target>
       </segment>
     </unit>
-    <unit id="a2f1pra" name="label.repeat_password">
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
       <segment>
         <source>label.repeat_password</source>
         <target>Répéter le mot de passe</target>
       </segment>
     </unit>
-    <unit id="2f19Gat" name="reset_password.not_matching_pwds">
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
       <segment>
         <source>reset_password.not_matching_pwds</source>
         <target>Les champs mot de passe doivent correspondre.</target>
       </segment>
     </unit>
-    <unit id="2ahb7da" name="reset_password.minimum_length">
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
       <segment>
         <source>reset_password.minimum_length</source>
         <target>Votre mot de passe doit contenir au moins %s caractères</target>
       </segment>
     </unit>
-    <unit id="a3frsl4" name="reset_password.no_token">
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
       <segment>
         <source>reset_password.no_token</source>
         <target>Aucun jeton de réinitialisation du mot de passe trouvé dans l'URL ou dans la session.</target>
       </segment>
     </unit>
-    <unit id="hsg341k" name="reset_password.reset_successful">
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
       <segment>
         <source>reset_password.reset_successful</source>
         <target>Votre mot de passe a été réinitialisé avec succès.</target>
       </segment>
     </unit>
-    <unit id="7f2x41k" name="reset_password.problem_with_request">
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
       <segment>
         <source>reset_password.problem_with_request</source>
         <target>Un problème est survenu lors du traitement de votre demande de réinitialisation de mot de passe - %s</target>
       </segment>
     </unit>
     <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>label.filtered_by</source>
         <target>filtré par</target>
       </segment>
     </unit>
     <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
       <segment>
         <source>action.preview_secure_share</source>
         <target>Partager un lien d'aperçu sécurisé</target>
       </segment>
     </unit>
     <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
       <segment>
         <source>action.stop_impersonating</source>
         <target>arreter l'usurpation</target>
       </segment>
     </unit>
     <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
       <segment>
         <source>action.impersonate</source>
         <target>usurper</target>
       </segment>
     </unit>
     <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
       <segment>
         <source>maintenance.activated_warning</source>
         <target>Le mode maintenance est activé</target>
       </segment>
     </unit>
     <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
       <segment>
         <source>action.refresh</source>
         <target>Actualiser</target>
       </segment>
     </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
       <segment>
         <source>listing_details_box.showing_records</source>
         <target>Affichage des enregistrements %current% de %total%</target>
       </segment>
     </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
       <segment>
         <source>listing_details_box.name</source>
         <target>Nom : %name% (singulier : %singularName%)</target>
       </segment>
     </unit>
     <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
       <segment>
         <source>listing_details_box.slug</source>
         <target>Slug : %slug% (singulier : %singularSlug%)</target>
       </segment>
     </unit>
     <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
       <segment>
         <source>listing_details_box.record_template</source>
         <target>Modèle de l'enregistrement : %template%</target>
       </segment>
     </unit>
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
       <segment>
         <source>listing_details_box.listing_template</source>
         <target>Modèle de liste : %template% (%listingRecords% enregistrements)</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
       <segment>
         <source>listing_details_box.locales</source>
-        <target>Locales: %locales%</target>
+        <target>Langues : %locales%</target>
       </segment>
     </unit>
     <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
       <segment>
         <source>action.edit_permissions</source>
         <target>Modifier les permissions</target>
       </segment>
     </unit>
     <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
       <segment>
         <source>general.label.search</source>
         <target>Rechercher</target>
       </segment>
     </unit>
     <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.image_preview</source>
         <target>Prévisualiser l'image</target>
       </segment>
     </unit>
     <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
       <segment>
         <source>listing_table.actions.select_all</source>
         <target>Tout sélectionner</target>
       </segment>
     </unit>
     <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
       <segment>
         <source>label.remembermeduration</source>
         <target>Se souvenir de moi ? (%duration% days)</target>
       </segment>
     </unit>
     <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
       <segment>
         <source>listing.current_sessions_header</source>
         <target>Sessions en cours</target>
       </segment>
     </unit>
     <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
       <segment>
         <source>image.button_upload_options</source>
         <target>Option de téléversement</target>
       </segment>
     </unit>
-    <unit id="hKmDb7q" name="Share secure preview link">
-      <segment>
-        <source>Share secure preview link</source>
-        <target>Partager un lien d'aperçu sécurisé</target>
-      </segment>
-    </unit>
     <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
       <segment>
         <source>Order</source>
         <target>Ordre</target>
       </segment>
     </unit>
     <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
       <segment>
         <source>placeholder.email</source>
         <target>votre email</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>Vous devez vous connecter pour accéder à cette page.</target>
-      </segment>
-    </unit>
     <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>modal.title.file_field</source>
         <target>Sélectionner un fichier</target>
       </segment>
     </unit>
     <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
       <segment>
         <source>modal.title.image_field</source>
         <target>Sélectionner une image</target>
       </segment>
     </unit>
     <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
       <segment>
         <source>modal.title.upload_from_url</source>
         <target>Téléverser à partir d'une URL</target>
       </segment>
     </unit>
     <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
       <segment>
         <source>modal.text.loading</source>
         <target>Chargement...</target>
       </segment>
     </unit>
     <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
       <segment>
         <source>modal.button_save</source>
         <target>Enregistrer</target>
       </segment>
     </unit>
     <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
       <segment>
         <source>modal.button_deny</source>
         <target>Fermer</target>

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -1,1384 +1,3438 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="hu" target-language="hu" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="tbB2gib" resname="not_available">
-        <source>not_available</source>
-        <target>Nem elérhető</target>
-        <note>templates/debug/source_code.twig:26</note>
-      </trans-unit>
-      <trans-unit id="DF34uM2" resname="http_error.name">
-        <source>http_error.name</source>
-        <target>Hiba %status_code%</target>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </trans-unit>
-      <trans-unit id="e3w.2Rf" resname="http_error.description">
-        <source>http_error.description</source>
-        <target>Ismeretlen (HTTP %status_code%) hiba miatt a kérés nem teljesíthető</target>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </trans-unit>
-      <trans-unit id="ru5FEGk" resname="http_error.suggestion">
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Néhány perc múlva próbáld újra vagy <a href="%url%">vissza a kezdőoldalra</a>.]]></target>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </trans-unit>
-      <trans-unit id="Qn5rwdU" resname="http_error_403.description">
-        <source>http_error_403.description</source>
-        <target>Nincs jogosultságod a hozzáféréshez.</target>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </trans-unit>
-      <trans-unit id="zDeeh7L" resname="http_error_403.suggestion">
-        <source>http_error_403.suggestion</source>
-        <target>Fordulj a rendszergazdához vagy üzemeltetőhöz engedélyért.</target>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </trans-unit>
-      <trans-unit id="_W1eNz2" resname="http_error_404.description">
-        <source>http_error_404.description</source>
-        <target>A hivatkozott oldal nem található.</target>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </trans-unit>
-      <trans-unit id="MWNS5dg" resname="http_error_404.suggestion">
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Ellenőrizd az esetleges elírást az URL-ben vagy <a href="%url%">vissza a kezdőoldalra</a>.]]></target>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </trans-unit>
-      <trans-unit id="ZYXSW95" resname="http_error_500.description">
-        <source>http_error_500.description</source>
-        <target>Hiba a szerveren.</target>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </trans-unit>
-      <trans-unit id="VVs_J1c" resname="http_error_500.suggestion">
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Próbáld újratölteni pár perc múlva vagy <a href="%url%">vissza a kezdőoldalra</a>.]]></target>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </trans-unit>
-      <trans-unit id="9RwuNlf" resname="title.source_code">
-        <source>title.source_code</source>
-        <target>Az oldal előállításához használt forráskód</target>
-        <note>templates/debug/source_code.twig:17</note>
-      </trans-unit>
-      <trans-unit id="jaB3QjG" resname="title.controller_code">
-        <source>title.controller_code</source>
-        <target>Kontroller kód</target>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </trans-unit>
-      <trans-unit id="2bH7SjO" resname="title.twig_template_code">
-        <source>title.twig_template_code</source>
-        <target>Twig sablon kód</target>
-        <note>templates/debug/source_code.twig:29</note>
-      </trans-unit>
-      <trans-unit id="1sstKF9" resname="title.edit_user">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="hu">
+  <file id="messages.hu">
+    <unit id="1sstKF9" name="title.edit_user">
+      <notes>
+        <note>templates/users/edit.html.twig:6</note>
+      </notes>
+      <segment>
         <source>title.edit_user</source>
         <target>Felhasználó szerkesztés</target>
-        <note>templates/users/edit.twig:4</note>
-      </trans-unit>
-      <trans-unit id="QbohvW1" resname="action.show_code">
-        <source>action.show_code</source>
-        <target>Kód megtekintése</target>
-        <note>templates/debug/source_code.twig:7</note>
-      </trans-unit>
-      <trans-unit id="HLtdhYw" resname="action.save">
+      </segment>
+    </unit>
+    <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
+      <segment>
         <source>action.save</source>
         <target>Mentés</target>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
-      </trans-unit>
-      <trans-unit id="a2vzLi7" resname="action.do_something">
+      </segment>
+    </unit>
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
+      <segment>
         <source>action.do_something</source>
         <target>Katt ide...</target>
-      </trans-unit>
-      <trans-unit id="etGJjTo" resname="action.edit_user">
-        <source>action.edit_user</source>
-        <target>Felhasználó szerkesztése</target>
-        <note>templates/users/change_password.twig:26</note>
-      </trans-unit>
-      <trans-unit id="ovKkXwU" resname="action.edit">
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
         <source>action.edit</source>
         <target>Szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="LDhDPrF" resname="label.username">
+      </segment>
+    </unit>
+    <unit id="LDhDPrF" name="label.username">
+      <notes>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
+      </notes>
+      <segment>
         <source>label.username</source>
         <target>Felhasználónév</target>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
-      </trans-unit>
-      <trans-unit id="VgeTgE2" resname="help.show_code">
-        <source>help.show_code</source>
-        <target><![CDATA[Az oldal előállításához használt <strong>Kontroller</strong> és <strong>sablon</strong> kódját a gombra kattintva tekintheted meg.]]></target>
-        <note>templates/debug/source_code.twig:3</note>
-      </trans-unit>
-      <trans-unit id="wtG.cxy" resname="info.change_password">
-        <source>info.change_password</source>
-        <target>A jelszó megváltoztatása után az alkalmazásból ki kell lépni.</target>
-        <note>templates/users/change_password.twig:12</note>
-      </trans-unit>
-      <trans-unit id="80JoLd0" resname="title.login">
+      </segment>
+    </unit>
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
+      <segment>
         <source>title.login</source>
         <target>Bejelentkezés</target>
-        <note>templates/security/login.twig:4</note>
-      </trans-unit>
-      <trans-unit id="9pvowqn" resname="label.password">
+      </segment>
+    </unit>
+    <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
+      <segment>
         <source>label.password</source>
         <target>Jelszó</target>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
-      </trans-unit>
-      <trans-unit id="gLN0C81" resname="action.log_in">
+      </segment>
+    </unit>
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
+      <segment>
         <source>action.log_in</source>
         <target>Bejelentkezés</target>
-        <note>templates/security/login.twig:84</note>
-      </trans-unit>
-      <trans-unit id="vJwSCBO" resname="title.contentlisting">
+      </segment>
+    </unit>
+    <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
+      <segment>
         <source>title.contentlisting</source>
         <target>Tartalom</target>
-        <note>templates/content/listing.twig:9</note>
-      </trans-unit>
-      <trans-unit id="CX_oSFd" resname="action.change_password">
-        <source>action.change_password</source>
-        <target>Jelszó változtatás</target>
-        <note>templates/users/edit.twig:24</note>
-      </trans-unit>
-      <trans-unit id="SNELzJ2" resname="field.id">
+      </segment>
+    </unit>
+    <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
+      <segment>
         <source>field.id</source>
         <target>ID</target>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
-      </trans-unit>
-      <trans-unit id="FuCyk5C" resname="field.status">
+      </segment>
+    </unit>
+    <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
+      <segment>
         <source>field.status</source>
         <target>Státusz</target>
-        <note>templates/editcontent/edit.twig:76</note>
-      </trans-unit>
-      <trans-unit id="O9wtVOp" resname="field.createdAt">
+      </segment>
+    </unit>
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
+      <segment>
         <source>field.createdAt</source>
         <target>Létrehozva</target>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
-      </trans-unit>
-      <trans-unit id="eVkSIKu" resname="field.modifiedAt">
+      </segment>
+    </unit>
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
+      <segment>
         <source>field.modifiedAt</source>
         <target>Módosítva</target>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
-      </trans-unit>
-      <trans-unit id="3gdi1dy" resname="field.publishedAt">
+      </segment>
+    </unit>
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
+      <segment>
         <source>field.publishedAt</source>
         <target>Publikáva</target>
-        <note>templates/editcontent/edit.twig:102</note>
-      </trans-unit>
-      <trans-unit id="eN7IfEL" resname="field.depublishedAt">
+      </segment>
+    </unit>
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
+      <segment>
         <source>field.depublishedAt</source>
         <target>Visszavonva</target>
-        <note>templates/editcontent/edit.twig:110</note>
-      </trans-unit>
-      <trans-unit id="VKhfRZB" resname="field.title">
+      </segment>
+    </unit>
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
+      <segment>
         <source>field.title</source>
         <target>Cím</target>
-        <note>templates/editcontent/media_edit.twig:47</note>
-      </trans-unit>
-      <trans-unit id="7_wwX8J" resname="field.description">
+      </segment>
+    </unit>
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
+      <segment>
         <source>field.description</source>
         <target>Leírás</target>
-        <note>templates/editcontent/media_edit.twig:53</note>
-      </trans-unit>
-      <trans-unit id="hjDmcPC" resname="field.copyright">
+      </segment>
+    </unit>
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
+      <segment>
         <source>field.copyright</source>
-        <target>Copyright</target>
-        <note>templates/editcontent/media_edit.twig:59</note>
-      </trans-unit>
-      <trans-unit id="v0sitU8" resname="field.originalFilename">
+        <target>Szerzői jog</target>
+      </segment>
+    </unit>
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
+      <segment>
         <source>field.originalFilename</source>
         <target>Eredeti fájlnév</target>
-        <note>templates/editcontent/media_edit.twig:66</note>
-      </trans-unit>
-      <trans-unit id="vlRe8Tx" resname="field.width">
+      </segment>
+    </unit>
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
+      <segment>
         <source>field.width</source>
         <target>szélesség</target>
-        <note>templates/editcontent/media_edit.twig:105</note>
-      </trans-unit>
-      <trans-unit id="CZbXbM_" resname="field.height">
+      </segment>
+    </unit>
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
+      <segment>
         <source>field.height</source>
         <target>magasság</target>
-        <note>templates/editcontent/media_edit.twig:112</note>
-      </trans-unit>
-      <trans-unit id="Sz_u.OS" resname="field.filesize">
+      </segment>
+    </unit>
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
+      <segment>
         <source>field.filesize</source>
         <target>Fájlméret</target>
-        <note>templates/editcontent/media_edit.twig:119</note>
-      </trans-unit>
-      <trans-unit id="RMPnq6o" resname="label.username_or_email">
+      </segment>
+    </unit>
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
+      <segment>
         <source>label.username_or_email</source>
         <target>Felhasználónév vagy email</target>
-        <note>templates/security/login.twig:61</note>
-      </trans-unit>
-      <trans-unit id="IaF1MjB" resname="label.rememberme">
+      </segment>
+    </unit>
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
         <source>label.rememberme</source>
         <target>Emlékezz rám</target>
-        <note>templates/security/login.twig:80</note>
-      </trans-unit>
-      <trans-unit id="k.JymqB" resname="about.visit_bolt">
+      </segment>
+    </unit>
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
+      <segment>
         <source>about.visit_bolt</source>
         <target>Boltcms.io megnyitása</target>
-        <note>templates/pages/about.twig:33</note>
-      </trans-unit>
-      <trans-unit id="UZFanGF" resname="about.bolt_documentation">
+      </segment>
+    </unit>
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
+      <segment>
         <source>about.bolt_documentation</source>
         <target>Bolt dokumentációja</target>
-        <note>templates/pages/about.twig:28</note>
-      </trans-unit>
-      <trans-unit id="FO7zDub" resname="about.bolt_on_github">
+      </segment>
+    </unit>
+    <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
+      <segment>
         <source>about.bolt_on_github</source>
         <target>Bolt a Githubon</target>
-        <note>templates/pages/about.twig:31</note>
-      </trans-unit>
-      <trans-unit id="_9fS00R" resname="about.used_libraries">
+      </segment>
+    </unit>
+    <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
+      <segment>
         <source>about.used_libraries</source>
         <target>A felhasznált modulok / komponensek</target>
-        <note>templates/pages/about.twig:35</note>
-      </trans-unit>
-      <trans-unit id="tgLgLDQ" resname="about.list_of_used_libraries">
+      </segment>
+    </unit>
+    <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
+      <segment>
         <source>about.list_of_used_libraries</source>
         <target>Alábbiakban a Bolt által használt szoftver összetevők.</target>
-        <note>templates/pages/about.twig:37</note>
-      </trans-unit>
-      <trans-unit id="aYnbvsn" resname="label.fullname">
-        <source>label.fullname</source>
-        <target>Teljes név</target>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="D2N6_cP" resname="label.email">
+      </segment>
+    </unit>
+    <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
+      <segment>
         <source>label.email</source>
         <target>Email cím</target>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="OBmPOoB" resname="user.updated_successfully">
+      </segment>
+    </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Névjegy</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
         <source>user.updated_successfully</source>
         <target>Sikeres frissítés</target>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="3hkt.eH" resname="content.updated_successfully">
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
         <source>content.updated_successfully</source>
         <target>Sikeres média tartalom frissítés</target>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="IB0mNQh" resname="content.created_successfully">
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
         <source>content.created_successfully</source>
         <target>Sikeres média tartalom létrehozás</target>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="b1jqjUC" resname="editfile.could_not_write">
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
         <source>editfile.could_not_write</source>
         <target>A média tartalom nem hozható létre</target>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
-      </trans-unit>
-      <trans-unit id="mEDsKHk" resname="label.locale">
+      </segment>
+    </unit>
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
         <source>label.locale</source>
-        <target>Locale</target>
-      </trans-unit>
-      <trans-unit id="98Q5SA2" resname="label.backend_theme">
-        <source>label.backend_theme</source>
-        <target>Admin téma</target>
-      </trans-unit>
-      <trans-unit id="Z84BVRW" resname="English (en)">
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </trans-unit>
-      <trans-unit id="eG9ABZd" resname="Nederlands (dutch, nl)">
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </trans-unit>
-      <trans-unit id="57LcBXV" resname="Español (Spanish, es)">
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </trans-unit>
-      <trans-unit id="e7RdvJ0" resname="français (French, fr)">
-        <source>français (French, fr)</source>
-        <target>français (French, fr)</target>
-      </trans-unit>
-      <trans-unit id="U1vrep2" resname="Deutsch (German, de)">
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </trans-unit>
-      <trans-unit id="EsWjyMS" resname="Język Polski (Polish, pl)">
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </trans-unit>
-      <trans-unit id="fbEbOrT" resname="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </trans-unit>
-      <trans-unit id="pBUPCm9" resname="Italiano (Italian, it)">
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
-      </trans-unit>
-      <trans-unit id="Oiwdkpg" resname="The Default theme">
+        <target>Területi beállítás</target>
+      </segment>
+    </unit>
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
         <source>The Default theme</source>
         <target>Az alapértelmezett téma</target>
-      </trans-unit>
-      <trans-unit id="C389Knp" resname="The Default Dark theme">
+      </segment>
+    </unit>
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
         <source>The Default Dark theme</source>
         <target>Az alapértelmezett sötét téma</target>
-      </trans-unit>
-      <trans-unit id="kouGbMq" resname="WoordPers: Kinda looks like that other CMS">
+      </segment>
+    </unit>
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Olyan mint az a másik CMS</target>
-      </trans-unit>
-      <trans-unit id="7aLIA3c" resname="caption.dashboard">
+      </segment>
+    </unit>
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.dashboard</source>
         <target>Botl Vezérlőpanel</target>
-      </trans-unit>
-      <trans-unit id="xuNRuUu" resname="caption.translations: messages">
-        <source>caption.translations: messages</source>
-        <target>caption.translations: üzenetek</target>
-      </trans-unit>
-      <trans-unit id="K6TmK4B" resname="caption.clear_cache">
+      </segment>
+    </unit>
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
         <source>caption.clear_cache</source>
         <target>Gyorsítótár törlése</target>
-      </trans-unit>
-      <trans-unit id="RRQ1EJ3" resname="caption.check_database">
-        <source>caption.check_database</source>
-        <target>Adatbázis ellenőrzés</target>
-      </trans-unit>
-      <trans-unit id="cIiIXu_" resname="caption.routing set up">
-        <source>caption.routing set up</source>
-        <target>Útvonal beállítások</target>
-      </trans-unit>
-      <trans-unit id="2RUXD4A" resname="caption.menu_setup">
+      </segment>
+    </unit>
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
         <source>caption.menu_setup</source>
         <target>Menü beállítás</target>
-      </trans-unit>
-      <trans-unit id="drK.0GZ" resname="caption.taxonomies">
+      </segment>
+    </unit>
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
         <source>caption.taxonomies</source>
         <target>Taxonómiák</target>
-      </trans-unit>
-      <trans-unit id="_w7J5rZ" resname="caption.contenttypes">
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
         <source>caption.contenttypes</source>
         <target>Tartalomtípusok</target>
-      </trans-unit>
-      <trans-unit id="kXNBV9S" resname="caption.main_configuration">
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
         <source>caption.main_configuration</source>
         <target>Általános beállítások</target>
-      </trans-unit>
-      <trans-unit id="ipmA6Ah" resname="caption.users_permissions">
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
         <source>caption.users_permissions</source>
         <target>Felhasznlók és jogosultságok</target>
-      </trans-unit>
-      <trans-unit id="zOLL.7E" resname="caption.configuration">
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
         <source>caption.configuration</source>
         <target>Konfiguráció</target>
-      </trans-unit>
-      <trans-unit id="ZO.uqIZ" resname="caption.settings">
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
         <source>caption.settings</source>
         <target>Beállítások</target>
-      </trans-unit>
-      <trans-unit id="1xlE8ex" resname="caption.content">
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
         <source>caption.content</source>
         <target>Tartalom</target>
-      </trans-unit>
-      <trans-unit id="l4yt0BE" resname="caption.file_management">
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.file_management</source>
         <target>Fájlkezelés</target>
-      </trans-unit>
-      <trans-unit id="mfvtHPQ" resname="caption.extensions">
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.extensions</source>
         <target>Bővítmények</target>
-      </trans-unit>
-      <trans-unit id="K4D568R" resname="caption.view_edit_templates">
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
         <source>caption.view_edit_templates</source>
         <target>Sablonok kezelése</target>
-      </trans-unit>
-      <trans-unit id="bq6bSf4" resname="caption.uploaded_files">
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
         <source>caption.uploaded_files</source>
         <target>Feltöltött fájlok</target>
-      </trans-unit>
-      <trans-unit id="wBKDkwl" resname="caption.routing_setup">
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
         <source>caption.routing_setup</source>
         <target>Útvonal beállítások</target>
-      </trans-unit>
-      <trans-unit id="dd5MzCM" resname="caption.translations">
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
         <source>caption.translations</source>
         <target>Fordítások / Cimkék</target>
-      </trans-unit>
-      <trans-unit id="wLaDaK5" resname="caption.about_bolt">
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
         <source>caption.about_bolt</source>
         <target>A Bolt</target>
-      </trans-unit>
-      <trans-unit id="xN1kSQQ" resname="caption.bolt_payoff">
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
         <source>caption.bolt_payoff</source>
         <target>Az ésszerű és egyszerű CMS</target>
-      </trans-unit>
-      <trans-unit id="HK7XTUX" resname="caption.edit">
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
         <source>caption.edit</source>
         <target>Szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="QZYjRy0" resname="caption.file_uploader">
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
         <source>caption.file_uploader</source>
         <target>Fájl feltöltő</target>
-      </trans-unit>
-      <trans-unit id="LaDIuZA" resname="caption.meta_information">
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
         <source>caption.meta_information</source>
         <target>Meta információk</target>
-      </trans-unit>
-      <trans-unit id="DodjLNR" resname="date">
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
         <source>date</source>
         <target>Dátum</target>
-      </trans-unit>
-      <trans-unit id="zNy_hG8" resname="size">
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
         <source>size</source>
         <target>Méret</target>
-      </trans-unit>
-      <trans-unit id="gPYflhh" resname="thumbnail">
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
         <source>thumbnail</source>
         <target>Nézőkép</target>
-      </trans-unit>
-      <trans-unit id="_XSgfqS" resname="filename">
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
         <source>filename</source>
         <target>Fájlnév</target>
-      </trans-unit>
-      <trans-unit id="Kw3N1AA" resname="actions">
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
         <source>actions</source>
         <target>Események</target>
-      </trans-unit>
-      <trans-unit id="KHvGNGW" resname="directoryname">
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
         <source>directoryname</source>
         <target>Könyvtárnév</target>
-      </trans-unit>
-      <trans-unit id="ZV7_x5F" resname="action.go">
-        <source>action.go</source>
-        <target>Hajrá</target>
-      </trans-unit>
-      <trans-unit id="C15MbYY" resname="form.quick_select_file">
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
         <source>form.quick_select_file</source>
         <target>Fájl választás…</target>
-      </trans-unit>
-      <trans-unit id="gFcV5nW" resname="label.quick_select">
-        <source>label.quick_select</source>
-        <target>Gyorskezelő</target>
-      </trans-unit>
-      <trans-unit id="FSroufa" resname="caption.path">
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
         <source>caption.path</source>
         <target>Útvonal</target>
-      </trans-unit>
-      <trans-unit id="y5otxEK" resname="caption.filename">
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
         <source>caption.filename</source>
         <target>Fájlnév</target>
-      </trans-unit>
-      <trans-unit id="XNTbZW6" resname="action.visit_site">
-        <source>action.visit_site</source>
-        <target>Oldal megtekintése</target>
-      </trans-unit>
-      <trans-unit id="KfVJho2" resname="action.create_new">
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
         <source>action.create_new</source>
         <target>Új...</target>
-      </trans-unit>
-      <trans-unit id="b_RPpcB" resname="general.greeting">
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
         <source>general.greeting</source>
         <target>Szia %name%!</target>
-      </trans-unit>
-      <trans-unit id="bmdn3u9" resname="action.logout">
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
         <source>action.logout</source>
         <target>Kijelentkezés</target>
-      </trans-unit>
-      <trans-unit id="zOfpTLD" resname="action.edit_profile">
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
         <source>action.edit_profile</source>
         <target>Profil szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="N_0yRcH" resname="action.close_alert">
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
         <source>action.close_alert</source>
         <target>Bezárás</target>
-      </trans-unit>
-      <trans-unit id="Dvu2HQx" resname="caption.api">
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
         <source>caption.api</source>
         <target>API</target>
-      </trans-unit>
-      <trans-unit id="i4cbdta" resname="caption.all_configuration_files">
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
         <source>caption.all_configuration_files</source>
         <target>Minden konfigurációs fájl</target>
-      </trans-unit>
-      <trans-unit id="OpKTKAL" resname="caption.maintenance">
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
         <source>caption.maintenance</source>
         <target>Karbantartás</target>
-      </trans-unit>
-      <trans-unit id="hGJoUs5" resname="caption.fixtures_dummy_content">
-        <source>caption.fixtures_dummy_content</source>
-        <target>Kitöltés (Minta tartalom)</target>
-      </trans-unit>
-      <trans-unit id="P1FHg3Q" resname="caption.edit_file">
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
         <source>caption.edit_file</source>
         <target>Fájl szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="_ef0RBR" resname="caption.installation_checks">
-        <source>caption.installation_checks</source>
-        <target>Ellenőrzés</target>
-      </trans-unit>
-      <trans-unit id="pNPctrH" resname="form.select_language">
-        <source>form.select_language</source>
-        <target>Nyelv kiválasztás</target>
-      </trans-unit>
-      <trans-unit id="9lJhqvA" resname="field.locale">
-        <source>field.locale</source>
-        <target>Lokalizáció</target>
-      </trans-unit>
-      <trans-unit id="8zEzq8N" resname="field.current_locale">
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
         <source>field.current_locale</source>
         <target>Aktuális lokalizáció</target>
-      </trans-unit>
-      <trans-unit id="ahZvOJz" resname="field.switch_to_locale">
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
         <source>field.switch_to_locale</source>
         <target>Lokalizáció megváltoztatása</target>
-      </trans-unit>
-      <trans-unit id="aQX4Emy" resname="field.author">
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
         <source>field.author</source>
         <target>Szerző</target>
-      </trans-unit>
-      <trans-unit id="UNBaDz." resname="general.phrase.edit">
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
         <source>general.phrase.edit</source>
         <target>Szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="t2TNwOq" resname="Unknown">
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
         <source>Unknown</source>
         <target>Ismeretlen</target>
-      </trans-unit>
-      <trans-unit id="A_d5KPt" resname="general.phrase.written-by-on">
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
         <source>general.phrase.written-by-on</source>
         <target>%name% készítette %date%-n.</target>
-      </trans-unit>
-      <trans-unit id="TVU.FCV" resname="general.phrase.missing-about-page">
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page</source>
         <target>A "Rólunk" oldal hiányzik</target>
-      </trans-unit>
-      <trans-unit id="7iq8jIG" resname="general.phrase.missing-about-page-block">
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>A "Rólunk" blokk hiányzik</target>
-      </trans-unit>
-      <trans-unit id="AGegYAN" resname="contenttypes.generic.recent">
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.recent</source>
         <target>Legutóbbi %contenttypes%</target>
-      </trans-unit>
-      <trans-unit id="gB.9hTu" resname="general.phrase.search-ellipsis">
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
-      </trans-unit>
-      <trans-unit id="wGlnx8X" resname="general.phrase.search">
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
         <source>general.phrase.search</source>
         <target>Keresés</target>
-      </trans-unit>
-      <trans-unit id="z0k8hRg" resname="9fb3e6e">
-        <source>9fb3e6e</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
-      </trans-unit>
-      <trans-unit id="wNEwZy_" resname="contenttypes.generic.overview">
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.overview</source>
         <target>%contenttypes% áttekintő</target>
-      </trans-unit>
-      <trans-unit id="skuzBpI" resname="contenttypes.generic.no-recent">
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Nincs aktuális %contenttype%</target>
-      </trans-unit>
-      <trans-unit id="ma9mBv_" resname="Menu">
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
         <source>Menu</source>
         <target>Menü</target>
-      </trans-unit>
-      <trans-unit id="ScJmuqq" resname="Search">
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
         <source>Search</source>
         <target>Keresés</target>
-      </trans-unit>
-      <trans-unit id="k.xuYv2" resname="general.phrase.permalink">
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
         <source>general.phrase.permalink</source>
-        <target>Permalink</target>
-      </trans-unit>
-      <trans-unit id="zsyp43M" resname="label.displayname">
-        <source>label.displayname</source>
-        <target>Név</target>
-      </trans-unit>
-      <trans-unit id="2MMvCKK" resname="label.cache_cleared">
+        <target>Állandó hivatkozás</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
         <source>label.cache_cleared</source>
         <target>A gyorsítótár törölve!</target>
-      </trans-unit>
-      <trans-unit id="Wou02nK" resname="caption.kitchensink">
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
         <source>caption.kitchensink</source>
         <target>Eszközkészlet</target>
-      </trans-unit>
-      <trans-unit id="wrUiAsV" resname="general.phrase.search-results-for-variable">
-        <source>general.phrase.search-results-for-variable</source>
-        <target>'%search%' találatok.</target>
-        <note>parameters:</note>
-        <note> '%search%': találatok</note>
-      </trans-unit>
-      <trans-unit id="2CfJ3WY" resname="general.phrase.search-results-for">
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
         <source>general.phrase.search-results-for</source>
         <target>'%search%' találatok.</target>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
-      </trans-unit>
-      <trans-unit id="V0VhH5g" resname="general.phrase.no-search-results-for">
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
         <source>general.phrase.no-search-results-for</source>
         <target>Nincsenek '%search%' találatok.</target>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
-      </trans-unit>
-      <trans-unit id="_KyvT9o" resname="general.phrase.no-search-term-provided">
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Kérlek adj meg érvényes kifejezést.</target>
-      </trans-unit>
-      <trans-unit id="Pily_qo" resname="general.phrase.read-more">
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
         <source>general.phrase.read-more</source>
         <target>Tovább</target>
-      </trans-unit>
-      <trans-unit id="psOa_9x" resname="general.phrase.built-with-bolt">
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
-      </trans-unit>
-      <trans-unit id="5IxD63c" resname="general.latest_bolt_news">
+        <target><![CDATA[Ez a weboldal a <a href='https://boltcms.io' target='_blank' title='Kifinomult, könnyű és egyszerű CMS'>Bolt CMS-sel készült</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
         <source>general.latest_bolt_news</source>
         <target>Legfrissebb Bolt hírek</target>
-      </trans-unit>
-      <trans-unit id="dQIY7_J" resname="action.preview">
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
         <source>action.preview</source>
         <target>Előnézet</target>
-      </trans-unit>
-      <trans-unit id="ok6YulQ" resname="action.view_saved">
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
         <source>action.view_saved</source>
         <target>Mentett változat megtekintése</target>
-      </trans-unit>
-      <trans-unit id="SeTqePC" resname="label.display_name">
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
         <source>label.display_name</source>
         <target>Név</target>
-      </trans-unit>
-      <trans-unit id="EvAqL__" resname="caption.duplicate">
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
         <source>caption.duplicate</source>
         <target>Duplikáció</target>
-      </trans-unit>
-      <trans-unit id="pGkejkU" resname="label.current_password">
-        <source>label.current_password</source>
-        <target>Aktuális jelszó</target>
-      </trans-unit>
-      <trans-unit id="iiWFLaI" resname="label.new_password">
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
         <source>label.new_password</source>
         <target>Új jelszó</target>
-      </trans-unit>
-      <trans-unit id="Ucl9Jfc" resname="label.new_password_confirm">
-        <source>label.new_password_confirm</source>
-        <target>Új jelszó (ismét)</target>
-      </trans-unit>
-      <trans-unit id="Iyry5.g" resname="editfile.updated_successfully">
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
         <source>editfile.updated_successfully</source>
         <target>Sikeres frissítés!</target>
-      </trans-unit>
-      <trans-unit id="eq5YMQf" resname="This website is &lt;a href='%url%' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.">
-        <source>This website is &lt;a href='%url%' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
-      </trans-unit>
-      <trans-unit id="3zlZmRK" resname="action.add_user">
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
         <source>action.add_user</source>
         <target>Felhasználó hozzáadása</target>
-      </trans-unit>
-      <trans-unit id="ruQIhH0" resname="success">
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
         <source>success</source>
         <target>Siker!</target>
-      </trans-unit>
-      <trans-unit id="YDH.7uR" resname="user.updated_profile">
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
         <source>user.updated_profile</source>
         <target>A felhasználói profil frissítve!</target>
-      </trans-unit>
-      <trans-unit id="iD6CNOO" resname="label.roles">
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
         <source>label.roles</source>
         <target>Szerepkörök</target>
-      </trans-unit>
-      <trans-unit id="7whLbH8" resname="user.new_user">
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
         <source>user.new_user</source>
         <target>Új felhasználói</target>
-      </trans-unit>
-      <trans-unit id="TtmWqX3" resname="action.view">
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
         <source>action.view</source>
         <target>Megtekintés:</target>
-      </trans-unit>
-      <trans-unit id="PE1dkX_" resname="Uploaded files">
-        <source>Uploaded files</source>
-        <target>Feltöltött fájlok</target>
-      </trans-unit>
-      <trans-unit id="I2ykiIZ" resname="caption.folders">
-        <source>caption.folders</source>
-        <target>Mappák</target>
-      </trans-unit>
-      <trans-unit id="cu3W5DR" resname="image.upload">
-        <source>image.upload</source>
-        <target>Feltöltés</target>
-      </trans-unit>
-      <trans-unit id="nrWBJNm" resname="extensions.title_desc">
-        <source>extensions.title_desc</source>
-        <target>Meghatározás:</target>
-      </trans-unit>
-      <trans-unit id="7raDJAR" resname="extensions.title_author">
-        <source>extensions.title_author</source>
-        <target>Szerző:</target>
-      </trans-unit>
-      <trans-unit id="UP8pNGy" resname="extensions.title_package">
-        <source>extensions.title_package</source>
-        <target>Csomag / Osztály név:</target>
-      </trans-unit>
-      <trans-unit id="QFQ1uTC" resname="extensions.title_version">
-        <source>extensions.title_version</source>
-        <target>Verzió:</target>
-      </trans-unit>
-      <trans-unit id="piuatxC" resname="extensions.info_not_installed">
-        <source>extensions.info_not_installed</source>
-        <target>Ez a csomag lokális, nem Composerrel lett telepítve</target>
-      </trans-unit>
-      <trans-unit id="3j1gEmk" resname="extensions.title_class">
-        <source>extensions.title_class</source>
-        <target>Osztálynév:</target>
-      </trans-unit>
-      <trans-unit id="mjhFljb" resname="extensions.button_configuration">
-        <source>extensions.button_configuration</source>
-        <target>Konfiguráció</target>
-      </trans-unit>
-      <trans-unit id="r3ryNTG" resname="extensions.button_source">
-        <source>extensions.button_source</source>
-        <target>Forrás</target>
-      </trans-unit>
-      <trans-unit id="7JK6jNv" resname="extensions.message_not_implemented">
-        <source>extensions.message_not_implemented</source>
-        <target>Sajnos még nincs implementálva!</target>
-      </trans-unit>
-      <trans-unit id="qc3rFkZ" resname="extensions.button_remove">
-        <source>extensions.button_remove</source>
-        <target>Bővítmény törlése</target>
-      </trans-unit>
-      <trans-unit id="SLZyVzU" resname="extensions.button_disable">
-        <source>extensions.button_disable</source>
-        <target>Bővítmény tiltása</target>
-      </trans-unit>
-      <trans-unit id="z2AgHGp" resname="flash_messages.notification">
-        <source>flash_messages.notification</source>
-        <target>Értesítés</target>
-      </trans-unit>
-      <trans-unit id="pcq1NGk" resname="listing_filter.button_compact">
-        <source>listing_filter.button_compact</source>
-        <target>Becsuk</target>
-      </trans-unit>
-      <trans-unit id="xIztVmp" resname="listing_filter.button_expanded">
-        <source>listing_filter.button_expanded</source>
-        <target>Kinyit</target>
-      </trans-unit>
-      <trans-unit id="L0TE0M9" resname="listing_table.actions.view_on_site">
-        <source>listing_table.actions.view_on_site</source>
-        <target>Megtekintés az Oldalon</target>
-      </trans-unit>
-      <trans-unit id="PoauAuK" resname="listing_table.actions.status_to_publish">
-        <source>listing_table.actions.status_to_publish</source>
-        <target>'publikált' státusz beállítása</target>
-      </trans-unit>
-      <trans-unit id="ZJxfdD6" resname="listing_table.actions.status_to_held">
-        <source>listing_table.actions.status_to_held</source>
-        <target>'visszavont' státusz beállítása</target>
-      </trans-unit>
-      <trans-unit id="apyOs0o" resname="listing_table.actions.status_to_draft">
-        <source>listing_table.actions.status_to_draft</source>
-        <target>'vázlat' státusz beállítása</target>
-      </trans-unit>
-      <trans-unit id="5H60Xq6" resname="listing_table.actions.duplicate">
-        <source>listing_table.actions.duplicate</source>
-        <target>Duplikálás</target>
-      </trans-unit>
-      <trans-unit id="hR8ri.m" resname="listing_table.actions.delete">
-        <source>listing_table.actions.delete</source>
-        <target>Törlés</target>
-      </trans-unit>
-      <trans-unit id="5zbX1vo" resname="listing_table.actions.slug">
-        <source>listing_table.actions.slug</source>
-        <target>Slug</target>
-      </trans-unit>
-      <trans-unit id="wKDOBOC" resname="listing_table.actions.created_on">
-        <source>listing_table.actions.created_on</source>
-        <target>Létrehozva: </target>
-      </trans-unit>
-      <trans-unit id="tVX01Xl" resname="listing_table.actions.published_on">
-        <source>listing_table.actions.published_on</source>
-        <target>Publikálva: </target>
-      </trans-unit>
-      <trans-unit id="kHkjS5U" resname="listing_table.actions.last_modified_on">
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Módosítva: </target>
-      </trans-unit>
-      <trans-unit id="zg5Dum5" resname="geolocation.label_geolocation">
-        <source>geolocation.label_geolocation</source>
-        <target>Geolokáció</target>
-      </trans-unit>
-      <trans-unit id="Com0pbc" resname="geolocation.label_address">
-        <source>geolocation.label_address</source>
-        <target>Cím keresés</target>
-      </trans-unit>
-      <trans-unit id="3o0LPHj" resname="geolocation.placeholder_address">
-        <source>geolocation.placeholder_address</source>
-        <target>Utca, irányítószám, város vagy helyszín…</target>
-      </trans-unit>
-      <trans-unit id="CC5QTmy" resname="geolocation.label_lat">
-        <source>geolocation.label_lat</source>
-        <target>Szélesség</target>
-      </trans-unit>
-      <trans-unit id="AHaenW3" resname="geolocation.label_long">
-        <source>geolocation.label_long</source>
-        <target>Hosszúság</target>
-      </trans-unit>
-      <trans-unit id="MJ5WYEM" resname="geolocation.label_address_matched">
-        <source>geolocation.label_address_matched</source>
-        <target>A pontos cím</target>
-      </trans-unit>
-      <trans-unit id="WJGjWG8" resname="geolocation.label_marker">
-        <source>geolocation.label_marker</source>
-        <target>Megjelölés</target>
-      </trans-unit>
-      <trans-unit id="SaP3OOf" resname="geolocation.label_control">
-        <source>geolocation.label_control</source>
-        <target>A legközelebbi címhez igazítás</target>
-      </trans-unit>
-      <trans-unit id="VQ2t655" resname="file.label_filename">
-        <source>file.label_filename</source>
-        <target>Fájlnév</target>
-      </trans-unit>
-      <trans-unit id="TJDc9vQ" resname="file.label_alt">
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </trans-unit>
-      <trans-unit id="tvpSmD7" resname="file.label_title">
-        <source>file.label_title</source>
-        <target>Cím</target>
-      </trans-unit>
-      <trans-unit id="hXT_hI." resname="file.button_view">
-        <source>file.button_view</source>
-        <target>Kép megtekintés</target>
-      </trans-unit>
-      <trans-unit id="QKIqqOw" resname="file.button_upload">
-        <source>file.button_upload</source>
-        <target>Feltöltés</target>
-      </trans-unit>
-      <trans-unit id="4_JdYp1" resname="file.remark">
-        <source>file.remark</source>
-        <target><![CDATA[Mejegyzés: Ez a mező ugyanaz mint az <code>image</code> mező.]]></target>
-      </trans-unit>
-      <trans-unit id="kHeY93_" resname="editor_embed.content_url">
-        <source>editor_embed.content_url</source>
-        <target>A beágyazott tartalom URL</target>
-      </trans-unit>
-      <trans-unit id="VoIdmBa" resname="editor_embed.placeholder_content_url">
-        <source>editor_embed.placeholder_content_url</source>
-        <target>Facebook, Twitter, Soundcloud, Youtube, stb. tartalom URL-je</target>
-      </trans-unit>
-      <trans-unit id="1.Eb1GS" resname="editor_embed.label_height">
-        <source>editor_embed.label_height</source>
-        <target>Magasság</target>
-      </trans-unit>
-      <trans-unit id="eWLSFJs" resname="editor_embed.label_pixel">
-        <source>editor_embed.label_pixel</source>
-        <target>képpont</target>
-      </trans-unit>
-      <trans-unit id="EAtXrAm" resname="editor_embed.label_matched_embed">
-        <source>editor_embed.label_matched_embed</source>
-        <target>Egyező beágyazás</target>
-      </trans-unit>
-      <trans-unit id="zATju4V" resname="editor_embed.label_preview">
-        <source>editor_embed.label_preview</source>
-        <target>Előnézet</target>
-      </trans-unit>
-      <trans-unit id="9SQ0oaR" resname="editor_embed.label_size">
-        <source>editor_embed.label_size</source>
-        <target>Méret</target>
-      </trans-unit>
-      <trans-unit id="BINgtmK" resname="editor_date.toggle">
-        <source>editor_date.toggle</source>
-        <target>Átváltás</target>
-      </trans-unit>
-      <trans-unit id="M.3olSc" resname="filelist.remark">
-        <source>filelist.remark</source>
-        <target><![CDATA[Megjegyzés: Ez a mező ugyanaz mint az <code>imagelist</code> mező.]]></target>
-      </trans-unit>
-      <trans-unit id="vptPhch" resname="image.button_upload">
-        <source>image.button_upload</source>
-        <target>Kép feltöltése</target>
-      </trans-unit>
-      <trans-unit id="vIVO1lU" resname="image.button_from_library">
-        <source>image.button_from_library</source>
-        <target>Képtárból</target>
-      </trans-unit>
-      <trans-unit id="oOuVKRv" resname="image.placeholder_filename">
-        <source>image.placeholder_filename</source>
-        <target>Filename</target>
-      </trans-unit>
-      <trans-unit id="BWubOnS" resname="image.placeholder_alt_text">
-        <source>image.placeholder_alt_text</source>
-        <target>Alt text</target>
-      </trans-unit>
-      <trans-unit id="VPV0lFM" resname="image.placeholder_title">
-        <source>image.placeholder_title</source>
-        <target>Cím</target>
-      </trans-unit>
-      <trans-unit id="kaK5Wdr" resname="slug.button_locked">
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
         <source>slug.button_locked</source>
         <target>Zárolt</target>
-      </trans-unit>
-      <trans-unit id="qcDEz5O" resname="slug.button_edit">
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
         <source>slug.button_edit</source>
         <target>Szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="raO5QSf" resname="slug.generate_from">
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
         <source>slug.generate_from</source>
         <target>Generálás…</target>
-      </trans-unit>
-      <trans-unit id="TkryUve" resname="imagelist.remark">
-        <source>imagelist.remark</source>
-        <target>__imagelist.remark</target>
-      </trans-unit>
-      <trans-unit id="v6cfPyt" resname="quickselect.title_select">
-        <source>quickselect.title_select</source>
-        <target>__quickselect.title_select</target>
-      </trans-unit>
-      <trans-unit id=".fL0AbE" resname="files_list.remark">
-        <source>files_list.remark</source>
-        <target><![CDATA[Megjegyzés: Ez a mező megegyezik a <code>filelist</code> mezővel.]]></target>
-      </trans-unit>
-      <trans-unit id="m3tNvJb" resname="finder.button_list">
-        <source>finder.button_list</source>
-        <target>Lista</target>
-      </trans-unit>
-      <trans-unit id="tRLgeoX" resname="finder.button_cards">
-        <source>finder.button_cards</source>
-        <target>Mátrix</target>
-      </trans-unit>
-      <trans-unit id="QQvRJe." resname="files_cards.button_toggle">
-        <source>files_cards.button_toggle</source>
-        <target>Legördülő átkapcsolása</target>
-      </trans-unit>
-      <trans-unit id="gtC_ujD" resname="files_cards.action_edit_image_info">
-        <source>files_cards.action_edit_image_info</source>
-        <target>Kép infó szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="5LXvJfE" resname="files_cards.action_edit_file">
-        <source>files_cards.action_edit_file</source>
-        <target>Fájl szerkesztése editorban</target>
-      </trans-unit>
-      <trans-unit id="H1pgP94" resname="files_cards.action_view_original">
-        <source>files_cards.action_view_original</source>
-        <target>Eredeti megtekintése</target>
-      </trans-unit>
-      <trans-unit id="ZoY6ADX" resname="files_cards.action_duplicate">
-        <source>files_cards.action_duplicate</source>
-        <target>Duplikáció</target>
-      </trans-unit>
-      <trans-unit id="JjU6ZQP" resname="files_cards.action_delete">
-        <source>files_cards.action_delete</source>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Kép feltöltése</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Képtárból</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Megtekintés az Oldalon</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>'publikált' státusz beállítása</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>'visszavont' státusz beállítása</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>'vázlat' státusz beállítása</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Duplikálás</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
         <target>Törlés</target>
-      </trans-unit>
-      <trans-unit id="3jdNwuk" resname="files_cards.label_filename">
-        <source>files_cards.label_filename</source>
-        <target>Fájlnév:</target>
-      </trans-unit>
-      <trans-unit id="Y90_Pn1" resname="files_cards.label_title">
-        <source>files_cards.label_title</source>
-        <target>Cím:</target>
-      </trans-unit>
-      <trans-unit id="EdCfIKX" resname="files_cards.label_dimensions">
-        <source>files_cards.label_dimensions</source>
-        <target>Dimenziók:</target>
-      </trans-unit>
-      <trans-unit id="eQBhceV" resname="files_cards.label_filesize">
-        <source>files_cards.label_filesize</source>
-        <target>Méret:</target>
-      </trans-unit>
-      <trans-unit id="uiCjlwk" resname="files_cards.label_created_on">
-        <source>files_cards.label_created_on</source>
-        <target>Létrehozva:</target>
-      </trans-unit>
-      <trans-unit id="8JeahIj" resname="files_cards.message_no_files">
-        <source>files_cards.message_no_files</source>
-        <target>Nincs fájl ebben a mappában. Jobboldalon válassz ki egy mappát!</target>
-      </trans-unit>
-      <trans-unit id="beqzCkE" resname="login.header_login">
-        <source>login.header_login</source>
-        <target>Bejelentkezés</target>
-      </trans-unit>
-      <trans-unit id="37kJiIe" resname="view_locales.badge_default">
-        <source>view_locales.badge_default</source>
-        <target>Alapértelmezett</target>
-      </trans-unit>
-      <trans-unit id="JTRCo_U" resname="view_locales.badge_ok">
-        <source>view_locales.badge_ok</source>
-        <target>OK</target>
-      </trans-unit>
-      <trans-unit id="ufFUPp7" resname="view_locales.badge_missing">
-        <source>view_locales.badge_missing</source>
-        <target>Hiányzó</target>
-      </trans-unit>
-      <trans-unit id="ypPzS03" resname="localeswitcher.button_info">
-        <source>localeswitcher.button_info</source>
-        <target>Lokalizáció megtekintése</target>
-      </trans-unit>
-      <trans-unit id="qQKx1lR" resname="buttons.button_toggle">
-        <source>buttons.button_toggle</source>
-        <target>Átkapcsolás</target>
-      </trans-unit>
-      <trans-unit id="Hlf9c1s" resname="listing.title_overview">
-        <source>listing.title_overview</source>
-        <target>Áttekintő</target>
-      </trans-unit>
-      <trans-unit id="BdhsE_X" resname="listing_select_box.card_header.selected">
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Létrehozva: </target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Publikálva: </target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Módosítva: </target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Kijelölve</target>
-      </trans-unit>
-      <trans-unit id="jBpmj90" resname="listing_select_box.card_body.records_passed">
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>a kijelölt rekord ID-ken végrehajtva</target>
-      </trans-unit>
-      <trans-unit id="D8vDkhK" resname="listing_select_box.card_body.remark">
-        <source>listing_select_box.card_body.remark</source>
-        <target>(ezek egyfajta "Axion" tömeges törlés/módosítással dolgozhatók fel)</target>
-      </trans-unit>
-      <trans-unit id="wQ0WYAT" resname="listing.title_sortby">
-        <source>listing.title_sortby</source>
-        <target>Rendezés</target>
-      </trans-unit>
-      <trans-unit id="ZGv90X8" resname="listing.option_select_item">
-        <source>listing.option_select_item</source>
-        <target>Elem kiválasztás</target>
-      </trans-unit>
-      <trans-unit id="TIyjgb6" resname="listing.title_title">
-        <source>listing.title_title</source>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>A beágyazott tartalom URL</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>Facebook, Twitter, Soundcloud, Youtube, stb. tartalom URL-je</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Magasság</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>képpont</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Egyező beágyazás</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Előnézet</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Méret</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Fájlnév (töltsön fel új fájlt, vagy válasszon egy meglévőt)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Alt text</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
         <target>Cím</target>
-      </trans-unit>
-      <trans-unit id="pn22p7q" resname="listing.placeholder_filter">
-        <source>listing.placeholder_filter</source>
-        <target>Kulcsszó…</target>
-      </trans-unit>
-      <trans-unit id="ni4zApC" resname="listing.button_filter">
-        <source>listing.button_filter</source>
-        <target>Szűrő</target>
-      </trans-unit>
-      <trans-unit id="doNsgm0" resname="listing.button_clear">
-        <source>listing.button_clear</source>
-        <target>Szűrés/Rendezés törlése</target>
-      </trans-unit>
-      <trans-unit id="jXAelLe" resname="admin_sidebar_toggler.toggle">
-        <source>admin_sidebar_toggler.toggle</source>
-        <target>Menü átkapcsolás</target>
-      </trans-unit>
-      <trans-unit id="Gabafxx" resname="admin_sidebar.toggler">
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
         <source>admin_sidebar.toggler</source>
         <target>Oldalpanel szélesség átkapcsolás</target>
-      </trans-unit>
-      <trans-unit id="73A2bWM" resname="finder.label_view">
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Váltás </span>menü]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Átváltás</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Értesítés</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Lokalizáció megtekintése</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Rendezés</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Kulcsszó…</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Szűrő</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Szűrés/Rendezés törlése</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Alapértelmezett</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Hiányzó</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Legördülő átkapcsolása</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Kép infó szerkesztés</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Fájl szerkesztése editorban</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Eredeti megtekintése</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Duplikáció</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Törlés</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Fájlnév:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Cím:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Dimenziók:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Méret:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Létrehozva:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Ebben a mappában nincsenek fájlok. Válasszon egy mappát a navigáláshoz.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>__quickselect.title_select</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Lista</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Mátrix</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Meghatározás:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Szerző:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Csomag / Osztály név:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Verzió:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Ez a csomag lokális, nem Composerrel lett telepítve</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Osztálynév:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Konfiguráció</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Forrás</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Bővítmény törlése</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Bővítmény tiltása</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bejelentkezés</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Sajnos még nincs implementálva!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Áttekintő</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>Nincs fájl ebben a mappában. Jobboldalon válassz ki egy mappát!</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Becsuk</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Kinyit</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
         <source>finder.label_view</source>
         <target>Elrendezés:</target>
-      </trans-unit>
-      <trans-unit id="Em.C0bV" resname="listing_table.actions.button_edit">
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="Iy4HXCU" resname="controller.user.title">
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
         <source>controller.user.title</source>
         <target>Felhasznlók és engedélyek</target>
-      </trans-unit>
-      <trans-unit id="HBwIQ9b" resname="controller.user.subtitle">
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
         <source>controller.user.subtitle</source>
         <target>Felhasználók és engedélyeik szerkesztése</target>
-      </trans-unit>
-      <trans-unit id="0Gyf5xr" resname="controller.database.check_title">
-        <source>controller.database.check_title</source>
-        <target>Adatbázis ellenőrzése</target>
-      </trans-unit>
-      <trans-unit id="SeDwjX6" resname="controller.database.check_subtitle">
-        <source>controller.database.check_subtitle</source>
-        <target>Az adatbázis vizsgálata</target>
-      </trans-unit>
-      <trans-unit id="nJnALPG" resname="controller.database.update_title">
-        <source>controller.database.update_title</source>
-        <target>Adatbázis frissítés</target>
-      </trans-unit>
-      <trans-unit id="nRE74_i" resname="controller.database.update_subtitle">
-        <source>controller.database.update_subtitle</source>
-        <target>Változás esetén történő frissítés</target>
-      </trans-unit>
-      <trans-unit id="a3UNsKw" resname="controller.omnisearch.title">
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </trans-unit>
-      <trans-unit id="4N41oTU" resname="controller.omnisearch.subtitle">
-        <source>controller.omnisearch.subtitle</source>
-        <target>Keresés mélytartalomban, részletekben</target>
-      </trans-unit>
-      <trans-unit id="7cXqH5s" resname="listing.title_display_name">
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
         <source>listing.title_display_name</source>
         <target>Megjelenített név</target>
-      </trans-unit>
-      <trans-unit id="Ay7xZ2h" resname="listing.title_username">
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
         <source>listing.title_username</source>
         <target>Felhasználónév</target>
-      </trans-unit>
-      <trans-unit id="RN1tdtJ" resname="listing.title_email">
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
         <source>listing.title_email</source>
-        <target>Email</target>
-      </trans-unit>
-      <trans-unit id="0pjZ.GV" resname="listing.title_roles">
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
         <source>listing.title_roles</source>
         <target>Szerepkörök</target>
-      </trans-unit>
-      <trans-unit id="hXEFV1n" resname="listing.title_last_seen">
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
         <source>listing.title_last_seen</source>
         <target>Utolsó bejelentkezés</target>
-      </trans-unit>
-      <trans-unit id="pn7kE17" resname="listing.title_last_ip">
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
         <source>listing.title_last_ip</source>
         <target>Utolsó IP</target>
-      </trans-unit>
-      <trans-unit id="GZ65uOC" resname="listing.title_actions">
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
         <source>listing.title_actions</source>
         <target>Műveletek</target>
-      </trans-unit>
-      <trans-unit id="fkXL.k6" resname="user.not_valid_email">
-        <source>user.not_valid_email</source>
-        <target>Érvénytelen email cím</target>
-      </trans-unit>
-      <trans-unit id="HjWW.NS" resname="user.not_valid_password">
-        <source>user.not_valid_password</source>
-        <target>Érvénytelen jelszó</target>
-      </trans-unit>
-      <trans-unit id="rCKtTo5" resname="caption.redirection_page">
-        <source>caption.redirection_page</source>
-        <target>Átirányítási oldal</target>
-      </trans-unit>
-      <trans-unit id="QVRwwK4" resname="about.system_info">
-        <source>about.system_info</source>
-        <target>Rendszer információ</target>
-      </trans-unit>
-      <trans-unit id="munFS0n" resname="title.filtered_by">
-        <source>title.filtered_by</source>
-        <target><![CDATA[A <em>'%szűrő%'-vel szűrt tartalom</em>.]]></target>
-      </trans-unit>
-      <trans-unit id="hgNZLwW" resname="extensions.title_configuration">
-        <source>extensions.title_configuration</source>
-        <target>Konfigurációs fájl</target>
-      </trans-unit>
-      <trans-unit id="LfwezhR" resname="extensions.title_dependencies">
-        <source>extensions.title_dependencies</source>
-        <target>Függőségek</target>
-      </trans-unit>
-      <trans-unit id="60xy4WG" resname="extensions.no_dependencies">
-        <source>extensions.no_dependencies</source>
-        <target>Nincsenek ismert függőségek</target>
-      </trans-unit>
-      <trans-unit id="2MtT_h0" resname="caption.logviewer">
-        <source>caption.logviewer</source>
-        <target>Napló</target>
-      </trans-unit>
-      <trans-unit id="BFARQEU" resname="extensions.button_detailed_view">
-        <source>extensions.button_detailed_view</source>
-        <target>Részletek</target>
-      </trans-unit>
-      <trans-unit id="YZJO3Ul" resname="upload.allow_file_types">
-        <source>upload.allow_file_types</source>
-        <target>Feltöltéshez engedélyezett fájlok</target>
-      </trans-unit>
-      <trans-unit id="noOf4ML" resname="upload.max_size">
-        <source>upload.max_size</source>
-        <target>Feltölthető méret</target>
-      </trans-unit>
-      <trans-unit id="FqVh1Hv" resname="image.button_remove">
-        <source>image.button_remove</source>
-        <target>Eltávolítás</target>
-      </trans-unit>
-      <trans-unit id="eHV6ZJB" resname="image.button_edit_attributes">
-        <source>image.button_edit_attributes</source>
-        <target>Attributumok szerkesztése</target>
-      </trans-unit>
-      <trans-unit id="ApPu4P_" resname="collection.move_item_up">
-        <source>collection.move_item_up</source>
-        <target>Mozgatás felfelé</target>
-      </trans-unit>
-      <trans-unit id="KzBtfHi" resname="collection.move_item_down">
-        <source>collection.move_item_down</source>
-        <target>Mozgatás lefelé</target>
-      </trans-unit>
-      <trans-unit id="JpJFIFq" resname="collection.confirm_delete">
-        <source>collection.confirm_delete</source>
-        <target>Biztos hogy törölni kívánod ezt az tételt?</target>
-      </trans-unit>
-      <trans-unit id=".t1ICS7" resname="collection.remove_item">
-        <source>collection.remove_item</source>
-        <target>Tétel eltávolítása</target>
-      </trans-unit>
-      <trans-unit id="0C9.Vmh" resname="collection.add_item">
-        <source>collection.add_item</source>
-        <target>Tétel hozzáadása</target>
-      </trans-unit>
-      <trans-unit id="H9knE.O" resname="collection.expand_all">
-        <source>collection.expand_all</source>
-        <target>Összes kibontása</target>
-      </trans-unit>
-      <trans-unit id="JjvI6hp" resname="collection.collapse_all">
-        <source>collection.collapse_all</source>
-        <target>Összes becsukása</target>
-      </trans-unit>
-      <trans-unit id="RBJ0NMl" resname="collection.select">
-        <source>collection.select</source>
-        <target>Kijelölés…</target>
-      </trans-unit>
-      <trans-unit id="7aSD0Qr" resname="image.button_up">
-        <source>image.button_up</source>
-        <target>Fel</target>
-      </trans-unit>
-      <trans-unit id="WihD8Y5" resname="image.button_down">
-        <source>image.button_down</source>
-        <target>Le</target>
-      </trans-unit>
-      <trans-unit id="8Q4FxVw" resname="file.add_new_file">
-        <source>file.add_new_file</source>
-        <target>Új fájl hozzáadás</target>
-      </trans-unit>
-      <trans-unit id="XQ2U6fN" resname="slug.button_unlocked">
-        <source>slug.button_unlocked</source>
-        <target>Feloldva</target>
-      </trans-unit>
-      <trans-unit id="Oj2UZ5J" resname="image.add_new_image">
-        <source>image.add_new_image</source>
-        <target>Új kép hozzáadása</target>
-      </trans-unit>
-      <trans-unit id="283aB_E" resname="caption.file_upload.upload_text">
-        <source>caption.file_upload.upload_text</source>
-        <target>Húzd ide a feltölteni kívánt fájlt</target>
-      </trans-unit>
-      <trans-unit id="wHPoBzP" resname="file.delete_confirm">
-        <source>file.delete_confirm</source>
-        <target>Biztos törölni szeretnéd ezt a fájlt?</target>
-      </trans-unit>
-      <trans-unit id="z_tOHwq" resname="placeholder.username_or_email">
-        <source>placeholder.username_or_email</source>
-        <target>felhasználónév vagy email</target>
-      </trans-unit>
-      <trans-unit id="xgYhRkc" resname="placeholder.password">
-        <source>placeholder.password</source>
-        <target>jelszó</target>
-      </trans-unit>
-      <trans-unit id="SGlj7K2" resname="view_locales.badge_empty">
-        <source>view_locales.badge_empty</source>
-        <target>Üres</target>
-      </trans-unit>
-      <trans-unit id="pXtciRI" resname="content.edit_missing_definition">
-        <source>content.edit_missing_definition</source>
-        <target>A Tartalom Típus definíciója hiányzik! A rekordot nem lehet majd megfelelően szerkeszteni. Kérlek ellenőrizd a contenttypes.yaml fájlt, hogy az tartalmazza-e a %contenttype%-t!</target>
-      </trans-unit>
-      <trans-unit id="JEnqOi." resname="title.primary_actions">
-        <source>title.primary_actions</source>
-        <target>Elsődleges műveletek</target>
-      </trans-unit>
-      <trans-unit id="7616Os4" resname="title.options">
-        <source>title.options</source>
-        <target>Opciók</target>
-      </trans-unit>
-      <trans-unit id="6Gw1lsE" resname="action.confirm_delete">
-        <source>action.confirm_delete</source>
-        <target>Biztos törölni kívánod ezt a tartalmat?</target>
-      </trans-unit>
-      <trans-unit id="hTKWQ6g" resname="action.delete">
-        <source>action.delete</source>
-        <target>Törlés</target>
-      </trans-unit>
-      <trans-unit id="WeJxw6Z" resname="action.update_all">
-        <source>action.update_all</source>
-        <target>Alkalmazás mindre</target>
-      </trans-unit>
-      <trans-unit id="hp554Ds" resname="listing.option_select_sortby">
-        <source>listing.option_select_sortby</source>
-        <target>Rendezés mezőre…</target>
-      </trans-unit>
-      <trans-unit id="IWbf2by" resname="listing.title_filterby">
-        <source>listing.title_filterby</source>
-        <target>Keresés / szűrés</target>
-      </trans-unit>
-      <trans-unit id="n.3JZvX" resname="title.contentType">
-        <source>title.contentType</source>
-        <target>Tartalomtípus</target>
-      </trans-unit>
-      <trans-unit id="Dgtkgju" resname="title.edit_user_profile">
-        <source>title.edit_user_profile</source>
-        <target>Profil szerkesztés</target>
-      </trans-unit>
-      <trans-unit id="Npkio79" resname="listing.title_session_expires">
-        <source>listing.title_session_expires</source>
-        <target>A munkafolyamat lejár</target>
-      </trans-unit>
-      <trans-unit id="mmUDcto" resname="listing.title_ip_address">
-        <source>listing.title_ip_address</source>
-        <target>IP cím</target>
-      </trans-unit>
-      <trans-unit id="x9qAwrz" resname="listing.title_browser">
-        <source>listing.title_browser</source>
-        <target>Böngésző / platform</target>
-      </trans-unit>
-      <trans-unit id="AMxTho9" resname="pager.previous">
-        <source>pager.previous</source>
-        <target>Előző</target>
-      </trans-unit>
-      <trans-unit id="L_YQKUn" resname="pager.next">
-        <source>pager.next</source>
-        <target>Következő</target>
-      </trans-unit>
-      <trans-unit id="O_m7mx1" resname="listing.placeholder_search">
-        <source>listing.placeholder_search</source>
-        <target>Kulcsszó keresése…</target>
-      </trans-unit>
-      <trans-unit id="f.rvF6y" resname="action.new">
-        <source>action.new</source>
-        <target>Új</target>
-      </trans-unit>
-      <trans-unit id="TtIlBDd" resname="caption.edit_image">
-        <source>caption.edit_image</source>
-        <target>Kép szerkesztése</target>
-      </trans-unit>
-      <trans-unit id="fLOd6Zd" resname="field.cropX">
-        <source>field.cropX</source>
-        <target>Kivágás (X)</target>
-      </trans-unit>
-      <trans-unit id="Sd_AbmV" resname="field.cropXPostfix">
-        <source>field.cropXPostfix</source>
-        <target>A kivágás pozíciója X tengelyen (0-100)</target>
-      </trans-unit>
-      <trans-unit id="hi98HIj" resname="field.cropY">
-        <source>field.cropY</source>
-        <target>Kivágás (Y)</target>
-      </trans-unit>
-      <trans-unit id="BQBmQHT" resname="field.cropYPostfix">
-        <source>field.cropYPostfix</source>
-        <target>A kivágás pozíciója Y tengelyen (0-100)</target>
-      </trans-unit>
-      <trans-unit id="PHOpD5y" resname="field.cropZoom">
-        <source>field.cropZoom</source>
-        <target>Kivágás nagyítás</target>
-      </trans-unit>
-      <trans-unit id="tn6Z8wY" resname="field.cropZoomPostfix">
-        <source>field.cropZoomPostfix</source>
-        <target>A kivágás nagyításának mértéke (1-10)</target>
-      </trans-unit>
-      <trans-unit id="EaqUUfe" resname="label.predominant_colors__in_image">
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Ismeretlen felhasználó</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
         <source>label.predominant_colors__in_image</source>
         <target>A kép meghatározó színei</target>
-      </trans-unit>
-      <trans-unit id="KshyLfh" resname="caption.other_content">
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Áttekintés a következőhöz: '%slug%'</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Kapcsolódó tartalom</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Keresés</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Új %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>Névtelen %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Profil szerkesztés</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Átirányítási oldal</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Kép szerkesztése</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Javasolt biztonságos jelszó: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Kivágás (X)</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>A kivágás pozíciója X tengelyen (0-100)</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>A kivágás pozíciója Y tengelyen (0-100)</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Kivágás (Y)</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Kivágás nagyítás</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>A kivágás nagyításának mértéke (1-10)</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Tartalomtípus</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Nincs találat. Bővítse a szűrési feltételeket, vagy adjon hozzá további tartalmat.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Rendezés mezőre…</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Elsődleges műveletek</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opciók</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Törlés</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Engedélyezés</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Letiltás</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>A munkafolyamat lejár</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>IP cím</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Böngésző / platform</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Eltávolítás</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Attributumok szerkesztése</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Új kép hozzáadása</target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Új fájl hozzáadás</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Tétel eltávolítása</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Új elem hozzáadása ehhez: '%name%'</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Mozgatás felfelé</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Mozgatás lefelé</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Részletek</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Konfigurációs fájl</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Húzd ide a feltölteni kívánt fájlt</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Következő</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Előző</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Fel</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Le</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Letöltés</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Napló</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Kérés</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Nyomkövetés</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Kontextus</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Szint</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Üzenet</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Időbélyeg</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Felhasználó</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Letiltva</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Feloldva</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Nem található tartalom</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Nincs</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Üres</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Alkalmazás mindre</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Rendszer információ</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Biztos törölni kívánod ezt a tartalmat?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>felhasználónév vagy email</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>jelszó</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
         <source>caption.other_content</source>
         <target>Egyéb tartalom</target>
-      </trans-unit>
-    </body>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>A mentés le van tiltva, mert a célfájl nem írható.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Ez a mező lefordítható</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Tartalom</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>A fájl sikeresen törölve!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Biztos törölni szeretnéd ezt a fájlt?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Keresés / szűrés</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Az állapot sikeresen megváltozott</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>A tartalom sikeresen törölve</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Jelenlegi állapot</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Közzétéve</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Piszkozat</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Időzített</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Visszatartva</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Biztos hogy törölni kívánod ezt az tételt?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Feltöltéshez engedélyezett fájlok</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Feltölthető méret</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Kulcsszó keresése…</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[A <em>'%filter%'</em> szerint szűrt tartalom.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Weboldal megtekintése</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Új</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Nincsenek ismert függőségek</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Függőségek</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Összes kibontása</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Összes becsukása</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>A Tartalom Típus definíciója hiányzik! A rekordot nem lehet majd megfelelően szerkeszteni. Kérlek ellenőrizd a contenttypes.yaml fájlt, hogy az tartalmazza-e a %contenttype%-t!</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Kijelölés…</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Kérjük, adja meg felhasználónevét vagy e-mail-címét</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Kérjük, adja meg jelszavát</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Kérjük, adja meg e-mail-címét</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Szűrés mező szerint</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>URL-ből</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Fájlhivatkozás másolása</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Figyelmeztetés</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>A mappa már létezik</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Nem sikerült létrehozni a mappát</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>A mappa sikeresen létrehozva.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>A mappa sikeresen törölve</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Új mappa</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatár</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Elfelejtett jelszó</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Jelszó visszaállítása</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Adja meg e-mail-címét, és küldünk egy hivatkozást a jelszava visszaállításához.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Küldés</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Vissza a bejelentkezéshez</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Jelszó visszaállítása</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Jelszó-visszaállító e-mail elküldve</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Küldtünk egy e-mailt, amely tartalmaz egy hivatkozást, amelyre kattintva visszaállíthatja jelszavát. Ez a hivatkozás %hours% óra múlva lejár.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Ha nem kap e-mailt, ellenőrizze a levélszemét mappát, vagy %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Jelszó visszaállítása</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Üdvözöljük!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Jelszava visszaállításához látogasson el a következő hivatkozásra</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Ez a hivatkozás %hours% óra múlva lejár.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Köszönjük!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Kérjük, adjon meg egy jelszót</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Jelszó megismétlése</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>A jelszómezőknek egyezniük kell.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Jelszavának legalább %s karakter hosszúnak kell lennie</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Nem található jelszó-visszaállító token az URL-ben vagy a munkamenetben.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Jelszava sikeresen visszaállítva.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Hiba történt a jelszó-visszaállítási kérés feldolgozása során - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>Szűrve a következő szerint</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Biztonságos előnézeti hivatkozás megosztása</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Megszemélyesítés leállítása</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Megszemélyesítés</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>A karbantartási mód aktiválva van</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Frissítés</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>%total% rekordból %current% megjelenítése</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Név: %name% (egyes szám: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (egyes szám: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Rekordsablon: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Listasablon: %template% (%listingRecords% rekord)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Nyelvek: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Jogosultságok szerkesztése</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Keresés</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Kép előnézete</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Összes kijelölése</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Emlékezzen rám? (%duration% nap)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Aktuális munkamenetek</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Feltöltési beállítások</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Sorrend</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>az Ön e-mail-címe</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Válasszon egy fájlt</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Válasszon egy képet</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Feltöltés URL-ből</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Betöltés...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Mentés</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Bezárás</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="it">
   <file id="messages.it">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Non disponibile</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Errore %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>Si è verificato un errore sconosciuto (HTTP %status_code%) che ha impedito il completamento della vostra richiesta.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Ricaricare la pagina fra qualche minuto oppure <a href="%url%">tornare all'homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>Non si dispone dei permessi per accedere a questa risorsa.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Rivolgersi all'amministratore di sistema per ottenere l'accesso a questa risorsa.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>Impossibile trovare la pagina richiesta.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Controllare l'esattezza dell'URL oppure <a href="%url%">tornare all'homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>Si è verificato un errore di sistema.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Ricaricare la pagina fra qualche minuto oppure <a href="%url%">tornare all'homepage</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Codice sorgente della pagina</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Codice del Controller</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Codice del template Twig</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Modifica Utente</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Mostra sorgente</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Fai qualcosa</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Modifica Utente</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Modifica</target>
@@ -173,45 +65,28 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
-        <target>Username</target>
-      </segment>
-    </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[Premere questo pulsante per mostrare il codice sorgente del <strong>Controller</strong> e del <strong>template</strong> utilizzati in questa pagina.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>Dopo la modifica della password dovrete effettuare nuovamente il login.</target>
+        <target>Nome utente</target>
       </segment>
     </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
-        <target>Login</target>
+        <target>Accesso</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>Lista dei contenuti</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Cambia la password</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -412,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,37 +297,36 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Di seguito l'elenco delle librerie di terze parti utilizzate da Bolt.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Nome completo</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>Indirizzo Email</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Su di me</target>
+      </segment>
+    </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -460,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -471,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -481,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -490,517 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Tema del Backend</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>Français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
+        <target>Lingua</target>
       </segment>
     </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Il tema di default</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>Il tema scuro di default</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: sembra un po' come quell'altro CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Dashboard</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>caption.translations: messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Cancella la cache</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Verifica del Database</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>caption.routing set up</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Impostazioni del Menu</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Tassonomie</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Tipi di contenuto</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Configurazione principale</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Utenti & Permessi]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Configurazione</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Impostazioni</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Contenuto</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Gestione File</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Estensioni</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
         <target><![CDATA[Visualizza & modifica templates]]></target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Files caricati</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Impostazioni di Routing</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Traduzioni / Etichette</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>Info su Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
         <target>Un CMS sofisticato, semplice e leggero</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Modifica</target>
       </segment>
     </unit>
-    <unit id="dbyz2hj" name="caption.finder">
-      <segment>
-        <source>caption.finder</source>
-        <target>Finder</target>
-      </segment>
-    </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Caricamento File</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Meta informazioni</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Data</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Dimensioni</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
-        <target>Thumbnail</target>
+        <target>Miniatura</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Nome file</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Azioni</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Nome Directory</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Vai</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Selezione veloce di un file da modificare…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Selezione veloce</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Percorso</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Nome File</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Visita il  sito</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Crea nuovo</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
-        <target>Hey, %name%!</target>
+        <target>Ciao, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
-        <target>Logout</target>
+        <target>Esci</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Modifica Profilo</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>chiudi</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Tutti i files di configurazione</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Manutenzione</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fixtures (Contenti fittizi)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Modifica File</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Verifica dell'installazione</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Seleziona Lingua</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Locale corrente</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Cambia locale</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Autore</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Modifica</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Sconosciuto</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Scritto da %name% il %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>Manca la pagina "About"</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>Manca il blocco "About"</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>%contenttypes% recenti</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Cerca</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>Panoramica dei %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Non è stato trovato alcun %contenttype%</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>Menu</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Cerca</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Permalink</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Displayname</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>La Cache è stata svuotata correttamente!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
         <target>La Discarica</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Risultati della ricerca di '%search%'.</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1009,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1018,117 +1018,2420 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Inserire un termine di ricerca per ottenere risultati rilevanti.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Altre informazioni</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
+        <target><![CDATA[Questo sito è <a href='https://boltcms.io' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Ultime notizie su Bolt</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>Anteprima</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>Mostra sul sito la versione salvata</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Nome Display</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Duplica</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>Password corrente</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>Nuova Password</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>Nuova Password (conferma)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>Il File è stato modificato con successo!</target>
       </segment>
     </unit>
-    <unit id="eq5YMQf" name="9fb3e6e">
-      <segment>
-        <source>This website is &lt;a href='%url%' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Aggiungi Utente</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Successo!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>Il Profilo Utente è stato aggiornato!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Ruoli</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>Nuovo Utente</target>
       </segment>
     </unit>
-    <unit id="mo_k9.1" name="general.dashboard">
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
-        <source>general.dashboard</source>
-        <target>general.dashboard</target>
+        <source>action.view</source>
+        <target>Visualizza</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Bloccato</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Modifica</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Genera da:</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Carica</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Dalla libreria</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Visualizza sul sito</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Cambia stato in "pubblicato"</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Cambia stato in "in attesa"</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Cambia stato in "bozza"</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Duplica</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Elimina</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Creato il</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Pubblicato il</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Ultima modifica il</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Selezionato</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>URL del contenuto da incorporare</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL del contenuto su Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Altezza</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>pixel</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Incorporamento corrispondente</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Anteprima</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Dimensione</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Nome file (carica un nuovo file o selezionane uno esistente)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Attributo alt</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Attributo title</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Attiva/disattiva larghezza barra laterale</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Attiva/disattiva </span>menu]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Attiva/disattiva</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Notifica</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Visualizza informazioni sulla localizzazione</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Ordina per</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Parola chiave per filtrare…</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filtra</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Cancella ordinamento/filtro</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Predefinito</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Mancante</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Attiva/disattiva menu a discesa</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Modifica informazioni immagine</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Modifica file nell’editor</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Visualizza originale</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Duplica</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Elimina</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Nome file:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Titolo:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Dimensioni:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Dimensione file:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Creato il:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Non sono presenti file in questa cartella. Seleziona una cartella in cui navigare.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Seleziona un file:</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Elenco</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Schede</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Descrizione:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Autore:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Nome pacchetto / classe:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Versione:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Questo è un pacchetto locale, non installato tramite Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Nome classe:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Configurazione</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Sorgente</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Rimuovi estensione</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Disabilita estensione</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Accesso</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Non ancora implementato. Spiacenti!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Panoramica per</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>Non sono presenti file in questa cartella. Seleziona una cartella in cui navigare, sul lato destro.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Compatto</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Espanso</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Visualizzazione:</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Modifica</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target><![CDATA[Utenti e permessi]]></target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>Per modificare gli utenti e i loro permessi</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Nome visualizzato</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Nome utente</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>Email</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Ruoli</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Durata della sessione</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Ultimo IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Azioni</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Utente sconosciuto</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Colori predominanti nell’immagine</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Panoramica per "%slug%"</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Contenuti correlati</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Cerca</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Nuovo %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>%contenttype% senza titolo</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Modifica profilo utente</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Pagina di reindirizzamento</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Modifica immagine</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Password sicura suggerita: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Ritaglio X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Posizione del ritaglio sull’asse X, intervallo 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Posizione del ritaglio sull’asse Y, intervallo 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Ritaglio Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Fattore di zoom del ritaglio</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Livello di zoom del ritaglio, intervallo 1-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Tipo di contenuto</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Nessun risultato trovato. Amplia i criteri di filtraggio o aggiungi altri contenuti.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Seleziona il campo per l’ordinamento…</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Azioni principali</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opzioni</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Elimina</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Abilita</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Disabilita</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>La sessione scade</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>Indirizzo IP</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Browser / piattaforma</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Rimuovi</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Modifica attributi</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Aggiungi nuova immagine</target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Aggiungi nuovo file</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Rimuovi elemento</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Aggiungi un nuovo elemento a "%name%"</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Sposta su</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Sposta giù</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Visualizza dettagli</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>File di configurazione</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Trascina qui i file da caricare</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Successivo</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Precedente</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Su</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Giù</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Scarica</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Visualizzatore log</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Richiesta</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Trace</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Contesto</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Livello</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Messaggio</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Timestamp</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Utente</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Disabilitato</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Sbloccato</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Nessun contenuto trovato</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Nessuno</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Vuoto</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Applica a tutti</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Informazioni di sistema</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Sei sicuro di voler eliminare questo contenuto?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>il tuo nome utente o email</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>la tua password</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Altri contenuti</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>Il salvataggio è disabilitato perché il file di destinazione non è scrivibile.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Questo campo è traducibile</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Contenuto</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>File eliminato con successo!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Sei sicuro di voler eliminare questo file?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Cerca / Filtra per</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Stato modificato con successo</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Contenuto eliminato con successo</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Stato attuale</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Pubblicato</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Bozza</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Programmato</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>In attesa</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Sei sicuro di voler eliminare questo elemento della raccolta?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Tipi di file consentiti per il caricamento</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Dimensione massima di caricamento</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Cerca per parola chiave …</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Tutti i contenuti, filtrati per <em>"%filter%"</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Visualizza sito web</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Nuovo</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Nessuna dipendenza nota</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Dipendenze</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Espandi tutto</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Comprimi tutto</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>La definizione per questo ContentType è mancante! La modifica di questo record non funzionerà come previsto. Controlla il tuo file contenttypes.yaml per assicurarti che contenga %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Seleziona …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Inserisci il tuo nome utente o email</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Inserisci la tua password</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Inserisci la tua email</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filtra per campo</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Da URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Copia il link al file</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Avviso</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>La cartella esiste già</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Impossibile creare la cartella</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Cartella creata con successo.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Cartella eliminata con successo</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Nuova cartella</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Password dimenticata</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Reimposta password</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Inserisci il tuo indirizzo email e ti invieremo un link per reimpostare la password.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Invia</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Email</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Torna all’accesso</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Reimposta la tua password</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Email di reimpostazione password inviata</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>È stata inviata un’email contenente un link su cui puoi fare clic per reimpostare la password. Questo link scadrà tra %hours% ora/e.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Se non ricevi l’email, controlla la cartella spam o %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Reimposta password</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Ciao!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Per reimpostare la password, visita il seguente link</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Questo link scadrà tra %hours% ora/e.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Saluti!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Inserisci una password</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Ripeti password</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>I campi della password devono corrispondere.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>La tua password deve contenere almeno %s caratteri</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Nessun token di reimpostazione password trovato nell’URL o nella sessione.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>La tua password è stata reimpostata con successo.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Si è verificato un problema durante la gestione della richiesta di reimpostazione della password - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>filtrato per</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Condividi link di anteprima sicuro</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>smetti di impersonare</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>impersona</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>La modalità di manutenzione è attivata</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Aggiorna</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Visualizzazione dei record %current% di %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Nome: %name% (singolare: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (singolare: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Template del record: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Template dell’elenco: %template% (%listingRecords% record)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Lingue: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Modifica permessi</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Cerca</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Anteprima dell’immagine</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Seleziona tutto</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Ricordami? (%duration% giorni)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Sessioni correnti</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Opzioni di caricamento</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Ordine</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>la tua email</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Seleziona un file</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Seleziona un’immagine</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Carica da URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Caricamento…</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Salva</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Chiudi</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -1,77 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="messages.nl">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Niet beschikbaar</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Fout %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig template broncode</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Bewerk gebruiker</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Toon broncode</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
         <target>Opslaan</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
+    <unit id="a2vzLi7" name="action.do_something">
       <notes>
-        <note>templates/users/change_password.twig:26</note>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
       </notes>
       <segment>
-        <source>action.edit_user</source>
-        <target>Bewerk gebruiker</target>
+        <source>action.do_something</source>
+        <target>Doe iets</target>
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>action.edit</source>
+        <target>Bewerk</target>
       </segment>
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
@@ -80,17 +75,18 @@
     </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
-        <target>Login</target>
+        <target>Inloggen</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -99,26 +95,26 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
-        <target>Log in</target>
+        <target>Inloggen</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
+    <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/users/edit.twig:24</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
-        <source>action.change_password</source>
-        <target>Wijzig wachtwoord</target>
+        <source>title.contentlisting</source>
+        <target>Lijst van content</target>
       </segment>
     </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -127,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -136,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -146,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -156,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -165,34 +164,102 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
         <target>Gedepubliceerd op</target>
       </segment>
     </unit>
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>field.title</source>
+        <target>Titel</target>
+      </segment>
+    </unit>
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>field.description</source>
+        <target>Beschrijving</target>
+      </segment>
+    </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
         <target>Copyright</target>
       </segment>
     </unit>
-    <unit id="2hoKa1k" name="label.remembermeduration">
+    <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
-        <source>label.remembermeduration</source>
-        <target>Onthoud me? (%duration% dagen)</target>
+        <source>field.originalFilename</source>
+        <target>Originele Bestandsnaam</target>
+      </segment>
+    </unit>
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
+      <segment>
+        <source>field.width</source>
+        <target>Breedte</target>
+      </segment>
+    </unit>
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
+      <segment>
+        <source>field.height</source>
+        <target>Hoogte</target>
+      </segment>
+    </unit>
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
+      <segment>
+        <source>field.filesize</source>
+        <target>Bestandsgrootte</target>
+      </segment>
+    </unit>
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
+      <segment>
+        <source>label.username_or_email</source>
+        <target>Gebruikersnaam of e-mail</target>
+      </segment>
+    </unit>
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.rememberme</source>
+        <target>Onthoud mij?</target>
       </segment>
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -201,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -210,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -219,1903 +288,3150 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
         <target>Gebruikte Libraries / Componenten</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
+    <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
-        <source>label.fullname</source>
-        <target>Volledige naam</target>
+        <source>about.list_of_used_libraries</source>
+        <target>Hieronder staat een lijst met een deel van de gebruikte Libraries / Componenten in Bolt.</target>
       </segment>
     </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>E-mail</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Over mij</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
+        <source>user.updated_successfully</source>
+        <target>Succesvol bijgewerkt</target>
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
+        <source>content.updated_successfully</source>
+        <target>Inhoud succesvol bijgewerkt</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Media-item succesvol aangemaakt</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>Kon media-item niet schrijven</target>
+      </segment>
+    </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Backend thema</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
+        <target>Taal</target>
       </segment>
     </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Het standaard thema</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>De standaard Dark Theme</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Lijkt een beetje op dat andere CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
-        <target>Bolt Dashboard</target>
+        <target>Bolt-dashboard</target>
       </segment>
     </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Leeg de cache</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Controleer Database</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Menu instellingen</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Taxonomieën</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Contenttypen</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Hoofdconfiguratie</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Gebruikers & permissies]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Configuratie</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Instellingen</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Inhoud</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Bestandsbeheer</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Extensies</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
         <target><![CDATA[Bekijk & bewerk templates]]></target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Geüploade bestanden</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Routing instellingen</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Vertalingen / Labels</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>Over Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
         <target>Weldoordacht, lichtgewicht en eenvoudig CMS</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Bewerk</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Bestandsuploader</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Meta informatie</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Datum</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Formaat</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
-        <target>Thumbnail</target>
+        <target>Miniatuur</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Bestandsnaam</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Acties</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Directorynaam</target>
       </segment>
     </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Selecteer een bestand om snel te bewerken…</target>
       </segment>
     </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Pad</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
-        <source>action.visit_site</source>
-        <target>Bekijk site</target>
+        <source>caption.filename</source>
+        <target>Bestandsnaam</target>
       </segment>
     </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Maak nieuwe</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Hoi, %name%</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Uitloggen</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Bewerk profiel</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>Sluit</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Alle configuratie bestanden</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Onderhoud</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fixtures (loze inhoud)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Bewerk Bestand</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Installatie-controle</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Kies een taal</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Locale</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Huidige locale</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Wissel naar locale</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Auteur</target>
       </segment>
     </unit>
-    <unit id="wGlnx8X" name="general.phrase.search">
-      <segment>
-        <source>general.phrase.search</source>
-        <target>Zoeken</target>
-      </segment>
-    </unit>
-    <unit id="2MMvCKK" name="label.cache_cleared">
-      <segment>
-        <source>label.cache_cleared</source>
-        <target>De Cache is leeggemaakt!</target>
-      </segment>
-    </unit>
-    <unit id="Pily_qo" name="general.phrase.read-more">
-      <segment>
-        <source>general.phrase.read-more</source>
-        <target>Lees meer</target>
-      </segment>
-    </unit>
-    <unit id="5IxD63c" name="general.latest_bolt_news">
-      <segment>
-        <source>general.latest_bolt_news</source>
-        <target>Het laatste Bolt nieuws</target>
-      </segment>
-    </unit>
-    <unit id="tgLgLDQ" name="about.list_of_used_libraries">
-      <segment>
-        <source>about.list_of_used_libraries</source>
-        <target>Hieronder staat een lijst met een deel van de gebruikte Libraries / Componenten in Bolt.</target>
-      </segment>
-    </unit>
-    <unit id="nrWBJNm" name="extensions.title_desc">
-      <segment>
-        <source>extensions.title_desc</source>
-        <target>Beschrijving:</target>
-      </segment>
-    </unit>
-    <unit id="7raDJAR" name="extensions.title_author">
-      <segment>
-        <source>extensions.title_author</source>
-        <target>Auteur:</target>
-      </segment>
-    </unit>
-    <unit id="UP8pNGy" name="extensions.title_package">
-      <segment>
-        <source>extensions.title_package</source>
-        <target>Package / Class naam:</target>
-      </segment>
-    </unit>
-    <unit id="QFQ1uTC" name="extensions.title_version">
-      <segment>
-        <source>extensions.title_version</source>
-        <target>Versie:</target>
-      </segment>
-    </unit>
-    <unit id="piuatxC" name="extensions.info_not_installed">
-      <segment>
-        <source>extensions.info_not_installed</source>
-        <target>Dit is een lokale package, niet geïnstalleerd met Composer</target>
-      </segment>
-    </unit>
-    <unit id="3j1gEmk" name="extensions.title_class">
-      <segment>
-        <source>extensions.title_class</source>
-        <target>Titel:</target>
-      </segment>
-    </unit>
-    <unit id="mjhFljb" name="extensions.button_configuration">
-      <segment>
-        <source>extensions.button_configuration</source>
-        <target>Configuratie</target>
-      </segment>
-    </unit>
-    <unit id="r3ryNTG" name="extensions.button_source">
-      <segment>
-        <source>extensions.button_source</source>
-        <target>Broncode</target>
-      </segment>
-    </unit>
-    <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment>
-        <source>extensions.message_not_implemented</source>
-        <target>Nog niet geïmplementeerd, sorry!</target>
-      </segment>
-    </unit>
-    <unit id="qc3rFkZ" name="extensions.button_remove">
-      <segment>
-        <source>extensions.button_remove</source>
-        <target>Verwijder</target>
-      </segment>
-    </unit>
-    <unit id="SLZyVzU" name="extensions.button_disable">
-      <segment>
-        <source>extensions.button_disable</source>
-        <target>Uitschakelen</target>
-      </segment>
-    </unit>
-    <unit id="z2AgHGp" name="flash_messages.notification">
-      <segment>
-        <source>flash_messages.notification</source>
-        <target>Notificatie</target>
-      </segment>
-    </unit>
-    <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment>
-        <source>listing_filter.button_compact</source>
-        <target>compact</target>
-      </segment>
-    </unit>
-    <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment>
-        <source>listing_filter.button_expanded</source>
-        <target>uitgebreid</target>
-      </segment>
-    </unit>
-    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <segment>
-        <source>listing_table.actions.view_on_site</source>
-        <target>bekijk op site</target>
-      </segment>
-    </unit>
-    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment>
-        <source>listing_table.actions.status_to_publish</source>
-        <target>Pas status aan naar 'gepubliceerd'</target>
-      </segment>
-    </unit>
-    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment>
-        <source>listing_table.actions.status_to_held</source>
-        <target>Pas status aan naar 'vasthouden'</target>
-      </segment>
-    </unit>
-    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment>
-        <source>listing_table.actions.status_to_draft</source>
-        <target>Pas status aan naar 'klad'</target>
-      </segment>
-    </unit>
-    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment>
-        <source>listing_table.actions.duplicate</source>
-        <target>dupliceer</target>
-      </segment>
-    </unit>
-    <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <segment>
-        <source>listing_table.actions.delete</source>
-        <target>verwijder</target>
-      </segment>
-    </unit>
-    <unit id="5zbX1vo" name="listing_table.actions.slug">
-      <segment>
-        <source>listing_table.actions.slug</source>
-        <target>slug</target>
-      </segment>
-    </unit>
-    <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <segment>
-        <source>listing_table.actions.created_on</source>
-        <target>Aangemaakt op</target>
-      </segment>
-    </unit>
-    <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <segment>
-        <source>listing_table.actions.published_on</source>
-        <target>Gepubliceerd op</target>
-      </segment>
-    </unit>
-    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment>
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Laatst gewijzigd op</target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Geolocatie</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Adres</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>Adres …</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Lat</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Lon</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Gevonden adres</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>Marker</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>__geolocation.label_control</target>
-      </segment>
-    </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Bestandsnaam</target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Title</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>Bekijk</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Upload</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target>__file.remark</target>
-      </segment>
-    </unit>
-    <unit id="kHeY93_" name="editor_embed.content_url">
-      <segment>
-        <source>editor_embed.content_url</source>
-        <target>Content URL</target>
-      </segment>
-    </unit>
-    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-      <segment>
-        <source>editor_embed.placeholder_content_url</source>
-        <target>Url van de content …</target>
-      </segment>
-    </unit>
-    <unit id="1.Eb1GS" name="editor_embed.label_height">
-      <segment>
-        <source>editor_embed.label_height</source>
-        <target>Hoogte</target>
-      </segment>
-    </unit>
-    <unit id="eWLSFJs" name="editor_embed.label_pixel">
-      <segment>
-        <source>editor_embed.label_pixel</source>
-        <target>pixels</target>
-      </segment>
-    </unit>
-    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
-      <segment>
-        <source>editor_embed.label_matched_embed</source>
-        <target>Gevonden Embed</target>
-      </segment>
-    </unit>
-    <unit id="zATju4V" name="editor_embed.label_preview">
-      <segment>
-        <source>editor_embed.label_preview</source>
-        <target>Voorvertoning</target>
-      </segment>
-    </unit>
-    <unit id="9SQ0oaR" name="editor_embed.label_size">
-      <segment>
-        <source>editor_embed.label_size</source>
-        <target>Grootte</target>
-      </segment>
-    </unit>
-    <unit id="BINgtmK" name="editor_date.toggle">
-      <segment>
-        <source>editor_date.toggle</source>
-        <target>Wissel</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target>__filelist.remark</target>
-      </segment>
-    </unit>
-    <unit id="vptPhch" name="image.button_upload">
-      <segment>
-        <source>image.button_upload</source>
-        <target>Uploaden</target>
-      </segment>
-    </unit>
-    <unit id="vIVO1lU" name="image.button_from_library">
-      <segment>
-        <source>image.button_from_library</source>
-        <target>Uit bibliotheek</target>
-      </segment>
-    </unit>
-    <unit id="oOuVKRv" name="image.placeholder_filename">
-      <segment>
-        <source>image.placeholder_filename</source>
-        <target>Bestandsnaam (upload een nieuw bestand, of selecteer een bestaande)</target>
-      </segment>
-    </unit>
-    <unit id="BWubOnS" name="image.placeholder_alt_text">
-      <segment>
-        <source>image.placeholder_alt_text</source>
-        <target>Alt attribuut</target>
-      </segment>
-    </unit>
-    <unit id="VPV0lFM" name="image.placeholder_title">
-      <segment>
-        <source>image.placeholder_title</source>
-        <target>Titel attribuut</target>
-      </segment>
-    </unit>
-    <unit id="kaK5Wdr" name="slug.button_locked">
-      <segment>
-        <source>slug.button_locked</source>
-        <target>Op slot</target>
-      </segment>
-    </unit>
-    <unit id="qcDEz5O" name="slug.button_edit">
-      <segment>
-        <source>slug.button_edit</source>
-        <target>Bewerk</target>
-      </segment>
-    </unit>
-    <unit id="raO5QSf" name="slug.generate_from">
-      <segment>
-        <source>slug.generate_from</source>
-        <target>Baseer op</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target>__imagelist.remark</target>
-      </segment>
-    </unit>
-    <unit id="v6cfPyt" name="quickselect.title_select">
-      <segment>
-        <source>quickselect.title_select</source>
-        <target>Selecteer</target>
-      </segment>
-    </unit>
-    <unit id=".fL0AbE" name="files_list.remark">
-      <segment>
-        <source>files_list.remark</source>
-        <target>Er staan geen bestanden in deze map. Kies een map om naar toe te navigeren.</target>
-      </segment>
-    </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Mappen</target>
-      </segment>
-    </unit>
-    <unit id="m3tNvJb" name="finder.button_list">
-      <segment>
-        <source>finder.button_list</source>
-        <target>Lijst</target>
-      </segment>
-    </unit>
-    <unit id="tRLgeoX" name="finder.button_cards">
-      <segment>
-        <source>finder.button_cards</source>
-        <target>Kaarten</target>
-      </segment>
-    </unit>
-    <unit id="QQvRJe." name="files_cards.button_toggle">
-      <segment>
-        <source>files_cards.button_toggle</source>
-        <target>Wissel</target>
-      </segment>
-    </unit>
-    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-      <segment>
-        <source>files_cards.action_edit_image_info</source>
-        <target>Bewerk info</target>
-      </segment>
-    </unit>
-    <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <segment>
-        <source>files_cards.action_edit_file</source>
-        <target>Bewerk bestand</target>
-      </segment>
-    </unit>
-    <unit id="H1pgP94" name="files_cards.action_view_original">
-      <segment>
-        <source>files_cards.action_view_original</source>
-        <target>Bekijk origineel</target>
-      </segment>
-    </unit>
-    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <segment>
-        <source>files_cards.action_duplicate</source>
-        <target>Dupliceer</target>
-      </segment>
-    </unit>
-    <unit id="JjU6ZQP" name="files_cards.action_delete">
-      <segment>
-        <source>files_cards.action_delete</source>
-        <target>Verwijder</target>
-      </segment>
-    </unit>
-    <unit id="3jdNwuk" name="files_cards.label_filename">
-      <segment>
-        <source>files_cards.label_filename</source>
-        <target>Bestandsnaam</target>
-      </segment>
-    </unit>
-    <unit id="Y90_Pn1" name="files_cards.label_title">
-      <segment>
-        <source>files_cards.label_title</source>
-        <target>Titel</target>
-      </segment>
-    </unit>
-    <unit id="EdCfIKX" name="files_cards.label_dimensions">
-      <segment>
-        <source>files_cards.label_dimensions</source>
-        <target>Afmetingen</target>
-      </segment>
-    </unit>
-    <unit id="eQBhceV" name="files_cards.label_filesize">
-      <segment>
-        <source>files_cards.label_filesize</source>
-        <target>Bestandsgrootte</target>
-      </segment>
-    </unit>
-    <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <segment>
-        <source>files_cards.label_created_on</source>
-        <target>Aangemaakt op</target>
-      </segment>
-    </unit>
-    <unit id="8JeahIj" name="files_cards.message_no_files">
-      <segment>
-        <source>files_cards.message_no_files</source>
-        <target>Aantal bestanden</target>
-      </segment>
-    </unit>
-    <unit id="beqzCkE" name="login.header_login">
-      <segment>
-        <source>login.header_login</source>
-        <target>Bolt » Login</target>
-      </segment>
-    </unit>
-    <unit id="37kJiIe" name="view_locales.badge_default">
-      <segment>
-        <source>view_locales.badge_default</source>
-        <target>Standaard</target>
-      </segment>
-    </unit>
-    <unit id="JTRCo_U" name="view_locales.badge_ok">
-      <segment>
-        <source>view_locales.badge_ok</source>
-        <target>OK</target>
-      </segment>
-    </unit>
-    <unit id="ufFUPp7" name="view_locales.badge_missing">
-      <segment>
-        <source>view_locales.badge_missing</source>
-        <target>Ontbreekt</target>
-      </segment>
-    </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Bewerk</target>
       </segment>
     </unit>
-    <unit id="ypPzS03" name="localeswitcher.button_info">
-      <segment>
-        <source>localeswitcher.button_info</source>
-        <target>Info</target>
-      </segment>
-    </unit>
-    <unit id="EvAqL__" name="caption.duplicate">
-      <segment>
-        <source>caption.duplicate</source>
-        <target>Dupliceer</target>
-      </segment>
-    </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Wissel</target>
-      </segment>
-    </unit>
-    <unit id="ok6YulQ" name="action.view_saved">
-      <segment>
-        <source>action.view_saved</source>
-        <target>Bekijk opgeslagen</target>
-      </segment>
-    </unit>
-    <unit id="Hlf9c1s" name="listing.title_overview">
-      <segment>
-        <source>listing.title_overview</source>
-        <target>Overzicht voor</target>
-      </segment>
-    </unit>
-    <unit id="vJwSCBO" name="title.contentlisting">
-      <segment>
-        <source>title.contentlisting</source>
-        <target>Lijst van content</target>
-      </segment>
-    </unit>
-    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <segment>
-        <source>listing_select_box.card_header.selected</source>
-        <target>Geselecteerd</target>
-      </segment>
-    </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>Doorgegeven gekozen IDs</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(these can be used with something like axios to bulk modify/delete)</target>
-      </segment>
-    </unit>
-    <unit id="wQ0WYAT" name="listing.title_sortby">
-      <segment>
-        <source>listing.title_sortby</source>
-        <target>Sorteer op</target>
-      </segment>
-    </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Kies item</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Titel</target>
-      </segment>
-    </unit>
-    <unit id="pn22p7q" name="listing.placeholder_filter">
-      <segment>
-        <source>listing.placeholder_filter</source>
-        <target>Trefwoord om op te filteren…</target>
-      </segment>
-    </unit>
-    <unit id="ni4zApC" name="listing.button_filter">
-      <segment>
-        <source>listing.button_filter</source>
-        <target>Filter</target>
-      </segment>
-    </unit>
-    <unit id="doNsgm0" name="listing.button_clear">
-      <segment>
-        <source>listing.button_clear</source>
-        <target>Leegmaken</target>
-      </segment>
-    </unit>
-    <unit id="SeTqePC" name="label.display_name">
-      <segment>
-        <source>label.display_name</source>
-        <target>Toon naam als</target>
-      </segment>
-    </unit>
-    <unit id="iD6CNOO" name="label.roles">
-      <segment>
-        <source>label.roles</source>
-        <target>Rollen</target>
-      </segment>
-    </unit>
-    <unit id="TtmWqX3" name="action.view">
-      <segment>
-        <source>action.view</source>
-        <target>Bekijk</target>
-      </segment>
-    </unit>
-    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment>
-        <source>admin_sidebar_toggler.toggle</source>
-        <target><![CDATA[<span class='sr-only'>Klap </span>menu<span class='sr-only'> in of uit</span>]]></target>
-      </segment>
-    </unit>
-    <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <segment>
-        <source>admin_sidebar.toggler</source>
-        <target>Wissel breedte zijbalk</target>
-      </segment>
-    </unit>
-    <unit id="y5otxEK" name="caption.filename">
-      <segment>
-        <source>caption.filename</source>
-        <target>Bestandsnaam</target>
-      </segment>
-    </unit>
-    <unit id="VKhfRZB" name="field.title">
-      <segment>
-        <source>field.title</source>
-        <target>Titel</target>
-      </segment>
-    </unit>
-    <unit id="7_wwX8J" name="field.description">
-      <segment>
-        <source>field.description</source>
-        <target>Beschrijving</target>
-      </segment>
-    </unit>
-    <unit id="v0sitU8" name="field.originalFilename">
-      <segment>
-        <source>field.originalFilename</source>
-        <target>Originele Bestandsnaam</target>
-      </segment>
-    </unit>
-    <unit id="vlRe8Tx" name="field.width">
-      <segment>
-        <source>field.width</source>
-        <target>Breedte</target>
-      </segment>
-    </unit>
-    <unit id="CZbXbM_" name="field.height">
-      <segment>
-        <source>field.height</source>
-        <target>Hoogte</target>
-      </segment>
-    </unit>
-    <unit id="Sz_u.OS" name="field.filesize">
-      <segment>
-        <source>field.filesize</source>
-        <target>Bestandsgrootte</target>
-      </segment>
-    </unit>
-    <unit id="Wou02nK" name="caption.kitchensink">
-      <segment>
-        <source>caption.kitchensink</source>
-        <target>Kitchensink</target>
-      </segment>
-    </unit>
-    <unit id="73A2bWM" name="finder.label_view">
-      <segment>
-        <source>finder.label_view</source>
-        <target>Bekijk</target>
-      </segment>
-    </unit>
-    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <segment>
-        <source>listing_table.actions.button_edit</source>
-        <target>Bewerk</target>
-      </segment>
-    </unit>
-    <unit id="Iy4HXCU" name="controller.user.title">
-      <segment>
-        <source>controller.user.title</source>
-        <target><![CDATA[Gebruikers & permissies]]></target>
-      </segment>
-    </unit>
-    <unit id="HBwIQ9b" name="controller.user.subtitle">
-      <segment>
-        <source>controller.user.subtitle</source>
-        <target><![CDATA[Gebruikers & permissies bewerken]]></target>
-      </segment>
-    </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Database Check</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>To check the Database</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Database Update</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>To update the Database</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>To search, in an omni-like fashion</target>
-      </segment>
-    </unit>
-    <unit id="7cXqH5s" name="listing.title_display_name">
-      <segment>
-        <source>listing.title_display_name</source>
-        <target>Toon naam als</target>
-      </segment>
-    </unit>
-    <unit id="Ay7xZ2h" name="listing.title_username">
-      <segment>
-        <source>listing.title_username</source>
-        <target>Gebruikersnaam</target>
-      </segment>
-    </unit>
-    <unit id="RN1tdtJ" name="listing.title_email">
-      <segment>
-        <source>listing.title_email</source>
-        <target>E-mail</target>
-      </segment>
-    </unit>
-    <unit id="0pjZ.GV" name="listing.title_roles">
-      <segment>
-        <source>listing.title_roles</source>
-        <target>Rollen</target>
-      </segment>
-    </unit>
-    <unit id="hXEFV1n" name="listing.title_last_seen">
-      <segment>
-        <source>listing.title_last_seen</source>
-        <target>Laatst gezien</target>
-      </segment>
-    </unit>
-    <unit id="pn7kE17" name="listing.title_last_ip">
-      <segment>
-        <source>listing.title_last_ip</source>
-        <target>Recentste IP</target>
-      </segment>
-    </unit>
-    <unit id="GZ65uOC" name="listing.title_actions">
-      <segment>
-        <source>listing.title_actions</source>
-        <target>Acties</target>
-      </segment>
-    </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Invalid email</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Invalid password</target>
-      </segment>
-    </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Onbekend</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Geschreven door %name% op %date%.</target>
       </segment>
     </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>De pagina "Over" ontbreekt</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Het blok "Over" ontbreekt</target>
+      </segment>
+    </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>Recente %contenttypes%</target>
       </segment>
     </unit>
-    <unit id="wNEwZy_" name="contenttypes.generic.overview">
-      <segment>
-        <source>contenttypes.generic.overview</source>
-        <target>Overzicht van %contenttypes%</target>
-      </segment>
-    </unit>
-    <unit id="ma9mBv_" name="Menu">
-      <segment>
-        <source>Menu</source>
-        <target>Menu</target>
-      </segment>
-    </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
-    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
-        <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Deze website is <a href='https://boltcms.io' target='_blank' title='Weldoordacht, lichtgewicht en eenvoudig CMS'>gemaakt met Bolt</a>. ]]></target>
+        <source>general.phrase.search</source>
+        <target>Zoeken</target>
       </segment>
     </unit>
-    <unit id="odDw0du" name="action.search">
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
-        <source>action.search</source>
-        <target>Zoek</target>
+        <source>contenttypes.generic.overview</source>
+        <target>Overzicht van %contenttypes%</target>
       </segment>
     </unit>
-    <unit id="TpGxDI3" name="user.unknown_user">
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
-        <source>user.unknown_user</source>
-        <target>Onbekende gebruiker</target>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Geen recente %contenttype% gevonden</target>
       </segment>
     </unit>
-    <unit id="ruQIhH0" name="success">
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
-        <source>success</source>
-        <target>Succes!</target>
+        <source>Menu</source>
+        <target>Menu</target>
       </segment>
     </unit>
-    <unit id="dQIY7_J" name="action.preview">
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
-        <source>action.preview</source>
-        <target>Voorvertoning</target>
+        <source>Search</source>
+        <target>Zoeken</target>
       </segment>
     </unit>
-    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
-        <source>label.predominant_colors__in_image</source>
-        <target>Overheersende kleuren in afbeelding</target>
+        <source>general.phrase.permalink</source>
+        <target>Permalink</target>
       </segment>
     </unit>
-    <unit id="rCKtTo5" name="caption.redirection_page">
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
-        <source>caption.redirection_page</source>
-        <target>Doorverwijzingspagina</target>
+        <source>label.cache_cleared</source>
+        <target>De Cache is leeggemaakt!</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
-        <source>general.phrase.select_language</source>
-        <target>Kies taal</target>
-      </segment>
-    </unit>
-    <unit id="7whLbH8" name="user.new_user">
-      <segment>
-        <source>user.new_user</source>
-        <target>Nieuwe gebruiker</target>
-      </segment>
-    </unit>
-    <unit id="hiE9jap" name="password.suggested">
-      <segment>
-        <source>password.suggested</source>
-        <target><![CDATA[Voorgesteld sterk wachtwoord: <code>%password%</code>]]></target>
-      </segment>
-    </unit>
-    <unit id="TtIlBDd" name="caption.edit_image">
-      <segment>
-        <source>caption.edit_image</source>
-        <target>Bewerk afbeelding</target>
-      </segment>
-    </unit>
-    <unit id="fLOd6Zd" name="field.cropX">
-      <segment>
-        <source>field.cropX</source>
-        <target>Uitsnede X</target>
-      </segment>
-    </unit>
-    <unit id="hi98HIj" name="field.cropY">
-      <segment>
-        <source>field.cropY</source>
-        <target>Uitsnede Y</target>
-      </segment>
-    </unit>
-    <unit id="PHOpD5y" name="field.cropZoom">
-      <segment>
-        <source>field.cropZoom</source>
-        <target>Zoomfactor uitsnede</target>
-      </segment>
-    </unit>
-    <unit id="BQBmQHT" name="field.cropYPostfix">
-      <segment>
-        <source>field.cropYPostfix</source>
-        <target>Positie van uitsnede op de Y-as, van 0-100. </target>
-      </segment>
-    </unit>
-    <unit id="Sd_AbmV" name="field.cropXPostfix">
-      <segment>
-        <source>field.cropXPostfix</source>
-        <target>Positie van uitsnede op de X-as, van 0-100. </target>
-      </segment>
-    </unit>
-    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
-      <segment>
-        <source>field.cropZoomPostfix</source>
-        <target>Zoom-niveau van uitsnede, van 1-10.</target>
-      </segment>
-    </unit>
-    <unit id="hp554Ds" name="listing.option_select_sortby">
-      <segment>
-        <source>listing.option_select_sortby</source>
-        <target>Kies Veldnaam om te sorteren…</target>
-      </segment>
-    </unit>
-    <unit id="n.3JZvX" name="title.contentType">
-      <segment>
-        <source>title.contentType</source>
-        <target>ContentType</target>
-      </segment>
-    </unit>
-    <unit id="Dgtkgju" name="title.edit_user_profile">
-      <segment>
-        <source>title.edit_user_profile</source>
-        <target>Bewerk gebruikersprofiel</target>
-      </segment>
-    </unit>
-    <unit id="YDH.7uR" name="user.updated_profile">
-      <segment>
-        <source>user.updated_profile</source>
-        <target>Gebruikersprofiel is bijgewerkt!</target>
-      </segment>
-    </unit>
-    <unit id="n.jOrkg" name="caption.untitled_contenttype">
-      <segment>
-        <source>caption.untitled_contenttype</source>
-        <target>%contenttype% zonder titel</target>
-      </segment>
-    </unit>
-    <unit id="JEnqOi." name="title.primary_actions">
-      <segment>
-        <source>title.primary_actions</source>
-        <target>Voornaamste handelingen</target>
-      </segment>
-    </unit>
-    <unit id="7616Os4" name="title.options">
-      <segment>
-        <source>title.options</source>
-        <target>Opties</target>
-      </segment>
-    </unit>
-    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
-      <segment>
-        <source>general.phrase.no-search-term-provided</source>
-        <target>Geef een zoekterm op om relevante resultaten te tonen.</target>
+        <source>caption.kitchensink</source>
+        <target>Kitchensink</target>
       </segment>
     </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
         <target>Zoekresultaten voor %search%.</target>
       </segment>
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
         <target>Geen zoekresultaten voor '%search%'.</target>
       </segment>
     </unit>
-    <unit id="0C9.Vmh" name="collection.add_item">
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
-        <source>collection.add_item</source>
-        <target>Voeg toe aan %name%</target>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Geef een zoekterm op om relevante resultaten te tonen.</target>
       </segment>
     </unit>
-    <unit id="ApPu4P_" name="collection.move_item_up">
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
-        <source>collection.move_item_up</source>
-        <target>Omhoog</target>
+        <source>general.phrase.read-more</source>
+        <target>Lees meer</target>
       </segment>
     </unit>
-    <unit id="KzBtfHi" name="collection.move_item_down">
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
-        <source>collection.move_item_down</source>
-        <target>Omlaag</target>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Deze website is <a href='https://boltcms.io' target='_blank' title='Weldoordacht, lichtgewicht en eenvoudig CMS'>gemaakt met Bolt</a>. ]]></target>
       </segment>
     </unit>
-    <unit id=".t1ICS7" name="collection.remove_item">
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
-        <source>collection.remove_item</source>
-        <target>Verwijder</target>
+        <source>general.latest_bolt_news</source>
+        <target>Het laatste Bolt nieuws</target>
       </segment>
     </unit>
-    <unit id="FqVh1Hv" name="image.button_remove">
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
-        <source>image.button_remove</source>
-        <target>Verwijder</target>
+        <source>action.preview</source>
+        <target>Voorvertoning</target>
       </segment>
     </unit>
-    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
-        <source>image.button_edit_attributes</source>
-        <target>Bewerk attributen</target>
+        <source>action.view_saved</source>
+        <target>Bekijk opgeslagen</target>
       </segment>
     </unit>
-    <unit id="7aSD0Qr" name="image.button_up">
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
-        <source>image.button_up</source>
-        <target>Omhoog</target>
+        <source>label.display_name</source>
+        <target>Toon naam als</target>
       </segment>
     </unit>
-    <unit id="WihD8Y5" name="image.button_down">
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
-        <source>image.button_down</source>
-        <target>Omlaag</target>
+        <source>caption.duplicate</source>
+        <target>Dupliceer</target>
       </segment>
     </unit>
-    <unit id="Oj2UZ5J" name="image.add_new_image">
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
-        <source>image.add_new_image</source>
-        <target>Voeg nieuwe afbeelding toe</target>
+        <source>label.new_password</source>
+        <target>Nieuw wachtwoord</target>
       </segment>
     </unit>
-    <unit id="8Q4FxVw" name="file.add_new_file">
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
-        <source>file.add_new_file</source>
-        <target>Voeg nieuw bestand toe</target>
+        <source>editfile.updated_successfully</source>
+        <target>Bestand succesvol bijgewerkt!</target>
       </segment>
     </unit>
-    <unit id="2MtT_h0" name="caption.logviewer">
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
-        <source>caption.logviewer</source>
-        <target>Logs bekijken</target>
+        <source>action.add_user</source>
+        <target>Toevoegen</target>
       </segment>
     </unit>
-    <unit id="ovKkXwU" name="action.edit">
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
-        <source>action.edit</source>
+        <source>success</source>
+        <target>Succes!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>Gebruikersprofiel is bijgewerkt!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Rollen</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Nieuwe gebruiker</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Bekijk</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Op slot</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
         <target>Bewerk</target>
       </segment>
     </unit>
-    <unit id="ryXZRAu" name="action.disable">
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
-        <source>action.disable</source>
+        <source>slug.generate_from</source>
+        <target>Baseer op</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Uploaden</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Uit bibliotheek</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>bekijk op site</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Pas status aan naar 'gepubliceerd'</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Pas status aan naar 'vasthouden'</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Pas status aan naar 'klad'</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>dupliceer</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>verwijder</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Aangemaakt op</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Gepubliceerd op</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Laatst gewijzigd op</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Geselecteerd</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>Content URL</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL van content op Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Hoogte</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>pixels</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Gevonden Embed</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Voorvertoning</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Grootte</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Bestandsnaam (upload een nieuw bestand, of selecteer een bestaande)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Alt attribuut</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Titel attribuut</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Wissel breedte zijbalk</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class='sr-only'>Klap </span>menu<span class='sr-only'> in of uit</span>]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Wissel</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Notificatie</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Bekijk lokalisatie-info</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Sorteer op</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Trefwoord om op te filteren…</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filteren</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Leegmaken</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Standaard</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Ontbreekt</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Wissel</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Bewerk info</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Bewerk bestand</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Bekijk origineel</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Dupliceer</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Verwijder</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Bestandsnaam</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Titel</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Afmetingen</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Bestandsgrootte</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Aangemaakt op</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Er staan geen bestanden in deze map. Kies een map om naar toe te navigeren.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Selecteer</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Lijst</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Kaarten</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Beschrijving:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Auteur:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Package / Class naam:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Versie:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Dit is een lokale package, niet geïnstalleerd met Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Titel:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Configuratie</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Broncode</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Verwijder</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
         <target>Uitschakelen</target>
       </segment>
     </unit>
-    <unit id="3MuwWwe" name="listing.disabled">
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
-        <source>listing.disabled</source>
-        <target>Uitgeschakeld</target>
+        <source>login.header_login</source>
+        <target>Bolt » Inloggen</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Nog niet geïmplementeerd, sorry!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Overzicht voor</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>Er zijn geen bestanden in deze map. Selecteer rechts een map om naartoe te navigeren.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>compact</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>uitgebreid</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Bekijk</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Bewerk</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target><![CDATA[Gebruikers & permissies]]></target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target><![CDATA[Gebruikers & permissies bewerken]]></target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Weergavenaam</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Gebruikersnaam</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Rollen</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Laatst gezien</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Recentste IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Acties</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Onbekende gebruiker</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Overheersende kleuren in afbeelding</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Overzicht voor '%slug%'</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Gerelateerde inhoud</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Zoek</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Nieuw %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>%contenttype% zonder titel</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Bewerk gebruikersprofiel</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Doorverwijzingspagina</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Bewerk afbeelding</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Voorgesteld sterk wachtwoord: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Uitsnede X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Positie van uitsnede op de X-as, van 0-100. </target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Positie van uitsnede op de Y-as, van 0-100. </target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Uitsnede Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Zoomfactor uitsnede</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Zoom-niveau van uitsnede, van 1-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>ContentType</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Geen resultaten gevonden. Verbreed de filtercriteria of voeg meer inhoud toe.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Kies Veldnaam om te sorteren…</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Voornaamste handelingen</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opties</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Verwijder</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Inschakelen</target>
       </segment>
     </unit>
-    <unit id="3zlZmRK" name="action.add_user">
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
-        <source>action.add_user</source>
-        <target>Toevoegen</target>
-      </segment>
-    </unit>
-    <unit id="x9qAwrz" name="listing.title_browser">
-      <segment>
-        <source>listing.title_browser</source>
-        <target>Browser / platform</target>
-      </segment>
-    </unit>
-    <unit id="mmUDcto" name="listing.title_ip_address">
-      <segment>
-        <source>listing.title_ip_address</source>
-        <target>IP-adres</target>
+        <source>action.disable</source>
+        <target>Uitschakelen</target>
       </segment>
     </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Sessie verloopt</target>
       </segment>
     </unit>
-    <unit id="hAysbHB" name="label.translatable">
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
-        <source>label.translatable</source>
-        <target>Dit veld is vertaalbaar</target>
+        <source>listing.title_ip_address</source>
+        <target>IP-adres</target>
       </segment>
     </unit>
-    <unit id="XQ2U6fN" name="slug.button_unlocked">
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
-        <source>slug.button_unlocked</source>
-        <target>Van slot</target>
+        <source>listing.title_browser</source>
+        <target>Browser / platform</target>
       </segment>
     </unit>
-    <unit id="IWbf2by" name="listing.title_filterby">
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
-        <source>listing.title_filterby</source>
-        <target>Filter op</target>
+        <source>image.button_remove</source>
+        <target>Verwijder</target>
       </segment>
     </unit>
-    <unit id="WeJxw6Z" name="action.update_all">
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
-        <source>action.update_all</source>
-        <target>Alles bijwerken</target>
+        <source>image.button_edit_attributes</source>
+        <target>Bewerk attributen</target>
       </segment>
     </unit>
-    <unit id="AMxTho9" name="pager.previous">
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
-        <source>pager.previous</source>
-        <target>Vorige</target>
+        <source>image.add_new_image</source>
+        <target>Voeg nieuwe afbeelding toe</target>
       </segment>
     </unit>
-    <unit id="L_YQKUn" name="pager.next">
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
-        <source>pager.next</source>
-        <target>Volgende</target>
+        <source>file.add_new_file</source>
+        <target>Voeg nieuw bestand toe</target>
       </segment>
     </unit>
-    <unit id=".I3mIHo" name="label.current_status">
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
-        <source>label.current_status</source>
-        <target>Huidige status</target>
+        <source>collection.remove_item</source>
+        <target>Verwijder</target>
       </segment>
     </unit>
-    <unit id="utGAKaQ" name="status.published">
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
-        <source>status.published</source>
-        <target>Gepubliceerd</target>
+        <source>collection.add_item</source>
+        <target>Voeg toe aan %name%</target>
       </segment>
     </unit>
-    <unit id="HJbHjee" name="status.draft">
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
-        <source>status.draft</source>
-        <target>In klad</target>
+        <source>collection.move_item_up</source>
+        <target>Omhoog</target>
       </segment>
     </unit>
-    <unit id="h7dP3WY" name="status.timed">
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
-        <source>status.timed</source>
-        <target>Ingepland</target>
-      </segment>
-    </unit>
-    <unit id="oxqDDuK" name="status.held">
-      <segment>
-        <source>status.held</source>
-        <target>Achtergehouden</target>
-      </segment>
-    </unit>
-    <unit id="6Gw1lsE" name="action.confirm_delete">
-      <segment>
-        <source>action.confirm_delete</source>
-        <target>Weet je zeker dat je deze content wilt verwijderen?</target>
-      </segment>
-    </unit>
-    <unit id="RMPnq6o" name="label.username_or_email">
-      <segment>
-        <source>label.username_or_email</source>
-        <target>Gebruikersnaam of e-mail</target>
-      </segment>
-    </unit>
-    <unit id="z_tOHwq" name="placeholder.username_or_email">
-      <segment>
-        <source>placeholder.username_or_email</source>
-        <target>je gebruikersnaam of e-mailadres</target>
-      </segment>
-    </unit>
-    <unit id="xgYhRkc" name="placeholder.password">
-      <segment>
-        <source>placeholder.password</source>
-        <target>je wachtwoord</target>
-      </segment>
-    </unit>
-    <unit id="z8r0TY6" name="action.edit_permissions">
-      <segment>
-        <source>action.edit_permissions</source>
-        <target>Bewerk permissies</target>
-      </segment>
-    </unit>
-    <unit id="eJG2.4P" name="listing.current_sessions_header">
-      <segment>
-        <source>listing.current_sessions_header</source>
-        <target>Huidige sessies</target>
-      </segment>
-    </unit>
-    <unit id="2SSLP1K" name="form.empty_username_email">
-      <segment>
-        <source>form.empty_username_email</source>
-        <target>Je gebruikersnaam of e-mail</target>
-      </segment>
-    </unit>
-    <unit id="5Qf_RiO" name="form.empty_password">
-      <segment>
-        <source>form.empty_password</source>
-        <target>Geef je wachtwoord op</target>
-      </segment>
-    </unit>
-    <unit id="i37ZNqN" name="login.forgotpassword">
-      <segment>
-        <source>login.forgotpassword</source>
-        <target>Wachtwoord vergeten</target>
-      </segment>
-    </unit>
-    <unit id="zYeSeNJ" name="action.stop_impersonating">
-      <segment>
-        <source>action.stop_impersonating</source>
-        <target>Beëindig imiteren gebruiker</target>
-      </segment>
-    </unit>
-    <unit id="O_m7mx1" name="listing.placeholder_search">
-      <segment>
-        <source>listing.placeholder_search</source>
-        <target>Zoek op trefwoord …</target>
-      </segment>
-    </unit>
-    <unit id="OYUVA5." name="general.label.search">
-      <segment>
-        <source>general.label.search</source>
-        <target>Zoek</target>
-      </segment>
-    </unit>
-    <unit id="f.rvF6y" name="action.new">
-      <segment>
-        <source>action.new</source>
-        <target>Nieuw</target>
-      </segment>
-    </unit>
-    <unit id="OEqzPDO" name="listing_table.actions.select_all">
-      <segment>
-        <source>listing_table.actions.select_all</source>
-        <target>Selecteer alle</target>
-      </segment>
-    </unit>
-    <unit id="9UKAP.V" name="listing_details_box.showing_records">
-      <segment>
-        <source>listing_details_box.showing_records</source>
-        <target>Toon records %current% van %total%</target>
-      </segment>
-    </unit>
-    <unit id="UrywY0R" name="listing_details_box.name">
-      <segment>
-        <source>listing_details_box.name</source>
-        <target>Naam: %name% (singular: %singularName%)</target>
-      </segment>
-    </unit>
-    <unit id=".l3zbrq" name="listing_details_box.slug">
-      <segment>
-        <source>listing_details_box.slug</source>
-        <target>Slug: %slug% (singular: %singularSlug%)</target>
-      </segment>
-    </unit>
-    <unit id="eJ9YbdG" name="listing_details_box.record_template">
-      <segment>
-        <source>listing_details_box.record_template</source>
-        <target>Record template: %template%</target>
-      </segment>
-    </unit>
-    <unit id="tsc7_G3" name="listing_details_box.listing_template">
-      <segment>
-        <source>listing_details_box.listing_template</source>
-        <target>Listing template: %template% (%listingRecords% records)</target>
-      </segment>
-    </unit>
-    <unit id="pPz9Ocx" name="listing_details_box.locales">
-      <segment>
-        <source>listing_details_box.locales</source>
-        <target>Locales: %locales%</target>
-      </segment>
-    </unit>
-    <unit id="qoZwSEY" name="action.preview_secure_share">
-      <segment>
-        <source>action.preview_secure_share</source>
-        <target>Preview link om te delen</target>
-      </segment>
-    </unit>
-    <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <segment>
-        <source>upload.allow_file_types</source>
-        <target>Toegestane bestandstypen</target>
-      </segment>
-    </unit>
-    <unit id="noOf4ML" name="upload.max_size">
-      <segment>
-        <source>upload.max_size</source>
-        <target>Maximale upload-grootte</target>
-      </segment>
-    </unit>
-    <unit id="a_COwtV" name="image.button_upload_options">
-      <segment>
-        <source>image.button_upload_options</source>
-        <target>Upload opties</target>
-      </segment>
-    </unit>
-    <unit id="kciiidS" name="image.button_from_url">
-      <segment>
-        <source>image.button_from_url</source>
-        <target>Vanaf URL</target>
-      </segment>
-    </unit>
-    <unit id="wG04eAa" name="image.image_preview">
-      <segment>
-        <source>image.image_preview</source>
-        <target>Preview afbeelding</target>
-      </segment>
-    </unit>
-    <unit id="a_CQgly" name="Order">
-      <segment>
-        <source>Order</source>
-        <target>Volgorde</target>
-      </segment>
-    </unit>
-    <unit id="Fmpfcri" name="Preview link om te delen">
-      <segment>
-        <source>Preview link om te delen</source>
-        <target>Preview link om te delen</target>
-      </segment>
-    </unit>
-    <unit id="W7z__Yi" name="action.impersonate">
-      <segment>
-        <source>action.impersonate</source>
-        <target>Imiteer</target>
-      </segment>
-    </unit>
-    <unit id="hgNZLwW" name="extensions.title_configuration">
-      <segment>
-        <source>extensions.title_configuration</source>
-        <target>Configuratiebestand</target>
+        <source>collection.move_item_down</source>
+        <target>Omlaag</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>Bekijk details</target>
       </segment>
     </unit>
-    <unit id="txRonia" name="label.id">
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
-        <source>label.id</source>
-        <target>ID</target>
+        <source>extensions.title_configuration</source>
+        <target>Configuratiebestand</target>
       </segment>
     </unit>
-    <unit id="IwLLxxx" name="label.level">
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
-        <source>label.level</source>
-        <target>Level</target>
+        <source>caption.file_upload.upload_text</source>
+        <target>Plaats hier bestanden om te uploaden</target>
       </segment>
     </unit>
-    <unit id="51OQi14" name="label.message">
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
-        <source>label.message</source>
-        <target>Bericht</target>
+        <source>pager.next</source>
+        <target>Volgende</target>
       </segment>
     </unit>
-    <unit id="S0f6iTL" name="label.timestamp">
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
-        <source>label.timestamp</source>
-        <target>Timestamp</target>
+        <source>pager.previous</source>
+        <target>Vorige</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Omhoog</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Omlaag</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Downloaden</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Logs bekijken</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
-        <target>Request</target>
+        <target>Verzoek</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>Trace</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>Context</target>
       </segment>
     </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Niveau</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Bericht</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Tijdstempel</target>
+      </segment>
+    </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>Gebruiker</target>
       </segment>
     </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Uitgeschakeld</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Van slot</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Geen inhoud gevonden</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Geen</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Leeg</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Alles bijwerken</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Systeeminformatie</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Weet je zeker dat je deze content wilt verwijderen?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>je gebruikersnaam of e-mailadres</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>je wachtwoord</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Overige inhoud</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>Opslaan is uitgeschakeld omdat het doelbestand niet beschrijfbaar is.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Dit veld is vertaalbaar</target>
+      </segment>
+    </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>Inhoud</target>
       </segment>
     </unit>
-    <unit id="cH6rDCP" name="Button">
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
-        <source>Button</source>
-        <target>Knop</target>
-      </segment>
-    </unit>
-    <unit id="1LzKCXS" name="&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.">
-      <segment>
-        <source>&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.</source>
-        <target><![CDATA[<strong>Goed gedaan!</strong> Je hebt dit belangrijke bericht gelezen]]></target>
-      </segment>
-    </unit>
-    <unit id="Bicbr0l" name="info">
-      <segment>
-        <source>info</source>
-        <target>info</target>
-      </segment>
-    </unit>
-    <unit id="Ej.WZqo" name="danger">
-      <segment>
-        <source>danger</source>
-        <target>gevaar</target>
-      </segment>
-    </unit>
-    <unit id="a2vzLi7" name="action.do_something">
-      <segment>
-        <source>action.do_something</source>
-        <target>Doe iets</target>
-      </segment>
-    </unit>
-    <unit id="S9k1S7Z" name="warning">
-      <segment>
-        <source>warning</source>
-        <target>Waarschuwing</target>
-      </segment>
-    </unit>
-    <unit id="283aB_E" name="caption.file_upload.upload_text">
-      <segment>
-        <source>caption.file_upload.upload_text</source>
-        <target>Plaats hier bestanden om te uploaden</target>
-      </segment>
-    </unit>
-    <unit id="a6Xhtq0" name="folder.create_new">
-      <segment>
-        <source>folder.create_new</source>
-        <target>Nieuwe map</target>
-      </segment>
-    </unit>
-    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
-      <segment>
-        <source>files_cards.copy_to_clipboard</source>
-        <target>Kopieer link naar bestand</target>
+        <source>file.delete_success</source>
+        <target>Bestand succesvol verwijderd!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Weet je zeker dat je dit bestand wilt verwijderen?</target>
       </segment>
     </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Filter op</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Status succesvol gewijzigd</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Inhoud succesvol verwijderd</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Huidige status</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Gepubliceerd</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>In klad</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Ingepland</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Achtergehouden</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Weet je zeker dat je dit collectie item wilt verwijderen?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Toegestane bestandstypen</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Maximale upload-grootte</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Zoek op trefwoord …</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Alle inhoud, gefilterd op <em>'%filter%'</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Website bekijken</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Nieuw</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Geen bekende afhankelijkheden</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Afhankelijkheden</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Alles uitvouwen</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Alles invouwen</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>De definitie voor dit ContentType ontbreekt! Het bewerken van dit record werkt niet zoals verwacht. Controleer je contenttypes.yaml om er zeker van te zijn dat het %contenttype% bevat.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Selecteren …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Je gebruikersnaam of e-mail</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Geef je wachtwoord op</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Voer je e-mailadres in</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filteren op veld</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Vanaf URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Kopieer link naar bestand</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Waarschuwing</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Map bestaat al</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Kon map niet aanmaken</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Map succesvol aangemaakt.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Map succesvol verwijderd</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Nieuwe map</target>
+      </segment>
+    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>Avatar</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
       <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>Je moet ingelogd zijn om deze pagina te bekijken.</target>
+        <source>login.forgotpassword</source>
+        <target>Wachtwoord vergeten</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Wachtwoord opnieuw instellen</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Voer je e-mailadres in en we sturen je een link om je wachtwoord opnieuw in te stellen.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Verzenden</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Terug naar inloggen</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Stel je wachtwoord opnieuw in</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>E-mail voor wachtwoordherstel verzonden</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Er is een e-mail verzonden met een link waarop je kunt klikken om je wachtwoord opnieuw in te stellen. Deze link verloopt over %hours% uur.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Als je geen e-mail ontvangt, controleer dan je spammap of %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Wachtwoord opnieuw instellen</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Hoi!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Om je wachtwoord opnieuw in te stellen, bezoek je de volgende link</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Deze link verloopt over %hours% uur.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Groeten!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Voer een wachtwoord in</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Herhaal wachtwoord</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>De wachtwoordvelden moeten overeenkomen.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Je wachtwoord moet minstens %s tekens bevatten</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Geen token voor wachtwoordherstel gevonden in de URL of in de sessie.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Je wachtwoord is succesvol opnieuw ingesteld.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Er is een probleem opgetreden bij het verwerken van je verzoek om het wachtwoord opnieuw in te stellen - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>gefilterd op</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Preview link om te delen</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Beëindig imiteren gebruiker</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Imiteer</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Onderhoudsmodus is geactiveerd</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Vernieuwen</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Toon records %current% van %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Naam: %name% (singular: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (enkelvoud: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Recordsjabloon: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Overzichtssjabloon: %template% (%listingRecords% records)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Talen: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Bewerk permissies</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Zoek</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Preview afbeelding</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Selecteer alle</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Onthoud me? (%duration% dagen)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Huidige sessies</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Upload opties</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Volgorde</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>je e-mailadres</target>
       </segment>
     </unit>
     <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>modal.title.file_field</source>
         <target>Kies een bestand</target>
       </segment>
     </unit>
     <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
       <segment>
         <source>modal.title.image_field</source>
         <target>Kies een afbeelding</target>
       </segment>
     </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Uploaden vanaf URL</target>
+      </segment>
+    </unit>
     <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
       <segment>
         <source>modal.text.loading</source>
-        <target>Loading...</target>
+        <target>Laden…</target>
       </segment>
     </unit>
     <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
       <segment>
         <source>modal.button_save</source>
         <target>Opslaan</target>
       </segment>
     </unit>
     <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
       <segment>
         <source>modal.button_deny</source>
         <target>Sluiten</target>
-      </segment>
-    </unit>
-    <unit id="JpJFIFq" name="collection.confirm_delete">
-      <segment>
-        <source>collection.confirm_delete</source>
-        <target>Weet je zeker dat je dit collectie item wilt verwijderen?</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.pl.xlf
+++ b/translations/messages.pl.xlf
@@ -1,1355 +1,3437 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="pl" trgLang="pl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pl">
   <file id="messages.pl">
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Edytuj użytkownika</target>
       </segment>
     </unit>
+    <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
+      <segment>
+        <source>action.save</source>
+        <target>Zapisz zmiany</target>
+      </segment>
+    </unit>
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>action.do_something</source>
+        <target>Zrób coś</target>
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>action.edit</source>
+        <target>Edytuj</target>
+      </segment>
+    </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Nazwa użytkownika</target>
       </segment>
     </unit>
-    <unit id="HLtdhYw" name="action.save">
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
       <segment>
-        <source>action.save</source>
-        <target>Zapisz zmiany</target>
-      </segment>
-    </unit>
-    <unit id="TpGxDI3" name="user.unknown_user">
-      <segment>
-        <source>user.unknown_user</source>
-        <target>Nieznany użytkownik</target>
-      </segment>
-    </unit>
-    <unit id="1xlE8ex" name="caption.content">
-      <segment>
-        <source>caption.content</source>
-        <target>Zawartość</target>
-      </segment>
-    </unit>
-    <unit id="ZO.uqIZ" name="caption.settings">
-      <segment>
-        <source>caption.settings</source>
-        <target>Ustawienia</target>
-      </segment>
-    </unit>
-    <unit id="zOLL.7E" name="caption.configuration">
-      <segment>
-        <source>caption.configuration</source>
-        <target>Konfiguracja</target>
-      </segment>
-    </unit>
-    <unit id="7aLIA3c" name="caption.dashboard">
-      <segment>
-        <source>caption.dashboard</source>
-        <target>Panel Bolta</target>
-      </segment>
-    </unit>
-    <unit id="ipmA6Ah" name="caption.users_permissions">
-      <segment>
-        <source>caption.users_permissions</source>
-        <target>Użytkownicy i uprawnienia</target>
-      </segment>
-    </unit>
-    <unit id="kXNBV9S" name="caption.main_configuration">
-      <segment>
-        <source>caption.main_configuration</source>
-        <target>Główna konfiguracja</target>
-      </segment>
-    </unit>
-    <unit id="_w7J5rZ" name="caption.contenttypes">
-      <segment>
-        <source>caption.contenttypes</source>
-        <target>Typy zawartości</target>
-      </segment>
-    </unit>
-    <unit id="drK.0GZ" name="caption.taxonomies">
-      <segment>
-        <source>caption.taxonomies</source>
-        <target>Taksonomie</target>
-      </segment>
-    </unit>
-    <unit id="wBKDkwl" name="caption.routing_setup">
-      <segment>
-        <source>caption.routing_setup</source>
-        <target>Ustawienia ścieżek</target>
-      </segment>
-    </unit>
-    <unit id="2RUXD4A" name="caption.menu_setup">
-      <segment>
-        <source>caption.menu_setup</source>
-        <target>Ustawienia menu</target>
-      </segment>
-    </unit>
-    <unit id="i4cbdta" name="caption.all_configuration_files">
-      <segment>
-        <source>caption.all_configuration_files</source>
-        <target>Wszystkie pliki konfiguracji</target>
-      </segment>
-    </unit>
-    <unit id="mfvtHPQ" name="caption.extensions">
-      <segment>
-        <source>caption.extensions</source>
-        <target>Rozszerzenia</target>
-      </segment>
-    </unit>
-    <unit id="OpKTKAL" name="caption.maintenance">
-      <segment>
-        <source>caption.maintenance</source>
-        <target>Konserwacja</target>
-      </segment>
-    </unit>
-    <unit id="2MtT_h0" name="caption.logviewer">
-      <segment>
-        <source>caption.logviewer</source>
-        <target>Czytnik logów</target>
-      </segment>
-    </unit>
-    <unit id="Dvu2HQx" name="caption.api">
-      <segment>
-        <source>caption.api</source>
-        <target>API</target>
-      </segment>
-    </unit>
-    <unit id="K6TmK4B" name="caption.clear_cache">
-      <segment>
-        <source>caption.clear_cache</source>
-        <target>Wyczyść cache</target>
-      </segment>
-    </unit>
-    <unit id="dd5MzCM" name="caption.translations">
-      <segment>
-        <source>caption.translations</source>
-        <target>Tłumaczenia / Etykiety</target>
-      </segment>
-    </unit>
-    <unit id="wLaDaK5" name="caption.about_bolt">
-      <segment>
-        <source>caption.about_bolt</source>
-        <target>O Bolcie</target>
-      </segment>
-    </unit>
-    <unit id="l4yt0BE" name="caption.file_management">
-      <segment>
-        <source>caption.file_management</source>
-        <target>Zarządzanie plikami</target>
-      </segment>
-    </unit>
-    <unit id="bq6bSf4" name="caption.uploaded_files">
-      <segment>
-        <source>caption.uploaded_files</source>
-        <target>Załadowane pliki</target>
-      </segment>
-    </unit>
-    <unit id="K4D568R" name="caption.view_edit_templates">
-      <segment>
-        <source>caption.view_edit_templates</source>
-        <target>Podgląd i edycja szablonów</target>
-      </segment>
-    </unit>
-    <unit id="UZFanGF" name="about.bolt_documentation">
-      <segment>
-        <source>about.bolt_documentation</source>
-        <target>Dokumentacja Bolta</target>
-      </segment>
-    </unit>
-    <unit id="b_RPpcB" name="general.greeting">
-      <segment>
-        <source>general.greeting</source>
-        <target>Witaj %name%</target>
-      </segment>
-    </unit>
-    <unit id="bmdn3u9" name="action.logout">
-      <segment>
-        <source>action.logout</source>
-        <target>Wyloguj</target>
-      </segment>
-    </unit>
-    <unit id="zOfpTLD" name="action.edit_profile">
-      <segment>
-        <source>action.edit_profile</source>
-        <target>Edytuj profil</target>
-      </segment>
-    </unit>
-    <unit id="k.JymqB" name="about.visit_bolt">
-      <segment>
-        <source>about.visit_bolt</source>
-        <target>Odwiedź Boltcms.io</target>
-      </segment>
-    </unit>
-    <unit id="wGlnx8X" name="general.phrase.search">
-      <segment>
-        <source>general.phrase.search</source>
-        <target>Szukaj</target>
-      </segment>
-    </unit>
-    <unit id="O_m7mx1" name="listing.placeholder_search">
-      <segment>
-        <source>listing.placeholder_search</source>
-        <target>Szukaj po słowie kluczu</target>
-      </segment>
-    </unit>
-    <unit id="Dgtkgju" name="title.edit_user_profile">
-      <segment>
-        <source>title.edit_user_profile</source>
-        <target>Edytuj profil użytkownika</target>
-      </segment>
-    </unit>
-    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment>
-        <source>admin_sidebar_toggler.toggle</source>
-        <target><![CDATA[<span class="sr-only">Przełącz </span>menu]]></target>
-      </segment>
-    </unit>
-    <unit id="Gabafxx" name="admin_sidebar.toggler">
-      <segment>
-        <source>admin_sidebar.toggler</source>
-        <target>Przełącz szerokość bocznego panelu</target>
-      </segment>
-    </unit>
-    <unit id="f.rvF6y" name="action.new">
-      <segment>
-        <source>action.new</source>
-        <target>Nowy</target>
-      </segment>
-    </unit>
-    <unit id="TtmWqX3" name="action.view">
-      <segment>
-        <source>action.view</source>
-        <target>Zobacz</target>
-      </segment>
-    </unit>
-    <unit id="SeTqePC" name="label.display_name">
-      <segment>
-        <source>label.display_name</source>
-        <target>Wyświetlana nazwa</target>
+        <source>title.login</source>
+        <target>Logowanie</target>
       </segment>
     </unit>
     <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
       <segment>
         <source>label.password</source>
         <target>Hasło</target>
       </segment>
     </unit>
-    <unit id="D2N6_cP" name="label.email">
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
       <segment>
-        <source>label.email</source>
-        <target>Adres e-mail</target>
-      </segment>
-    </unit>
-    <unit id="mEDsKHk" name="label.locale">
-      <segment>
-        <source>label.locale</source>
-        <target>Lokalizacja</target>
-      </segment>
-    </unit>
-    <unit id="N_0yRcH" name="action.close_alert">
-      <segment>
-        <source>action.close_alert</source>
-        <target>Zamknij</target>
-      </segment>
-    </unit>
-    <unit id="z2AgHGp" name="flash_messages.notification">
-      <segment>
-        <source>flash_messages.notification</source>
-        <target>Powiadomienie</target>
-      </segment>
-    </unit>
-    <unit id="ruQIhH0" name="success">
-      <segment>
-        <source>success</source>
-        <target>Sukces!</target>
-      </segment>
-    </unit>
-    <unit id="YDH.7uR" name="user.updated_profile">
-      <segment>
-        <source>user.updated_profile</source>
-        <target>Profil użytkownika został zaktualizowany!</target>
-      </segment>
-    </unit>
-    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-      <segment>
-        <source>listing_select_box.card_header.selected</source>
-        <target>Zaznaczony</target>
-      </segment>
-    </unit>
-    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment>
-        <source>listing_table.actions.status_to_draft</source>
-        <target>Zmień status na 'wersja robocza'</target>
-      </segment>
-    </unit>
-    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment>
-        <source>listing_table.actions.status_to_held</source>
-        <target>Zmień status na 'wstrzymany'</target>
-      </segment>
-    </unit>
-    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment>
-        <source>listing_table.actions.status_to_publish</source>
-        <target>Zmień status na 'opublikowany'</target>
-      </segment>
-    </unit>
-    <unit id="hTKWQ6g" name="action.delete">
-      <segment>
-        <source>action.delete</source>
-        <target>Usuń</target>
-      </segment>
-    </unit>
-    <unit id="WeJxw6Z" name="action.update_all">
-      <segment>
-        <source>action.update_all</source>
-        <target>Zastosuj do wszystkich</target>
+        <source>action.log_in</source>
+        <target>Zaloguj</target>
       </segment>
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>Lista treści</target>
       </segment>
     </unit>
-    <unit id="KfVJho2" name="action.create_new">
-      <segment>
-        <source>action.create_new</source>
-        <target>Utwórz nowy</target>
-      </segment>
-    </unit>
-    <unit id="wQ0WYAT" name="listing.title_sortby">
-      <segment>
-        <source>listing.title_sortby</source>
-        <target>Sortuj po</target>
-      </segment>
-    </unit>
-    <unit id="hp554Ds" name="listing.option_select_sortby">
-      <segment>
-        <source>listing.option_select_sortby</source>
-        <target>Wybierz pole, po którym chcesz sortować</target>
-      </segment>
-    </unit>
-    <unit id="IWbf2by" name="listing.title_filterby">
-      <segment>
-        <source>listing.title_filterby</source>
-        <target>Szukaj / Filtruj po</target>
-      </segment>
-    </unit>
-    <unit id="pn22p7q" name="listing.placeholder_filter">
-      <segment>
-        <source>listing.placeholder_filter</source>
-        <target>Słowo klucz do filtrowania ...</target>
-      </segment>
-    </unit>
-    <unit id="ni4zApC" name="listing.button_filter">
-      <segment>
-        <source>listing.button_filter</source>
-        <target>Filtruj</target>
-      </segment>
-    </unit>
-    <unit id="n.3JZvX" name="title.contentType">
-      <segment>
-        <source>title.contentType</source>
-        <target>Typ zawartości</target>
-      </segment>
-    </unit>
-    <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment>
-        <source>listing_filter.button_compact</source>
-        <target>Kompaktowy</target>
-      </segment>
-    </unit>
-    <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment>
-        <source>listing_filter.button_expanded</source>
-        <target>Rozwinięty</target>
-      </segment>
-    </unit>
-    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-      <segment>
-        <source>listing_table.actions.view_on_site</source>
-        <target>Zobacz na Stronie</target>
-      </segment>
-    </unit>
-    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment>
-        <source>listing_table.actions.duplicate</source>
-        <target>Powiel</target>
-      </segment>
-    </unit>
-    <unit id="hR8ri.m" name="listing_table.actions.delete">
-      <segment>
-        <source>listing_table.actions.delete</source>
-        <target>Usuń</target>
-      </segment>
-    </unit>
-    <unit id="5zbX1vo" name="listing_table.actions.slug">
-      <segment>
-        <source>listing_table.actions.slug</source>
-        <target>Slug</target>
-      </segment>
-    </unit>
-    <unit id="wKDOBOC" name="listing_table.actions.created_on">
-      <segment>
-        <source>listing_table.actions.created_on</source>
-        <target>Utworzono</target>
-      </segment>
-    </unit>
-    <unit id="tVX01Xl" name="listing_table.actions.published_on">
-      <segment>
-        <source>listing_table.actions.published_on</source>
-        <target>Opublikowano</target>
-      </segment>
-    </unit>
-    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment>
-        <source>listing_table.actions.last_modified_on</source>
-        <target>Ostatnio zmodyfikowano</target>
-      </segment>
-    </unit>
-    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-      <segment>
-        <source>listing_table.actions.button_edit</source>
-        <target>Edytuj</target>
-      </segment>
-    </unit>
-    <unit id="AMxTho9" name="pager.previous">
-      <segment>
-        <source>pager.previous</source>
-        <target>Poprzednia</target>
-      </segment>
-    </unit>
-    <unit id="L_YQKUn" name="pager.next">
-      <segment>
-        <source>pager.next</source>
-        <target>Następna</target>
-      </segment>
-    </unit>
-    <unit id="cH6rDCP" name="Button">
-      <segment>
-        <source>Button</source>
-        <target>Przycisk</target>
-      </segment>
-    </unit>
-    <unit id="1LzKCXS" name="&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.">
-      <segment>
-        <source>&lt;strong&gt;Well done!&lt;/strong&gt; You successfully read this important alert message.</source>
-        <target><![CDATA[<strong>Dobra robota!</strong> Pomyślnie przeczytałeś ten ważny komunikat ostrzegawczy.]]></target>
-      </segment>
-    </unit>
-    <unit id="a2vzLi7" name="action.do_something">
-      <segment>
-        <source>action.do_something</source>
-        <target>Zrób coś</target>
-      </segment>
-    </unit>
-    <unit id="hAysbHB" name="label.translatable">
-      <segment>
-        <source>label.translatable</source>
-        <target>To pole można przetłumaczyć</target>
-      </segment>
-    </unit>
-    <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <segment>
-        <source>upload.allow_file_types</source>
-        <target>Typy plików, które można przesyłać</target>
-      </segment>
-    </unit>
-    <unit id="noOf4ML" name="upload.max_size">
-      <segment>
-        <source>upload.max_size</source>
-        <target>Maksymalny rozmiar przesyłanych plików</target>
-      </segment>
-    </unit>
-    <unit id="vptPhch" name="image.button_upload">
-      <segment>
-        <source>image.button_upload</source>
-        <target>Prześlij</target>
-      </segment>
-    </unit>
-    <unit id="vIVO1lU" name="image.button_from_library">
-      <segment>
-        <source>image.button_from_library</source>
-        <target>Z biblioteki</target>
-      </segment>
-    </unit>
-    <unit id="FqVh1Hv" name="image.button_remove">
-      <segment>
-        <source>image.button_remove</source>
-        <target>Usuń</target>
-      </segment>
-    </unit>
-    <unit id="oOuVKRv" name="image.placeholder_filename">
-      <segment>
-        <source>image.placeholder_filename</source>
-        <target>image.placeholder_filename</target>
-      </segment>
-    </unit>
-    <unit id="eHV6ZJB" name="image.button_edit_attributes">
-      <segment>
-        <source>image.button_edit_attributes</source>
-        <target>Edytuj atrybuty</target>
-      </segment>
-    </unit>
-    <unit id="S9k1S7Z" name="warning">
-      <segment>
-        <source>warning</source>
-        <target>Ostrzeżenie</target>
-      </segment>
-    </unit>
-    <unit id="Bicbr0l" name="info">
-      <segment>
-        <source>info</source>
-        <target>informacja</target>
-      </segment>
-    </unit>
-    <unit id="Ej.WZqo" name="danger">
-      <segment>
-        <source>danger</source>
-        <target>niebezpieczeństwo</target>
-      </segment>
-    </unit>
-    <unit id="JEnqOi." name="title.primary_actions">
-      <segment>
-        <source>title.primary_actions</source>
-        <target>Podstawowe Działania</target>
-      </segment>
-    </unit>
-    <unit id="dQIY7_J" name="action.preview">
-      <segment>
-        <source>action.preview</source>
-        <target>Podejrzyj</target>
-      </segment>
-    </unit>
-    <unit id=".I3mIHo" name="label.current_status">
-      <segment>
-        <source>label.current_status</source>
-        <target>Obecny status</target>
-      </segment>
-    </unit>
-    <unit id="utGAKaQ" name="status.published">
-      <segment>
-        <source>status.published</source>
-        <target>Opublikowany</target>
-      </segment>
-    </unit>
-    <unit id="eVkSIKu" name="field.modifiedAt">
-      <segment>
-        <source>field.modifiedAt</source>
-        <target>Zmodyfikowano</target>
-      </segment>
-    </unit>
-    <unit id="ok6YulQ" name="action.view_saved">
-      <segment>
-        <source>action.view_saved</source>
-        <target>Zobacz zapisaną wersję</target>
-      </segment>
-    </unit>
-    <unit id="6Gw1lsE" name="action.confirm_delete">
-      <segment>
-        <source>action.confirm_delete</source>
-        <target>Czy na pewno zamierzasz usunąć tę zawartość?</target>
-      </segment>
-    </unit>
-    <unit id="8zEzq8N" name="field.current_locale">
-      <segment>
-        <source>field.current_locale</source>
-        <target>Obecna lokalizacja</target>
-      </segment>
-    </unit>
-    <unit id="7616Os4" name="title.options">
-      <segment>
-        <source>title.options</source>
-        <target>Opcje</target>
-      </segment>
-    </unit>
-    <unit id="FuCyk5C" name="field.status">
-      <segment>
-        <source>field.status</source>
-        <target>Status</target>
-      </segment>
-    </unit>
-    <unit id="oxqDDuK" name="status.held">
-      <segment>
-        <source>status.held</source>
-        <target>Wstrzymany</target>
-      </segment>
-    </unit>
-    <unit id="HJbHjee" name="status.draft">
-      <segment>
-        <source>status.draft</source>
-        <target>Wersja robocza</target>
-      </segment>
-    </unit>
-    <unit id="3gdi1dy" name="field.publishedAt">
-      <segment>
-        <source>field.publishedAt</source>
-        <target>Opublikowano</target>
-      </segment>
-    </unit>
-    <unit id="BINgtmK" name="editor_date.toggle">
-      <segment>
-        <source>editor_date.toggle</source>
-        <target>Przełącz</target>
-      </segment>
-    </unit>
-    <unit id="eN7IfEL" name="field.depublishedAt">
-      <segment>
-        <source>field.depublishedAt</source>
-        <target>Zdjęto</target>
-      </segment>
-    </unit>
-    <unit id="aQX4Emy" name="field.author">
-      <segment>
-        <source>field.author</source>
-        <target>Autor</target>
-      </segment>
-    </unit>
-    <unit id="O9wtVOp" name="field.createdAt">
-      <segment>
-        <source>field.createdAt</source>
-        <target>Utworzono</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
       <segment>
         <source>field.id</source>
         <target>ID</target>
       </segment>
     </unit>
-    <unit id="XQ2U6fN" name="slug.button_unlocked">
+    <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
       <segment>
-        <source>slug.button_unlocked</source>
-        <target>Odblokowany</target>
+        <source>field.status</source>
+        <target>Status</target>
       </segment>
     </unit>
-    <unit id="HK7XTUX" name="caption.edit">
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
       <segment>
-        <source>caption.edit</source>
-        <target>Edytuj</target>
+        <source>field.createdAt</source>
+        <target>Utworzono</target>
       </segment>
     </unit>
-    <unit id="kaK5Wdr" name="slug.button_locked">
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
       <segment>
-        <source>slug.button_locked</source>
-        <target>Zablokowany</target>
+        <source>field.modifiedAt</source>
+        <target>Zmodyfikowano</target>
       </segment>
     </unit>
-    <unit id="qcDEz5O" name="slug.button_edit">
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
       <segment>
-        <source>slug.button_edit</source>
-        <target>Edytuj</target>
+        <source>field.publishedAt</source>
+        <target>Opublikowano</target>
       </segment>
     </unit>
-    <unit id="raO5QSf" name="slug.generate_from">
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
       <segment>
-        <source>slug.generate_from</source>
-        <target>Utwórz na podstawie</target>
+        <source>field.depublishedAt</source>
+        <target>Zdjęto</target>
       </segment>
     </unit>
-    <unit id="h7dP3WY" name="status.timed">
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
       <segment>
-        <source>status.timed</source>
-        <target>Zaplanowany</target>
+        <source>field.title</source>
+        <target>Tytuł</target>
       </segment>
     </unit>
-    <unit id="ahZvOJz" name="field.switch_to_locale">
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
       <segment>
-        <source>field.switch_to_locale</source>
-        <target>Zmień lokalizację na</target>
+        <source>field.description</source>
+        <target>Opis</target>
       </segment>
     </unit>
-    <unit id="ypPzS03" name="localeswitcher.button_info">
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
       <segment>
-        <source>localeswitcher.button_info</source>
-        <target>Zobacz informacje na temat Lokalizacji</target>
+        <source>field.copyright</source>
+        <target>Prawa autorskie</target>
       </segment>
     </unit>
-    <unit id="BWubOnS" name="image.placeholder_alt_text">
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
       <segment>
-        <source>image.placeholder_alt_text</source>
-        <target>Atrybut "alt"</target>
+        <source>field.originalFilename</source>
+        <target>Oryginalna nazwa pliku</target>
       </segment>
     </unit>
-    <unit id="Hlf9c1s" name="listing.title_overview">
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
       <segment>
-        <source>listing.title_overview</source>
-        <target>Widok ogólny</target>
+        <source>field.width</source>
+        <target>szerokość</target>
       </segment>
     </unit>
-    <unit id="Wou02nK" name="caption.kitchensink">
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
       <segment>
-        <source>caption.kitchensink</source>
-        <target>caption.kitchensink</target>
+        <source>field.height</source>
+        <target>wysokość</target>
       </segment>
     </unit>
-    <unit id="munFS0n" name="title.filtered_by">
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
       <segment>
-        <source>title.filtered_by</source>
-        <target><![CDATA[Cała zawartość, przefiltrowana po <em>'%filter%'</em>.]]></target>
+        <source>field.filesize</source>
+        <target>Rozmiar pliku</target>
       </segment>
     </unit>
-    <unit id="HBwIQ9b" name="controller.user.subtitle">
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
       <segment>
-        <source>controller.user.subtitle</source>
-        <target>Do edycji użytkowników i ich uprawnień</target>
+        <source>label.username_or_email</source>
+        <target>Nazwa użytkownika lub email</target>
       </segment>
     </unit>
-    <unit id="Iy4HXCU" name="controller.user.title">
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
       <segment>
-        <source>controller.user.title</source>
-        <target>Użytkownicy i Uprawnienia</target>
+        <source>label.rememberme</source>
+        <target>Zapamiętaj mnie?</target>
       </segment>
     </unit>
-    <unit id="7cXqH5s" name="listing.title_display_name">
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
       <segment>
-        <source>listing.title_display_name</source>
-        <target>Wyświetlana nazwa</target>
+        <source>about.visit_bolt</source>
+        <target>Odwiedź Boltcms.io</target>
       </segment>
     </unit>
-    <unit id="Ay7xZ2h" name="listing.title_username">
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
       <segment>
-        <source>listing.title_username</source>
-        <target>Nazwa użytkownika</target>
-      </segment>
-    </unit>
-    <unit id="RN1tdtJ" name="listing.title_email">
-      <segment>
-        <source>listing.title_email</source>
-        <target>Adres e-mail</target>
-      </segment>
-    </unit>
-    <unit id="0pjZ.GV" name="listing.title_roles">
-      <segment>
-        <source>listing.title_roles</source>
-        <target>Role</target>
-      </segment>
-    </unit>
-    <unit id="hXEFV1n" name="listing.title_last_seen">
-      <segment>
-        <source>listing.title_last_seen</source>
-        <target>Ostatnio widziany</target>
-      </segment>
-    </unit>
-    <unit id="pn7kE17" name="listing.title_last_ip">
-      <segment>
-        <source>listing.title_last_ip</source>
-        <target>Ostatni IP</target>
-      </segment>
-    </unit>
-    <unit id="GZ65uOC" name="listing.title_actions">
-      <segment>
-        <source>listing.title_actions</source>
-        <target>Działania</target>
-      </segment>
-    </unit>
-    <unit id="ovKkXwU" name="action.edit">
-      <segment>
-        <source>action.edit</source>
-        <target>Edytuj</target>
-      </segment>
-    </unit>
-    <unit id="ryXZRAu" name="action.disable">
-      <segment>
-        <source>action.disable</source>
-        <target>Zablokuj</target>
-      </segment>
-    </unit>
-    <unit id="3zlZmRK" name="action.add_user">
-      <segment>
-        <source>action.add_user</source>
-        <target>Dodaj użytkownika</target>
-      </segment>
-    </unit>
-    <unit id="Npkio79" name="listing.title_session_expires">
-      <segment>
-        <source>listing.title_session_expires</source>
-        <target>Sesja wygasa</target>
-      </segment>
-    </unit>
-    <unit id="mmUDcto" name="listing.title_ip_address">
-      <segment>
-        <source>listing.title_ip_address</source>
-        <target>Adres IP</target>
-      </segment>
-    </unit>
-    <unit id="x9qAwrz" name="listing.title_browser">
-      <segment>
-        <source>listing.title_browser</source>
-        <target>Przeglądarka / platforma</target>
-      </segment>
-    </unit>
-    <unit id="3MuwWwe" name="listing.disabled">
-      <segment>
-        <source>listing.disabled</source>
-        <target>Zablokowany</target>
-      </segment>
-    </unit>
-    <unit id="ezqx.4H" name="action.enable">
-      <segment>
-        <source>action.enable</source>
-        <target>Odblokuj</target>
-      </segment>
-    </unit>
-    <unit id="OBmPOoB" name="user.updated_successfully">
-      <segment>
-        <source>user.updated_successfully</source>
-        <target>Aktualizacja zakończyła się powodzeniem.</target>
-      </segment>
-    </unit>
-    <unit id="7whLbH8" name="user.new_user">
-      <segment>
-        <source>user.new_user</source>
-        <target>Nowy użytkownik</target>
-      </segment>
-    </unit>
-    <unit id="hiE9jap" name="password.suggested">
-      <segment>
-        <source>password.suggested</source>
-        <target><![CDATA[Sugerowane bezpieczne hasło: <code>%password%</code>]]></target>
-      </segment>
-    </unit>
-    <unit id="iD6CNOO" name="label.roles">
-      <segment>
-        <source>label.roles</source>
-        <target>Role</target>
-      </segment>
-    </unit>
-    <unit id="FSroufa" name="caption.path">
-      <segment>
-        <source>caption.path</source>
-        <target>Ścieżka</target>
-      </segment>
-    </unit>
-    <unit id="P1FHg3Q" name="caption.edit_file">
-      <segment>
-        <source>caption.edit_file</source>
-        <target>Edytuj plik</target>
-      </segment>
-    </unit>
-    <unit id="LaDIuZA" name="caption.meta_information">
-      <segment>
-        <source>caption.meta_information</source>
-        <target>Meta informacje</target>
-      </segment>
-    </unit>
-    <unit id="73A2bWM" name="finder.label_view">
-      <segment>
-        <source>finder.label_view</source>
-        <target>Tryb widoku</target>
-      </segment>
-    </unit>
-    <unit id="m3tNvJb" name="finder.button_list">
-      <segment>
-        <source>finder.button_list</source>
-        <target>Lista</target>
-      </segment>
-    </unit>
-    <unit id="tRLgeoX" name="finder.button_cards">
-      <segment>
-        <source>finder.button_cards</source>
-        <target>Karty</target>
-      </segment>
-    </unit>
-    <unit id="QZYjRy0" name="caption.file_uploader">
-      <segment>
-        <source>caption.file_uploader</source>
-        <target>Przesyłanie plików</target>
-      </segment>
-    </unit>
-    <unit id="283aB_E" name="caption.file_upload.upload_text">
-      <segment>
-        <source>caption.file_upload.upload_text</source>
-        <target>Upuść tutaj pliki, aby je przesłać</target>
-      </segment>
-    </unit>
-    <unit id="v6cfPyt" name="quickselect.title_select">
-      <segment>
-        <source>quickselect.title_select</source>
-        <target>Wybierz plik</target>
-      </segment>
-    </unit>
-    <unit id="C15MbYY" name="form.quick_select_file">
-      <segment>
-        <source>form.quick_select_file</source>
-        <target>Szybko wybierz plik do edycji...</target>
-      </segment>
-    </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Katalogi</target>
-      </segment>
-    </unit>
-    <unit id="KHvGNGW" name="directoryname">
-      <segment>
-        <source>directoryname</source>
-        <target>Nazwa katalogu</target>
-      </segment>
-    </unit>
-    <unit id="Kw3N1AA" name="actions">
-      <segment>
-        <source>actions</source>
-        <target>Działania</target>
-      </segment>
-    </unit>
-    <unit id="_XSgfqS" name="filename">
-      <segment>
-        <source>filename</source>
-        <target>Nazwa pliku</target>
-      </segment>
-    </unit>
-    <unit id="zNy_hG8" name="size">
-      <segment>
-        <source>size</source>
-        <target>Rozmiar</target>
-      </segment>
-    </unit>
-    <unit id="gPYflhh" name="thumbnail">
-      <segment>
-        <source>thumbnail</source>
-        <target>Miniatura</target>
-      </segment>
-    </unit>
-    <unit id="DodjLNR" name="date">
-      <segment>
-        <source>date</source>
-        <target>Data</target>
-      </segment>
-    </unit>
-    <unit id="5LXvJfE" name="files_cards.action_edit_file">
-      <segment>
-        <source>files_cards.action_edit_file</source>
-        <target>Edytuj plik w edytorze</target>
-      </segment>
-    </unit>
-    <unit id="H1pgP94" name="files_cards.action_view_original">
-      <segment>
-        <source>files_cards.action_view_original</source>
-        <target>Zobacz oryginał</target>
-      </segment>
-    </unit>
-    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <segment>
-        <source>files_cards.action_duplicate</source>
-        <target>Powiel</target>
-      </segment>
-    </unit>
-    <unit id="wHPoBzP" name="file.delete_confirm">
-      <segment>
-        <source>file.delete_confirm</source>
-        <target>Czy jesteś pewien/pewna, że chcesz usunąć ten plik?</target>
-      </segment>
-    </unit>
-    <unit id="JjU6ZQP" name="files_cards.action_delete">
-      <segment>
-        <source>files_cards.action_delete</source>
-        <target>Usuń</target>
-      </segment>
-    </unit>
-    <unit id="3jdNwuk" name="files_cards.label_filename">
-      <segment>
-        <source>files_cards.label_filename</source>
-        <target>Nazwa pliku:</target>
-      </segment>
-    </unit>
-    <unit id="eQBhceV" name="files_cards.label_filesize">
-      <segment>
-        <source>files_cards.label_filesize</source>
-        <target>Rozmiar pliku:</target>
-      </segment>
-    </unit>
-    <unit id="uiCjlwk" name="files_cards.label_created_on">
-      <segment>
-        <source>files_cards.label_created_on</source>
-        <target>Utworzony:</target>
-      </segment>
-    </unit>
-    <unit id="nrWBJNm" name="extensions.title_desc">
-      <segment>
-        <source>extensions.title_desc</source>
-        <target>Opis:</target>
-      </segment>
-    </unit>
-    <unit id="7raDJAR" name="extensions.title_author">
-      <segment>
-        <source>extensions.title_author</source>
-        <target>Autor:</target>
-      </segment>
-    </unit>
-    <unit id="UP8pNGy" name="extensions.title_package">
-      <segment>
-        <source>extensions.title_package</source>
-        <target>Paczka / Nazwa klasy:</target>
-      </segment>
-    </unit>
-    <unit id="hgNZLwW" name="extensions.title_configuration">
-      <segment>
-        <source>extensions.title_configuration</source>
-        <target>Plik konfiguracji:</target>
-      </segment>
-    </unit>
-    <unit id="QFQ1uTC" name="extensions.title_version">
-      <segment>
-        <source>extensions.title_version</source>
-        <target>Wersja:</target>
-      </segment>
-    </unit>
-    <unit id="BFARQEU" name="extensions.button_detailed_view">
-      <segment>
-        <source>extensions.button_detailed_view</source>
-        <target>Zobacz szczegóły</target>
-      </segment>
-    </unit>
-    <unit id="mjhFljb" name="extensions.button_configuration">
-      <segment>
-        <source>extensions.button_configuration</source>
-        <target>Edytuj konfigurację</target>
-      </segment>
-    </unit>
-    <unit id="r3ryNTG" name="extensions.button_source">
-      <segment>
-        <source>extensions.button_source</source>
-        <target>Źródło</target>
-      </segment>
-    </unit>
-    <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment>
-        <source>extensions.message_not_implemented</source>
-        <target>Jeszcze nie zaimplementowane. Wybacz!</target>
-      </segment>
-    </unit>
-    <unit id="qc3rFkZ" name="extensions.button_remove">
-      <segment>
-        <source>extensions.button_remove</source>
-        <target>Usuń rozszerzenie</target>
-      </segment>
-    </unit>
-    <unit id="SLZyVzU" name="extensions.button_disable">
-      <segment>
-        <source>extensions.button_disable</source>
-        <target>Zablokuj rozszerzenie</target>
-      </segment>
-    </unit>
-    <unit id="LfwezhR" name="extensions.title_dependencies">
-      <segment>
-        <source>extensions.title_dependencies</source>
-        <target>Zależności</target>
-      </segment>
-    </unit>
-    <unit id="txRonia" name="label.id">
-      <segment>
-        <source>label.id</source>
-        <target>ID</target>
-      </segment>
-    </unit>
-    <unit id="IwLLxxx" name="label.level">
-      <segment>
-        <source>label.level</source>
-        <target>Poziom</target>
-      </segment>
-    </unit>
-    <unit id="51OQi14" name="label.message">
-      <segment>
-        <source>label.message</source>
-        <target>Wiadomość</target>
-      </segment>
-    </unit>
-    <unit id="S0f6iTL" name="label.timestamp">
-      <segment>
-        <source>label.timestamp</source>
-        <target>Znacznik czasu</target>
-      </segment>
-    </unit>
-    <unit id="FlGE3qB" name="label.request">
-      <segment>
-        <source>label.request</source>
-        <target>Żądanie</target>
-      </segment>
-    </unit>
-    <unit id="l71Tprl" name="label.trace">
-      <segment>
-        <source>label.trace</source>
-        <target>Ślad</target>
-      </segment>
-    </unit>
-    <unit id="29ZEo1r" name="label.context">
-      <segment>
-        <source>label.context</source>
-        <target>Kontekst</target>
-      </segment>
-    </unit>
-    <unit id="O2X4xZH" name="label.user">
-      <segment>
-        <source>label.user</source>
-        <target>Użytkownik</target>
-      </segment>
-    </unit>
-    <unit id="2MMvCKK" name="label.cache_cleared">
-      <segment>
-        <source>label.cache_cleared</source>
-        <target>Cache został pomyślnie wyczyszczony!</target>
-      </segment>
-    </unit>
-    <unit id="5IxD63c" name="general.latest_bolt_news">
-      <segment>
-        <source>general.latest_bolt_news</source>
-        <target>Najnowsze wiadomości o Bolcie</target>
-      </segment>
-    </unit>
-    <unit id="Pily_qo" name="general.phrase.read-more">
-      <segment>
-        <source>general.phrase.read-more</source>
-        <target>Przeczytaj więcej</target>
-      </segment>
-    </unit>
-    <unit id="RaGzSx5" name="57d589f">
-      <segment>
-        <source>57d589f</source>
-        <target><![CDATA[<strong>Czuwaj!</strong> Ten alaram wymaga Twojej uwagi, ale nie jest bardzo istotny.]]></target>
-      </segment>
-    </unit>
-    <unit id="JYILFeM" name="&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.">
-      <segment>
-        <source>&lt;strong&gt;Warning!&lt;/strong&gt; Better check yourself, you're not looking too good.</source>
-        <target><![CDATA[<strong>Uwaga!</strong> Miej się na baczności, nie wyglądasz za dobrze.]]></target>
-      </segment>
-    </unit>
-    <unit id="OGd6iOm" name="&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.">
-      <segment>
-        <source>&lt;strong&gt;Oh snap!&lt;/strong&gt; Change a few things up and try submitting again.</source>
-        <target><![CDATA[<strong>O kurczę!</strong> Popraw kilka rzeczy i spróbuj wysłać ponownie.]]></target>
-      </segment>
-    </unit>
-    <unit id="xN1kSQQ" name="caption.bolt_payoff">
-      <segment>
-        <source>caption.bolt_payoff</source>
-        <target>Wyrafinowany, lekki i prosty w użyciu CMS</target>
-      </segment>
-    </unit>
-    <unit id="QVRwwK4" name="about.system_info">
-      <segment>
-        <source>about.system_info</source>
-        <target>Informacje o systemie</target>
+        <source>about.bolt_documentation</source>
+        <target>Dokumentacja Bolta</target>
       </segment>
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
       <segment>
         <source>about.bolt_on_github</source>
         <target>Bolt na GitHubie</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
       <segment>
         <source>about.used_libraries</source>
         <target>Wykorzystane biblioteki / komponenty</target>
       </segment>
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Poniżej znajduj się biblioteki od zewnętrznych dostawców, których używa Bolt</target>
       </segment>
     </unit>
-    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+    <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
       <segment>
-        <source>files_cards.action_edit_image_info</source>
-        <target>Edytuj informacje obrazka</target>
+        <source>label.email</source>
+        <target>Adres e-mail</target>
       </segment>
     </unit>
-    <unit id="Y90_Pn1" name="files_cards.label_title">
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
       <segment>
-        <source>files_cards.label_title</source>
-        <target>Tytuł:</target>
+        <source>label.about</source>
+        <target>O mnie</target>
       </segment>
     </unit>
-    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
       <segment>
-        <source>files_cards.label_dimensions</source>
-        <target>Wymiary:</target>
+        <source>user.updated_successfully</source>
+        <target>Aktualizacja zakończyła się powodzeniem.</target>
       </segment>
     </unit>
-    <unit id=".fL0AbE" name="files_list.remark">
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
       <segment>
-        <source>files_list.remark</source>
-        <target>W tym folderze nie ma żadnych plików. Wybierz folder, do którego chcesz przejść</target>
+        <source>content.updated_successfully</source>
+        <target>Treść zaktualizowana pomyślnie</target>
       </segment>
     </unit>
-    <unit id="VPV0lFM" name="image.placeholder_title">
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
       <segment>
-        <source>image.placeholder_title</source>
-        <target>Tytuł atrybutu</target>
+        <source>content.created_successfully</source>
+        <target>Element multimedialny utworzony pomyślnie</target>
       </segment>
     </unit>
-    <unit id="0C9.Vmh" name="collection.add_item">
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
       <segment>
-        <source>collection.add_item</source>
-        <target>Dodaj nowy element do '%name%'</target>
+        <source>editfile.could_not_write</source>
+        <target>Nie można zapisać elementu multimedialnego</target>
       </segment>
     </unit>
-    <unit id="H9knE.O" name="collection.expand_all">
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
-        <source>collection.expand_all</source>
-        <target>Rozwiń wszystkie</target>
+        <source>label.locale</source>
+        <target>Lokalizacja</target>
       </segment>
     </unit>
-    <unit id="JjvI6hp" name="collection.collapse_all">
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
-        <source>collection.collapse_all</source>
-        <target>Zwiń wszystkie</target>
+        <source>The Default theme</source>
+        <target>Motyw domyślny</target>
       </segment>
     </unit>
-    <unit id="RBJ0NMl" name="collection.select">
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
-        <source>collection.select</source>
-        <target>Wybierz ...</target>
+        <source>The Default Dark theme</source>
+        <target>Domyślny ciemny motyw</target>
       </segment>
     </unit>
-    <unit id="ApPu4P_" name="collection.move_item_up">
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
-        <source>collection.move_item_up</source>
-        <target>Przesuń wyżej</target>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Wygląda trochę jak ten inny CMS</target>
       </segment>
     </unit>
-    <unit id="KzBtfHi" name="collection.move_item_down">
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
-        <source>collection.move_item_down</source>
-        <target>Przesuń niżej</target>
+        <source>caption.dashboard</source>
+        <target>Panel Bolta</target>
       </segment>
     </unit>
-    <unit id="JpJFIFq" name="collection.confirm_delete">
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
-        <source>collection.confirm_delete</source>
-        <target>Czy jesteś pewna/pewien, że chcesz usunąć ten element kolekcji?</target>
+        <source>caption.clear_cache</source>
+        <target>Wyczyść cache</target>
       </segment>
     </unit>
-    <unit id=".t1ICS7" name="collection.remove_item">
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
-        <source>collection.remove_item</source>
-        <target>Usuń element</target>
+        <source>caption.menu_setup</source>
+        <target>Ustawienia menu</target>
       </segment>
     </unit>
-    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
-        <source>caption.untitled_contenttype</source>
-        <target>Pozbawiony tytułu %contenttype%</target>
+        <source>caption.taxonomies</source>
+        <target>Taksonomie</target>
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
+        <source>caption.contenttypes</source>
+        <target>Typy zawartości</target>
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
+        <source>caption.main_configuration</source>
+        <target>Główna konfiguracja</target>
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
+        <source>caption.users_permissions</source>
+        <target>Użytkownicy i uprawnienia</target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Konfiguracja</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Ustawienia</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Zawartość</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Zarządzanie plikami</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Rozszerzenia</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target>Podgląd i edycja szablonów</target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Załadowane pliki</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Ustawienia ścieżek</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Tłumaczenia / Etykiety</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>O Bolcie</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target>Wyrafinowany, lekki i prosty w użyciu CMS</target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Edytuj</target>
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>caption.file_uploader</source>
+        <target>Przesyłanie plików</target>
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>caption.meta_information</source>
+        <target>Meta informacje</target>
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
+        <source>date</source>
+        <target>Data</target>
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>size</source>
+        <target>Rozmiar</target>
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>thumbnail</source>
+        <target>Miniatura</target>
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
+        <source>filename</source>
+        <target>Nazwa pliku</target>
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>actions</source>
+        <target>Działania</target>
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>directoryname</source>
+        <target>Nazwa katalogu</target>
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>form.quick_select_file</source>
+        <target>Szybko wybierz plik do edycji...</target>
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>caption.path</source>
+        <target>Ścieżka</target>
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>caption.filename</source>
+        <target>Nazwa pliku</target>
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>action.create_new</source>
+        <target>Utwórz nowy</target>
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Witaj %name%</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Wyloguj</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Edytuj profil</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>Zamknij</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>API</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Wszystkie pliki konfiguracji</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Konserwacja</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Edytuj plik</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Obecna lokalizacja</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Zmień lokalizację na</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Autor</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Edytuj</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Nieznane</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Napisane przez %name% dnia %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>Brak strony „O nas”</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Brak bloku „O nas”</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>Ostatnie %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>…</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Szukaj</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Przegląd %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Nie znaleziono ostatnich %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Menu</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Szukaj</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Bezpośredni odnośnik</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>Cache został pomyślnie wyczyszczony!</target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Kitchensink</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Wyniki wyszukiwania dla „%search%”.</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>Nie znaleziono wyników wyszukiwania dla „%search%”.</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Podaj wyszukiwaną frazę, aby wyświetlić odpowiednie wyniki.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Przeczytaj więcej</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Ta strona jest <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>zbudowana z Bolt</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Najnowsze wiadomości o Bolcie</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Podejrzyj</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Zobacz zapisaną wersję</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Wyświetlana nazwa</target>
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.duplicate</source>
+        <target>Duplikuj</target>
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
+        <source>label.new_password</source>
+        <target>Nowe hasło</target>
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
+        <source>editfile.updated_successfully</source>
+        <target>Plik zaktualizowany pomyślnie!</target>
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
+        <source>action.add_user</source>
+        <target>Dodaj użytkownika</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Sukces!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>Profil użytkownika został zaktualizowany!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Role</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Nowy użytkownik</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Zobacz</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Zablokowany</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Edytuj</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Utwórz na podstawie</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Prześlij</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Z biblioteki</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Zobacz na Stronie</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Zmień status na 'opublikowany'</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Zmień status na 'wstrzymany'</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Zmień status na 'wersja robocza'</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Powiel</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Usuń</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Utworzono</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Opublikowano</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Ostatnio zmodyfikowano</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Zaznaczony</target>
       </segment>
     </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>URL do treści, którą chcesz osadzić</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL do treści na Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Wysokość</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>pikseli</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Dopasowane osadzenia</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>Podgląd</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Rozmiar</target>
       </segment>
     </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Nazwa pliku (prześlij nowy plik lub wybierz istniejący)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Atrybut "alt"</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Tytuł atrybutu</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Przełącz szerokość bocznego panelu</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Przełącz </span>menu]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Przełącz</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Powiadomienie</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Zobacz informacje na temat Lokalizacji</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Sortuj po</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Słowo klucz do filtrowania ...</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filtruj</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Wyczyść sortowanie/filtr</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Domyślny</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Brakujący</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Przełącz listę rozwijaną</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Edytuj informacje obrazka</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Edytuj plik w edytorze</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Zobacz oryginał</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Powiel</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Usuń</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Nazwa pliku:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Tytuł:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Wymiary:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Rozmiar pliku:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Utworzony:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>W tym folderze nie ma żadnych plików. Wybierz folder, do którego chcesz przejść</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Wybierz plik</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Lista</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Karty</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Opis:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Autor:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Paczka / Nazwa klasy:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Wersja:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>To jest lokalny pakiet, nie zainstalowany przez Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Nazwa klasy:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Edytuj konfigurację</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Źródło</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Usuń rozszerzenie</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Zablokuj rozszerzenie</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Logowanie</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Jeszcze nie zaimplementowane. Wybacz!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Widok ogólny</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>W tym folderze nie ma żadnych plików. Wybierz folder, do którego chcesz przejść, po prawej stronie.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Kompaktowy</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Rozwinięty</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Tryb widoku</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Edytuj</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target>Użytkownicy i Uprawnienia</target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>Do edycji użytkowników i ich uprawnień</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Wyświetlana nazwa</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Nazwa użytkownika</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>Adres e-mail</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Role</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Ostatnio widziany</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Ostatni IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Działania</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Nieznany użytkownik</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Dominujące kolory na obrazie</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Przegląd dla „%slug%”</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Powiązana treść</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Szukaj</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Nowy %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>Pozbawiony tytułu %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Edytuj profil użytkownika</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Strona przekierowania</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Edytuj obraz</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Sugerowane bezpieczne hasło: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Przytnij X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Pozycja przycięcia na osi X, zakres 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Pozycja przycięcia na osi Y, zakres 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Przytnij Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Współczynnik powiększenia przycięcia</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Poziom powiększenia przycięcia, zakres 1-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Typ zawartości</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Nie znaleziono wyników. Rozszerz kryteria filtrowania lub dodaj więcej treści.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Wybierz pole, po którym chcesz sortować</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Podstawowe Działania</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opcje</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Usuń</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Odblokuj</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Zablokuj</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>Sesja wygasa</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>Adres IP</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Przeglądarka / platforma</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Usuń</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Edytuj atrybuty</target>
+      </segment>
+    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Dodaj nowy obraz</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Dodaj nowy plik</target>
       </segment>
     </unit>
-    <unit id="WihD8Y5" name="image.button_down">
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
-        <source>image.button_down</source>
-        <target>W dół</target>
+        <source>collection.remove_item</source>
+        <target>Usuń element</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Dodaj nowy element do '%name%'</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Przesuń wyżej</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Przesuń niżej</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Zobacz szczegóły</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Plik konfiguracji:</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Upuść tutaj pliki, aby je przesłać</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Następna</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Poprzednia</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>W górę</target>
       </segment>
     </unit>
-    <unit id="80JoLd0" name="title.login">
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
-        <source>title.login</source>
-        <target>Logowanie</target>
+        <source>image.button_down</source>
+        <target>W dół</target>
       </segment>
     </unit>
-    <unit id="beqzCkE" name="login.header_login">
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
-        <source>login.header_login</source>
-        <target>Bolt » Logowanie</target>
+        <source>general.phrase.download</source>
+        <target>Pobierz</target>
       </segment>
     </unit>
-    <unit id="RMPnq6o" name="label.username_or_email">
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
-        <source>label.username_or_email</source>
-        <target>Nazwa użytkownika lub email</target>
+        <source>caption.logviewer</source>
+        <target>Czytnik logów</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Żądanie</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Ślad</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Kontekst</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Poziom</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Wiadomość</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Znacznik czasu</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Użytkownik</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Zablokowany</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Odblokowany</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Nie znaleziono treści</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Brak</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Pusty</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Zastosuj do wszystkich</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Informacje o systemie</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Czy na pewno zamierzasz usunąć tę zawartość?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>Twoja nazwa użytkownika lub email</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>Twoje hasło</target>
       </segment>
     </unit>
-    <unit id="gLN0C81" name="action.log_in">
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
-        <source>action.log_in</source>
-        <target>Zaloguj</target>
+        <source>caption.other_content</source>
+        <target>Inna treść</target>
       </segment>
     </unit>
-    <unit id="IaF1MjB" name="label.rememberme">
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
-        <source>label.rememberme</source>
-        <target>Zapamiętaj mnie?</target>
+        <source>editfile.target_not_writable</source>
+        <target>Zapisywanie jest wyłączone, ponieważ plik docelowy nie jest zapisywalny.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>To pole można przetłumaczyć</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Treść</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>Plik usunięty pomyślnie!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Czy jesteś pewien/pewna, że chcesz usunąć ten plik?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Szukaj / Filtruj po</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Status zmieniony pomyślnie</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Treść usunięta pomyślnie</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Obecny status</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Opublikowany</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Wersja robocza</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Zaplanowany</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Wstrzymany</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Czy jesteś pewna/pewien, że chcesz usunąć ten element kolekcji?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Typy plików, które można przesyłać</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Maksymalny rozmiar przesyłanych plików</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Szukaj po słowie kluczu</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Cała zawartość, przefiltrowana po <em>'%filter%'</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Zobacz witrynę</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Nowy</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Brak znanych zależności</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Zależności</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Rozwiń wszystkie</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Zwiń wszystkie</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>Brak definicji dla tego ContentType! Edycja tego rekordu nie będzie działać zgodnie z oczekiwaniami. Sprawdź plik contenttypes.yaml, aby upewnić się, że zawiera %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Wybierz ...</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Wprowadź swoją nazwę użytkownika lub adres e-mail</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Wprowadź swoje hasło</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Wprowadź swój adres e-mail</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filtruj według pola</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Z adresu URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Kopiuj link do pliku</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Ostrzeżenie</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Folder już istnieje</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Nie można utworzyć folderu</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Folder utworzony pomyślnie.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Folder usunięty pomyślnie</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Nowy folder</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Awatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Zapomniane hasło</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Zresetuj hasło</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Wprowadź swój adres e-mail, a wyślemy Ci link do zresetowania hasła.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Wyślij</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Powrót do logowania</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Zresetuj swoje hasło</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Wysłano e-mail do resetowania hasła</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Wysłano e-mail zawierający link, który możesz kliknąć, aby zresetować hasło. Ten link wygaśnie za %hours% godz.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Jeśli nie otrzymasz e-maila, sprawdź folder ze spamem lub %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Zresetuj hasło</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Cześć!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Aby zresetować hasło, odwiedź poniższy link</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Ten link wygaśnie za %hours% godz.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Pozdrawiamy!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Wprowadź hasło</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Powtórz hasło</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Pola haseł muszą być zgodne.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Twoje hasło powinno mieć co najmniej %s znaków</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Nie znaleziono tokena resetowania hasła w adresie URL ani w sesji.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Twoje hasło zostało pomyślnie zresetowane.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Wystąpił problem podczas przetwarzania żądania resetowania hasła - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>filtrowane według</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Udostępnij bezpieczny link do podglądu</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>przestań się podszywać</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>podszyj się</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Tryb konserwacji jest włączony</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Odśwież</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Wyświetlanie rekordów %current% z %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Nazwa: %name% (liczba pojedyncza: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (liczba pojedyncza: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Szablon rekordu: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Szablon listy: %template% (%listingRecords% rekordów)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Języki: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Edytuj uprawnienia</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Szukaj</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Podgląd obrazu</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Zaznacz wszystko</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Zapamiętaj mnie? (%duration% dni)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Bieżące sesje</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Opcje przesyłania</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Kolejność</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>twój adres e-mail</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Wybierz plik</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Wybierz obraz</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Prześlij z adresu URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Ładowanie…</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Zapisz</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Zamknij</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.pt_BR.xlf
+++ b/translations/messages.pt_BR.xlf
@@ -1,10 +1,3438 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-    </body>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pt-BR">
+  <file id="messages.pt_BR">
+    <unit id="1sstKF9" name="title.edit_user">
+      <notes>
+        <note>templates/users/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user</source>
+        <target>Editar usuário</target>
+      </segment>
+    </unit>
+    <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
+      <segment>
+        <source>action.save</source>
+        <target>Salvar alterações</target>
+      </segment>
+    </unit>
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>action.do_something</source>
+        <target>Faça algo</target>
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>action.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="LDhDPrF" name="label.username">
+      <notes>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>label.username</source>
+        <target>Nome de usuário</target>
+      </segment>
+    </unit>
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>title.login</source>
+        <target>Entrar</target>
+      </segment>
+    </unit>
+    <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>label.password</source>
+        <target>Senha</target>
+      </segment>
+    </unit>
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>action.log_in</source>
+        <target>Entrar</target>
+      </segment>
+    </unit>
+    <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>title.contentlisting</source>
+        <target>Listagem de conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
+      <segment>
+        <source>field.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
+      <segment>
+        <source>field.status</source>
+        <target>Status</target>
+      </segment>
+    </unit>
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
+      <segment>
+        <source>field.createdAt</source>
+        <target>Criado em</target>
+      </segment>
+    </unit>
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
+      <segment>
+        <source>field.modifiedAt</source>
+        <target>Modificado em</target>
+      </segment>
+    </unit>
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>field.publishedAt</source>
+        <target>Publicado em</target>
+      </segment>
+    </unit>
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>field.depublishedAt</source>
+        <target>Despublicado em</target>
+      </segment>
+    </unit>
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>field.title</source>
+        <target>Título</target>
+      </segment>
+    </unit>
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>field.description</source>
+        <target>Descrição</target>
+      </segment>
+    </unit>
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
+      <segment>
+        <source>field.copyright</source>
+        <target>Direitos autorais</target>
+      </segment>
+    </unit>
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>field.originalFilename</source>
+        <target>Nome de arquivo original</target>
+      </segment>
+    </unit>
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
+      <segment>
+        <source>field.width</source>
+        <target>largura</target>
+      </segment>
+    </unit>
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
+      <segment>
+        <source>field.height</source>
+        <target>altura</target>
+      </segment>
+    </unit>
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
+      <segment>
+        <source>field.filesize</source>
+        <target>Tamanho do arquivo</target>
+      </segment>
+    </unit>
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
+      <segment>
+        <source>label.username_or_email</source>
+        <target>Nome de usuário ou e-mail</target>
+      </segment>
+    </unit>
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.rememberme</source>
+        <target>Lembrar de mim?</target>
+      </segment>
+    </unit>
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>about.visit_bolt</source>
+        <target>Visite Boltcms.io</target>
+      </segment>
+    </unit>
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
+      <segment>
+        <source>about.bolt_documentation</source>
+        <target>Documentação do Bolt</target>
+      </segment>
+    </unit>
+    <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>about.bolt_on_github</source>
+        <target>Bolt no Github</target>
+      </segment>
+    </unit>
+    <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>about.used_libraries</source>
+        <target>Bibliotecas / Componentes utilizados</target>
+      </segment>
+    </unit>
+    <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
+      <segment>
+        <source>about.list_of_used_libraries</source>
+        <target>Abaixo estão as bibliotecas de terceiros utilizadas pelo Bolt.</target>
+      </segment>
+    </unit>
+    <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
+      <segment>
+        <source>label.email</source>
+        <target>Endereço de e-mail</target>
+      </segment>
+    </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Sobre mim</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
+        <source>user.updated_successfully</source>
+        <target>Atualizado com sucesso</target>
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
+        <source>content.updated_successfully</source>
+        <target>Conteúdo atualizado com sucesso</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Item de mídia criado com sucesso</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>Não foi possível gravar o item de mídia</target>
+      </segment>
+    </unit>
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
+        <source>label.locale</source>
+        <target>Idioma</target>
+      </segment>
+    </unit>
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
+        <source>The Default theme</source>
+        <target>O tema padrão</target>
+      </segment>
+    </unit>
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>The Default Dark theme</source>
+        <target>O tema escuro padrão</target>
+      </segment>
+    </unit>
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Parece um pouco com aquele outro CMS</target>
+      </segment>
+    </unit>
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.dashboard</source>
+        <target>Painel do Bolt</target>
+      </segment>
+    </unit>
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>caption.clear_cache</source>
+        <target>Limpar o cache</target>
+      </segment>
+    </unit>
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
+        <source>caption.menu_setup</source>
+        <target>Configuração do menu</target>
+      </segment>
+    </unit>
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
+        <source>caption.taxonomies</source>
+        <target>Taxonomias</target>
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
+        <source>caption.contenttypes</source>
+        <target>Tipos de conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
+        <source>caption.main_configuration</source>
+        <target>Configuração principal</target>
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
+        <source>caption.users_permissions</source>
+        <target><![CDATA[Usuários e permissões]]></target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Configuração</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Configurações</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Gerenciamento de arquivos</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Extensões</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target><![CDATA[Visualizar e editar templates]]></target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Arquivos enviados</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Configuração de roteamento</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Traduções / Rótulos</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>Sobre o Bolt</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target><![CDATA[Um CMS sofisticado, leve e simples]]></target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>caption.file_uploader</source>
+        <target>Envio de arquivos</target>
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>caption.meta_information</source>
+        <target>Meta informações</target>
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
+        <source>date</source>
+        <target>Data</target>
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>size</source>
+        <target>Tamanho</target>
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>thumbnail</source>
+        <target>Miniatura</target>
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
+        <source>filename</source>
+        <target>Nome do arquivo</target>
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>actions</source>
+        <target>Ações</target>
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>directoryname</source>
+        <target>Nome da pasta</target>
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>form.quick_select_file</source>
+        <target>Selecione rapidamente um arquivo para editar…</target>
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>caption.path</source>
+        <target>Caminho</target>
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>caption.filename</source>
+        <target>Nome do arquivo</target>
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>action.create_new</source>
+        <target>Criar novo</target>
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Olá, %name%!</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Sair</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Editar perfil</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>Fechar</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>API</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Todos os arquivos de configuração</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Manutenção</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Editar arquivo</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Idioma atual</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Mudar para o idioma</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Autor</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Desconhecido</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Escrito por %name% em %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>A página "Sobre" está faltando</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>O bloco "Sobre" está faltando</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>%contenttypes% recentes</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>…</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Pesquisar</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Visão geral de %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Nenhum %contenttype% recente encontrado</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Menu</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Pesquisar</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Link permanente</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>Cache limpo com sucesso!</target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Kitchensink</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Resultados da pesquisa para "%search%".</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>Nenhum resultado de pesquisa encontrado para "%search%".</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Forneça um termo de pesquisa para exibir resultados relevantes.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Leia mais</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Este site foi <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>construído com Bolt</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Últimas notícias do Bolt</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Pré-visualizar</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Ver versão salva</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Nome de exibição</target>
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.duplicate</source>
+        <target>Duplicar</target>
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
+        <source>label.new_password</source>
+        <target>Nova senha</target>
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
+        <source>editfile.updated_successfully</source>
+        <target>Arquivo atualizado com sucesso!</target>
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
+        <source>action.add_user</source>
+        <target>Adicionar usuário</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Sucesso!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>O perfil do usuário foi atualizado!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Funções</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Novo usuário</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Visualizar</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Bloqueado</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Gerar a partir de:</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Enviar</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>Da biblioteca</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Ver no site</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Alterar status para "publicado"</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Alterar status para "retido"</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Alterar status para "rascunho"</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Duplicar</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Excluir</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Slug</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Criado em</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Publicado em</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Última modificação em</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Selecionado</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>URL do conteúdo a incorporar</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL do conteúdo no Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Altura</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>pixel</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Incorporação correspondente</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Pré-visualização</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Tamanho</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Nome do arquivo (envie um novo arquivo ou selecione um existente)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Atributo alt</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Atributo title</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Alternar largura da barra lateral</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Alternar </span>menu]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Alternar</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Notificação</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Ver informações de localização</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Ordenar por</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Palavra-chave para filtrar…</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Filtrar</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Limpar ordenação/filtro</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>Padrão</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Ausente</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Alternar menu suspenso</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Editar informações da imagem</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Editar arquivo no editor</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Ver original</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Duplicar</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Excluir</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Nome do arquivo:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Título:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Dimensões:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Tamanho do arquivo:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Criado em:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>Não há arquivos nesta pasta. Selecione uma pasta para navegar.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Selecione um arquivo:</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Lista</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Cartões</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Descrição:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Autor:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Nome do pacote / classe:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Versão:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Este é um pacote local, não instalado através do Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Nome da classe:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Configuração</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Código-fonte</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Remover extensão</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Desabilitar extensão</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Entrar</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Ainda não implementado. Desculpe!</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Visão geral de</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>Não há arquivos nesta pasta. Selecione uma pasta para navegar, no lado direito.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Compacto</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Expandido</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Visualização:</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Editar</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target><![CDATA[Usuários e permissões]]></target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>Para editar usuários e suas permissões</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Nome de exibição</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Nome de usuário</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Funções</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Duração da sessão</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Último IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Ações</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Usuário desconhecido</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Cores predominantes na imagem</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Visão geral de "%slug%"</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Conteúdo relacionado</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Pesquisar</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Novo %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>%contenttype% sem título</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Editar perfil do usuário</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Página de redirecionamento</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Editar imagem</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Senha segura sugerida: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Recorte X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Posição do recorte no eixo X, intervalo 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Posição do recorte no eixo Y, intervalo 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Recorte Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Fator de zoom do recorte</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Nível de zoom do recorte, intervalo 1-10.</target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Tipo de conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Nenhum resultado encontrado. Amplie os critérios de filtragem ou adicione mais conteúdo.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Selecione o campo para ordenar…</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Ações principais</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Opções</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Excluir</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Habilitar</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Desabilitar</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>A sessão expira</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>Endereço IP</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Navegador / plataforma</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Remover</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Editar atributos</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Adicionar nova imagem</target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Adicionar novo arquivo</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Remover item</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Adicionar um novo item a "%name%"</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Mover para cima</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Mover para baixo</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Ver detalhes</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Arquivo de configuração</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Solte os arquivos aqui para enviar</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Próximo</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Anterior</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Cima</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Baixo</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Baixar</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Visualizador de logs</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Requisição</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Rastreamento</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Contexto</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Nível</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Mensagem</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Timestamp</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Usuário</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Desabilitado</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Desbloqueado</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Nenhum conteúdo encontrado</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Nenhum</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Vazio</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Aplicar a todos</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Informações do sistema</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Tem certeza de que deseja excluir este conteúdo?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>seu nome de usuário ou e-mail</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>sua senha</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Outro conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>O salvamento está desabilitado porque o arquivo de destino não é gravável.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Este campo é traduzível</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Conteúdo</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>Arquivo excluído com sucesso!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Tem certeza de que deseja excluir este arquivo?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Pesquisar / Filtrar por</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Status alterado com sucesso</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Conteúdo excluído com sucesso</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Status atual</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Publicado</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Rascunho</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Programado</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Retido</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Tem certeza de que deseja excluir este item da coleção?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Tipos de arquivo permitidos para envio</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Tamanho máximo de envio</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Pesquisar por palavra-chave …</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Todo o conteúdo, filtrado por <em>"%filter%"</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Ver site</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Novo</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Nenhuma dependência conhecida</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Dependências</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Expandir tudo</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Recolher tudo</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>A definição para este ContentType está faltando! A edição deste registro não funcionará como esperado. Verifique seu arquivo contenttypes.yaml para garantir que ele contenha %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Selecionar …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Digite seu nome de usuário ou e-mail</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Digite sua senha</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Digite seu e-mail</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Filtrar por campo</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>Da URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Copiar link para o arquivo</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Aviso</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>A pasta já existe</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Não foi possível criar a pasta</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Pasta criada com sucesso.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Pasta excluída com sucesso</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Nova pasta</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Esqueceu a senha</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Redefinir senha</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Digite seu endereço de e-mail e enviaremos um link para redefinir sua senha.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Enviar</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-mail</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Voltar para o login</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Redefina sua senha</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>E-mail de redefinição de senha enviado</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Foi enviado um e-mail contendo um link no qual você pode clicar para redefinir sua senha. Este link expirará em %hours% hora(s).</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Se você não receber o e-mail, verifique sua pasta de spam ou %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Redefinir senha</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Olá!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Para redefinir sua senha, visite o link a seguir</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Este link expirará em %hours% hora(s).</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Atenciosamente!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Digite uma senha</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Repita a senha</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Os campos de senha devem coincidir.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Sua senha deve ter pelo menos %s caracteres</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Nenhum token de redefinição de senha encontrado na URL ou na sessão.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Sua senha foi redefinida com sucesso.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Ocorreu um problema ao processar sua solicitação de redefinição de senha - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>filtrado por</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Compartilhar link de pré-visualização seguro</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>parar de personificar</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>personificar</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>O modo de manutenção está ativado</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Atualizar</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Exibindo registros %current% de %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Nome: %name% (singular: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (singular: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Template do registro: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Template da listagem: %template% (%listingRecords% registros)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Idiomas: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Editar permissões</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Pesquisar</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Pré-visualizar a imagem</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Selecionar tudo</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Lembrar de mim? (%duration% dias)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Sessões atuais</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Opções de envio</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Ordem</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>seu e-mail</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Selecione um arquivo</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Selecione uma imagem</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Enviar a partir da URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Carregando…</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Salvar</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Fechar</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="ru" trgLang="ru">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="ru">
   <file id="messages.ru">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Недоступно</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Ошибка %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>Произошла неизвестная ошибка (HTTP %status_code%), которая помешала выполнить ваш запрос.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Попробуйте загрузить эту страницу ещё раз через несколько минут или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>У вас нет разрешения на доступ к этому ресурсу.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Попросите вашего менеджера или системного администратора предоставить вам доступ к этому ресурсу.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>Нам не удалось найти запрошенную вами страницу.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[Проверьте правильность написания URL-адреса или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>Произошла внутренняя ошибка сервера.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment state="translated">
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Попробуйте загрузить эту страницу ещё раз через несколько минут или <a href="%url%">вернитесь на главную страницу</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Исходный код, использованный для отображения этой страницы</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Код контроллера</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig код шаблона</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Редактировать пользователя</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Показать код</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Сделайте что-нибудь</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Редактировать пользователя</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Редактировать</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Имя пользователя</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment state="translated">
-        <source>help.show_code</source>
-        <target><![CDATA[Нажмите эту кнопку, чтобы отобразить исходный код <strong>Контроллера</strong> и <strong>шаблона</strong>, которые используются для рендеринга этой страницы.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment state="translated">
-        <source>info.change_password</source>
-        <target>После изменения пароля вы автоматически выйдете из приложения.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>Список содержимого</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Измените пароль</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,16 +230,16 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>field.filesize</source>
         <target>Размер файла</target>
       </segment>
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,16 +257,20 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>about.visit_bolt</source>
         <target>Перейти на boltcms.io</target>
       </segment>
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -412,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,58 +297,47 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Ниже приведены сторонние библиотеки, которые использует Bolt.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Полное имя</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>Адрес электронной почты</target>
       </segment>
     </unit>
-	    <unit id="D2N7_cP" name="label.about">
+    <unit id="D2N7_cP" name="label.about">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>templates/users/_form.html.twig:185</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>label.about</source>
         <target>Подробности</target>
       </segment>
     </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>user.updated_successfully</source>
         <target>Обновление успешно завершено</target>
       </segment>
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -481,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -491,524 +355,662 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
-      <segment state="translated">
+      <segment>
         <source>editfile.could_not_write</source>
         <target>Не удалось записать медиа-элемент</target>
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>Локаль</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Бэкэнд-тема</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment state="translated">
-        <source>English (en)</source>
-        <target>English (UK &amp; USA, en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment state="translated">
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (Dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment state="translated">
-        <source>français (French, fr)</source>
-        <target>Français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Тема по умолчанию</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
         <source>The Default Dark theme</source>
         <target>Тёмная тема по умолчанию</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Вроде как похоже на ту другую CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Панель Bolt</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment state="translated">
-        <source>caption.translations: messages</source>
-        <target>Переводы: сообщения</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Очистить кеш</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Проверить базу данных</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment state="translated">
-        <source>caption.routing set up</source>
-        <target>Настройка маршрутизации</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Настройка меню</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Категоризация</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>Типы контента</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Основная конфигурация</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target>Пользователи и права</target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Конфигурация</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Настройки</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>Контент</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Файлы</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Расширения</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
         <target>Шаблоны</target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Загруженные файлы</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Конфигурация маршрутизации</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Переводы / Ярлыки</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>О Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
         <source>caption.bolt_payoff</source>
-        <target><![CDATA[Изысканная, лёгкая и простая CMS]]></target>
+        <target>Изысканная, лёгкая и простая CMS</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Редактировать</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Загрузчик файлов</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
         <source>caption.meta_information</source>
         <target>Мета-информация</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Дата</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Размер</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
         <source>thumbnail</source>
         <target>Миниатюра</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Имя файла</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Действия</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Имя каталога</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Старт</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Выбор файла для редактирования…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Выбор</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Путь</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Имя файла</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Посетите сайт</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Создать</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Привет, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Выйти</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Профиль</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>закрыть</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Файлы конфигураций</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Обслуживание</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment state="translated">
-        <source>caption.fixtures_dummy_content</source>
-        <target>Фикстуры (контент для примера)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Редактировать файл</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Проверка установки</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Выберите язык</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Локаль</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Текущая локаль</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Переключить локаль</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Автор</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Редактирование</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Неизвестно</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>Написано %name% , %date%.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page</source>
-        <target>Страница "Подробности" отсутствует.</target>
+        <target>Страница «О нас» отсутствует</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
         <source>general.phrase.missing-about-page-block</source>
-        <target>Блок "Подробности" отсутствует.</target>
+        <target>Блок «О нас» отсутствует</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>Недавно используемые %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Поиск</target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>Список записей %contenttypes%</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Недавних записей %contenttype% не обнаружено</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>Меню</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Поиск</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Постоянная ссылка</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Отображаемое имя</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>Кеш успешно очищен!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
-      <segment state="translated">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
         <source>caption.kitchensink</source>
         <target>Кухонная раковина</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>Результаты поиска по запросу "% search%".</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
-        <target>Результаты поиска по запросу "% search%".</target>
+        <target>Результаты поиска по запросу "%search%".</target>
       </segment>
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1016,1743 +1018,2420 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Введите поисковый запрос, чтобы отображать релевантные результаты.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Подробнее</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
-      <segment state="translated">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
         <source>general.phrase.built-with-bolt</source>
         <target><![CDATA[Этот сайт <a href='https://boltcms.io' target='_blank' title='Изысканная, лёгкая и простая CMS'>сделан на Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Новости Bolt</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
-        <target>Список</target>
+        <target>Предпросмотр</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
         <source>action.view_saved</source>
         <target>Посмотреть сохранённую версию</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Отображаемое имя</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Дубликат</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>Текущий пароль</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>Новый пароль</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>Новый пароль (подтверждение)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
         <source>editfile.updated_successfully</source>
         <target>Файл обновлён успешно!</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Добавить пользователя</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Успешно!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
         <source>user.updated_profile</source>
         <target>Профиль пользователя обновлён!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Роли</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>Новый пользователь</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>Список</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Папки</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>Заблокировано</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>Редактировать</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>Создать на основе поля:</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>Загрузить</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
         <target>Из библиотеки</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>Просмотр на сайте</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Измените статус на «опубликовать»</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Изменить статус на «неактивно»</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Изменить статус на «черновик»</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Создать дубликат</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>Удалить</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Сегмент адреса</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>Создано</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>Опубликовано</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Изменён</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Выбрано</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>переданы идентификаторы выбранных записей</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(это можно использовать с чем-то вроде axios для массового изменения / удаления)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>URL-адрес контента для встраивания</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>URL-адрес контента в Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Высота</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>пиксель</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Соответствующий встроенный элемент</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
         <source>editor_embed.label_preview</source>
         <target>Предпросмотр</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Размер</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>Имя файла (загрузите новый файл или выберите существующий)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Атрибут Alt</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>Заголовок</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>Переключить ширину боковой панели</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-      <segment state="translated">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[<span class="sr-only">Вкл./Откл.</span> меню]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
         <source>editor_date.toggle</source>
         <target>Вкл./Откл.</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Имя файла</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Заголовок</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>Просмотр изображения</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Загрузите изображение</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Примечание. Это поле практически такое же, как поле <code>image</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Примечание. Это поле практически такое же, как поле <code>imagelist</code>.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Геолокация:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Поиск адреса</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment state="translated">
-        <source>geolocation.placeholder_address</source>
-        <target>Улица, почтовый индекс, город или другие данные…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Широта</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Соответствующий адрес</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>Размещение маркера</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>Привязать к ближайшему адресу</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Долгота</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Примечание. Это поле практически такое же, как поле <code>filelist</code>.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>Уведомление</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Переключить раскрывающийся список</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
         <source>localeswitcher.button_info</source>
         <target>Подробная информация о локализации</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Сортировать по</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Выбрать элемент</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Заголовок</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Ключевое слово для фильтрации…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Отфильтровать</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
         <source>listing.button_clear</source>
         <target>Очистить сортировку / фильтр</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>По умолчанию</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
         <target>Отсутствует</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Переключить раскрывающийся список</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Редактировать информацию об изображении</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>Изменить файл в редакторе</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>Просмотр</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-      <segment state="translated">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
         <source>files_cards.action_duplicate</source>
         <target>Создать дубликат</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>Удалить</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>Имя файла:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>Заголовок:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>Размеры:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>Размер файла:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>Создан:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>В этой папке нет файлов. Выберите папку для перехода.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>Выбор файла:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>Список</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>Карточки</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>Описание:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>Автор:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
         <target>Пакет / имя класса:</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Версия:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
         <source>extensions.info_not_installed</source>
         <target>Это локальный пакет, он не установлен через Composer</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Имя класса:</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>Конфигурация</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
         <target>Источник</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>Удалить расширение</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Отключить расширение</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
         <target>Bolt » Вход</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
         <source>extensions.message_not_implemented</source>
         <target>Ещё не реализовано.</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>Список записей</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>В этой папке нет файлов. Выберите папку для перехода с правой стороны.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
         <source>listing_filter.button_compact</source>
         <target>Свёрнуто</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
         <source>listing_filter.button_expanded</source>
         <target>Развёрнуто</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>Просмотр:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Редактировать</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
         <target>Пользователи и права</target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>Для редактирования пользователей и их прав</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Проверка базы данных</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>Чтобы проверить базу данных</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Обновление базы данных</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>Чтобы обновить базу данных</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment state="translated">
-        <source>controller.omnisearch.title</source>
-        <target>Всеохватывающий поиск</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment state="translated">
-        <source>controller.omnisearch.subtitle</source>
-        <target>Для поиска во всеохватывающем режиме</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>Отображаемое имя</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>Имя пользователя</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
         <source>listing.title_email</source>
-        <target>Email</target>
+        <target>Эл. почта</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>Роли</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
         <target>Возраст сессии</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
         <target>Последний IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Действия</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Неверный адрес электронной почты</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Неправильный пароль. Пароль должен содержать не менее 6 символов.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>Неизвестный пользователь</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Преобладающие цвета в изображении</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>Обзор для '%slug%'</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>Связанный контент</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>Искать</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>Создать %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>%contenttype%  без названия</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>Редактировать профиль пользователя</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>Страница перенаправления</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>Редактировать изображение</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>Выбрать язык</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[Предлагаемый безопасный пароль: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
         <target>Обрезать X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Положение кадрирования по оси X, диапазон 0-100.</target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Положение кадрирования по оси Y, диапазон 0-100. </target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>Обрезать Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>Коэффициент масштабирования кадрирования</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>Масштаб кадрирования, диапазон 1-10. </target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>Тип контента</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>Категории</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>Результаты не найдены. Расширьте критерии фильтрации или добавьте больше контента.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>Выберите поле для сортировки …</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>Основные действия</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>Опции</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Удалить</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Вкл.</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>Откл.</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>Пользователь успешно включён!</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment state="translated">
-        <source>user.disabled_successfully</source>
-        <target>Пользователь был успешно отключён!</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Сессия истекает</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>IP адрес</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Браузер / платформа</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>Удалить</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>Редактировать атрибуты</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>Вверх</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>Вниз</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Добавить новое изображение</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Добавить новый файл</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>Удалить элемент</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>Добавить элемент к '%name%'</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>Вверх</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>Вниз</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>Посмотреть детали</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>Файл конфигурации</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Перетащите сюда файлы для загрузки</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>Далее</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>Обратно</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>Вверх</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
         <target>Вниз</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>Скачать</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>Просмотр логов</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
         <target>Запрос</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>Трассировка</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>Контекст</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>Уровень</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>Сообщение</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
-      <segment state="translated">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
         <source>label.timestamp</source>
         <target>Временная метка</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>Пользователь</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
         <source>listing.disabled</source>
         <target>Вывод отключён</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>Разблокировано</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>Контент не найден</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>Похоже, что база данных пуста. Внесите контент в бэкэнде Bolt, или запустите команду, чтобы добавить немного фикстур (контента для примера). </target>
+        <source>general.phrase.none</source>
+        <target>Нет</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
         <target>Пусто</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>Применить ко всем</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>Системная информация</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Недействительное отображаемое имя</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>Вы уверены, что хотите удалить этот контент?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>Ваше имя пользователя или email</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>Ваш пароль</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Другой контент</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>Сохранение отключено, поскольку целевой файл недоступен для записи.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>Это поле можно перевести</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>Контент</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
         <source>file.delete_success</source>
         <target>Файл успешно удалён!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Вы уверены, что хотите удалить этот файл?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>Искать / фильтровать по</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
         <source>content.status_changed_successfully</source>
         <target>Статус успешно изменён</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
         <source>content.deleted_successfully</source>
         <target>Контент успешно удалён</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>Текущий статус</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>Опубликовано</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>Черновик</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>Отсрочен</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>Не активно</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>Вы действительно хотите удалить этот элемент коллекции?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
         <source>upload.allow_file_types</source>
         <target>Типы файлов, разрешённые для загрузки</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>Максимальный размер загружаемого файла</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>Ключевое слово…</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[Весь контент, отфильтрованный по <em>'%filter%'</em>.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>Перейти на сайт</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>Создать</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>Нет известных зависимостей</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>Зависимости</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Развернуть все</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Свернуть все</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
         <source>content.edit_missing_definition</source>
         <target>Определение этого Типа контента отсутствует! Редактирование этой записи не будет работать должным образом. Пожалуйста, проверьте свой contenttypes.yaml, чтобы убедиться, что он содержит %contenttype%.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
         <source>collection.select</source>
         <target>Выбрать …</target>
       </segment>
     </unit>
     <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
       <segment>
         <source>form.empty_username_email</source>
         <target>Пожалуйста, введите ваше имя пользователя или адрес электронной почты</target>
       </segment>
     </unit>
     <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
       <segment>
         <source>form.empty_password</source>
         <target>Пожалуйста, введите ваш пароль</target>
       </segment>
     </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Пожалуйста, введите email</target>
+      </segment>
+    </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Фильтр по полю</target>
       </segment>
     </unit>
     <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
       <segment>
         <source>image.button_from_url</source>
         <target>По URL</target>
       </segment>
     </unit>
     <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
       <segment>
         <source>files_cards.copy_to_clipboard</source>
         <target>Скопировать ссылку на файл</target>
       </segment>
     </unit>
     <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
       <segment>
         <source>warning</source>
         <target>Предупреждение</target>
       </segment>
     </unit>
     <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_already_exists</source>
         <target>Папка уже существует</target>
       </segment>
     </unit>
     <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_error</source>
         <target>Не удалось создать папку</target>
       </segment>
     </unit>
     <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_success</source>
         <target>Папка успешно создана.</target>
       </segment>
     </unit>
     <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
-      <segment state="translated">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
         <source>filemanager.delete_folder_successful</source>
         <target>Папка успешно удалена.</target>
       </segment>
     </unit>
     <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
       <segment>
         <source>folder.create_new</source>
         <target>Новая папка</target>
       </segment>
     </unit>
-    <unit id="FcXvWL8" name="title.add_user">
-      <segment>
-        <source>title.add_user</source>
-        <target>Добавить пользователя</target>
-      </segment>
-    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>Аватар</target>
       </segment>
     </unit>
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <segment state="translated">
-        <source>You have to login in order to access this page.</source>
-        <target>Вы должны войти в систему, чтобы получить доступ к этой странице.</target>
-      </segment>
-    </unit>
-    <unit id="dp42qbF" name="reset_password.email_title">
-      <segment state="translated">
-        <source>reset_password.email_title</source>
-        <target>Привет!</target>
-      </segment>
-    </unit>
-    <unit id="apkSD11" name="reset_password.email_expire">
-      <segment state="translated">
-        <source>reset_password.email_expire</source>
-        <target>Срок действия этой ссылки истечёт через %hours% час(а/ов).</target>
-      </segment>
-    </unit>
-    <unit id="lpzL089" name="Email">
-      <segment>
-        <source>Email</source>
-        <target>Email</target>
-      </segment>
-    </unit>
-    <unit id="0yPnNMd" name="modal.title.image_field">
-      <segment state="translated">
-        <source>modal.title.image_field</source>
-        <target>Выберите изображение</target>
-      </segment>
-    </unit>
-    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
-      <segment state="translated">
-        <source>reset_password.problem_with_request</source>
-        <target>Возникла проблема с обработкой вашего запроса на сброс пароля - %s</target>
-      </segment>
-    </unit>
-    <unit id="Y7ajNNN" name="placeholder.email">
-      <segment state="translated">
-        <source>placeholder.email</source>
-        <target>ваш email</target>
-      </segment>
-    </unit>
-    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
-      <segment state="translated">
-        <source>reset_password.check_email_sent_header</source>
-        <target>Электронное письмо для сброса пароля - отправлено</target>
-      </segment>
-    </unit>
     <unit id="i37ZNqN" name="login.forgotpassword">
-      <segment state="translated">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
         <source>login.forgotpassword</source>
         <target>Забыл пароль</target>
       </segment>
     </unit>
     <unit id="y.dIywE" name="reset_password.request_header">
-      <segment state="translated">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
         <source>reset_password.request_header</source>
         <target>Сбросить пароль</target>
       </segment>
     </unit>
-    <unit id="W7z__Yi" name="action.impersonate">
-      <segment state="translated">
-        <source>action.impersonate</source>
-        <target>выдавать себя за</target>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Введите свой адрес электронной почты, и мы вышлем вам ссылку для сброса вашего пароля.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Подтвердить</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Эл. почта</target>
       </segment>
     </unit>
     <unit id="k9hekeu" name="reset_password.back-to-login">
-      <segment state="translated">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
         <source>reset_password.back-to-login</source>
         <target>Вернуться к входу в систему</target>
       </segment>
     </unit>
-    <unit id="SjuOnue" name="reset_password.reset_successful">
-      <segment state="translated">
-        <source>reset_password.reset_successful</source>
-        <target>Ваш пароль был успешно сброшен.</target>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Сбросьте свой пароль</target>
       </segment>
     </unit>
-    <unit id="VlfWDQr" name="modal.button_save">
-      <segment state="translated">
-        <source>modal.button_save</source>
-        <target>Сохранить</target>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Электронное письмо для сброса пароля - отправлено</target>
       </segment>
     </unit>
-    <unit id="1JZeWxG" name="reset_password.minimum_length">
-      <segment state="translated">
-        <source>reset_password.minimum_length</source>
-        <target>Ваш пароль должен содержать не менее %s символов</target>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Было отправлено электронное письмо, содержащее ссылку, по которой вы можете перейти, чтобы сбросить свой пароль. Срок действия этой ссылки истечёт через %hours% час(а/ов).</target>
       </segment>
     </unit>
-    <unit id=".l3zbrq" name="listing_details_box.slug">
-      <segment state="translated">
-        <source>listing_details_box.slug</source>
-        <target>Сегмент адреса: %slug% (в ед. числе: %singularSlug%)</target>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Если вы не получили электронное письмо, пожалуйста, проверьте свою папку со спамом или %tryagain%.</target>
       </segment>
     </unit>
-    <unit id="z8r0TY6" name="action.edit_permissions">
-      <segment state="translated">
-        <source>action.edit_permissions</source>
-        <target>Редактировать права</target>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Сбросить пароль</target>
       </segment>
     </unit>
-    <unit id="qlucRr7" name="maintenance.activated_warning">
-      <segment state="translated">
-        <source>maintenance.activated_warning</source>
-        <target>Активирован режим технического обслуживания</target>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Привет!</target>
       </segment>
     </unit>
-    <unit id="OYUVA5." name="general.label.search">
-      <segment state="translated">
-        <source>general.label.search</source>
-        <target>Поиск</target>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Чтобы сбросить свой пароль, пожалуйста, перейдите по следующей ссылке</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Срок действия этой ссылки истечёт через %hours% час(а/ов).</target>
       </segment>
     </unit>
     <unit id="_gg3hPE" name="reset_password.email_thanks">
-      <segment state="translated">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
         <source>reset_password.email_thanks</source>
         <target>Всего самого хорошего!</target>
       </segment>
     </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Пожалуйста, введите пароль</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Повторите пароль</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Пароли должны совпадать.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Ваш пароль должен содержать не менее %s символов</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>Токен сброса пароля не найден ни в URL-адресе, ни в сеансе.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Ваш пароль был успешно сброшен.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Возникла проблема с обработкой вашего запроса на сброс пароля - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>отфильтровано по</target>
+      </segment>
+    </unit>
     <unit id="qoZwSEY" name="action.preview_secure_share">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
         <source>action.preview_secure_share</source>
         <target>Поделиться защищённой ссылкой для предварительного просмотра</target>
       </segment>
     </unit>
     <unit id="zYeSeNJ" name="action.stop_impersonating">
-      <segment state="translated">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
         <source>action.stop_impersonating</source>
         <target>перестать выдавать себя за</target>
       </segment>
     </unit>
-    <unit id="tsc7_G3" name="listing_details_box.listing_template">
-      <segment state="translated">
-        <source>listing_details_box.listing_template</source>
-        <target>Шаблон списка: %template% (%listingRecords% записей)</target>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>выдавать себя за</target>
       </segment>
     </unit>
-    <unit id="SwOgM7K" name="reset_password.request_description">
-      <segment state="translated">
-        <source>reset_password.request_description</source>
-        <target>Введите свой адрес электронной почты, и мы вышлем вам ссылку для сброса вашего пароля.</target>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Активирован режим технического обслуживания</target>
       </segment>
     </unit>
     <unit id="CvNi3GD" name="action.refresh">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
         <source>action.refresh</source>
         <target>Обновить</target>
       </segment>
     </unit>
-    <unit id="harDiJR" name="reset_password.enter_pwd">
-      <segment state="translated">
-        <source>reset_password.enter_pwd</source>
-        <target>Пожалуйста, введите пароль</target>
-      </segment>
-    </unit>
-    <unit id="f8zXapF" name="form.empty_email">
-      <segment state="translated">
-        <source>form.empty_email</source>
-        <target>Пожалуйста, введите email</target>
-      </segment>
-    </unit>
-    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
-      <segment state="translated">
-        <source>modal.title.upload_from_url</source>
-        <target>Загрузить с URL-адреса</target>
-      </segment>
-    </unit>
-    <unit id="ct_I4w3" name="modal.button_deny">
-      <segment state="translated">
-        <source>modal.button_deny</source>
-        <target>Закрыть</target>
-      </segment>
-    </unit>
-    <unit id="MjY7.cg" name="modal.title.file_field">
-      <segment state="translated">
-        <source>modal.title.file_field</source>
-        <target>Выберите файл</target>
-      </segment>
-    </unit>
-    <unit id="2hoKa1k" name="label.remembermeduration">
-      <segment state="translated">
-        <source>label.remembermeduration</source>
-        <target>Запомнить меня? (на %duration% дня(ей))</target>
-      </segment>
-    </unit>
-    <unit id="eJ9YbdG" name="listing_details_box.record_template">
-      <segment state="translated">
-        <source>listing_details_box.record_template</source>
-        <target>Шаблон записи: %template%</target>
-      </segment>
-    </unit>
-    <unit id="pPz9Ocx" name="listing_details_box.locales">
-      <segment state="translated">
-        <source>listing_details_box.locales</source>
-        <target>Локали: %locales%</target>
-      </segment>
-    </unit>
-    <unit id="RX0Iuzi" name="reset_password.request_send">
-      <segment state="translated">
-        <source>reset_password.request_send</source>
-        <target>Подтвердить</target>
-      </segment>
-    </unit>
-    <unit id="a_COwtV" name="image.button_upload_options">
-      <segment state="translated">
-        <source>image.button_upload_options</source>
-        <target>Параметры загрузки</target>
-      </segment>
-    </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
         <source>listing_details_box.showing_records</source>
         <target>Показано %current% из %total% записей</target>
       </segment>
     </unit>
-    <unit id="gVc0Uf4" name="reset_password.reset_header">
-      <segment state="translated">
-        <source>reset_password.reset_header</source>
-        <target>Сбросьте свой пароль</target>
-      </segment>
-    </unit>
-    <unit id="u3DMmBH" name="label.filtered_by">
-      <segment state="translated">
-        <source>label.filtered_by</source>
-        <target>отфильтровано по</target>
-      </segment>
-    </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
-      <segment state="translated">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
         <source>listing_details_box.name</source>
         <target>Имя: %name% (в ед. числе: %singularName%)</target>
       </segment>
     </unit>
-    <unit id="rU9cSfq" name="label.repeat_password">
-      <segment state="translated">
-        <source>label.repeat_password</source>
-        <target>Повторите пароль</target>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Сегмент адреса: %slug% (в ед. числе: %singularSlug%)</target>
       </segment>
     </unit>
-    <unit id="a_CQgly" name="Order">
-      <segment state="translated">
-        <source>Order</source>
-        <target>Порядок</target>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Шаблон записи: %template%</target>
       </segment>
     </unit>
-    <unit id="ODb3pJA" name="modal.text.loading">
-      <segment state="translated">
-        <source>modal.text.loading</source>
-        <target>Загрузка...</target>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Шаблон списка: %template% (%listingRecords% записей)</target>
       </segment>
     </unit>
-    <unit id="OEqzPDO" name="listing_table.actions.select_all">
-      <segment state="translated">
-        <source>listing_table.actions.select_all</source>
-        <target>Выбрать все</target>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Локали: %locales%</target>
       </segment>
     </unit>
-    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
-      <segment state="translated">
-        <source>reset_password.check_email_sent_text_2</source>
-        <target>Если вы не получили электронное письмо, пожалуйста, проверьте свою папку со спамом или %tryagain%.</target>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Редактировать права</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Поиск</target>
       </segment>
     </unit>
     <unit id="wG04eAa" name="image.image_preview">
-      <segment state="translated">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
         <source>image.image_preview</source>
         <target>Предварительный просмотр изображения</target>
       </segment>
     </unit>
-    <unit id="GUQYLn2" name="reset_password.no_token">
-      <segment state="translated">
-        <source>reset_password.no_token</source>
-        <target>Токен сброса пароля не найден ни в URL-адресе, ни в сеансе.</target>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Выбрать все</target>
       </segment>
     </unit>
-    <unit id="QpUMHfK" name="reset_password.reset_btn">
-      <segment state="translated">
-        <source>reset_password.reset_btn</source>
-        <target>Сбросить пароль</target>
-      </segment>
-    </unit>
-    <unit id="xS2vvXw" name="reset_password.email_description">
-      <segment state="translated">
-        <source>reset_password.email_description</source>
-        <target>Чтобы сбросить свой пароль, пожалуйста, перейдите по следующей ссылке</target>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Запомнить меня? (на %duration% дня(ей))</target>
       </segment>
     </unit>
     <unit id="eJG2.4P" name="listing.current_sessions_header">
-      <segment state="translated">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
         <source>listing.current_sessions_header</source>
         <target>Текущие сессии</target>
       </segment>
     </unit>
-    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
-      <segment state="translated">
-        <source>reset_password.not_matching_pwds</source>
-        <target>Пароли должны совпадать.</target>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Параметры загрузки</target>
       </segment>
     </unit>
-    <unit id="hKmDb7q" name="Share secure preview link">
-      <segment state="translated">
-        <source>Share secure preview link</source>
-        <target>Поделитесь защищённой ссылкой для предварительного просмотра</target>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Порядок</target>
       </segment>
     </unit>
-    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
-      <segment state="translated">
-        <source>reset_password.check_email_sent_text_1</source>
-        <target>Было отправлено электронное письмо, содержащее ссылку, по которой вы можете перейти, чтобы сбросить свой пароль. Срок действия этой ссылки истечёт через %hours% час(а/ов).</target>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>ваш email</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Выберите файл</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Выберите изображение</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Загрузить с URL-адреса</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Загрузка...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Сохранить</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Закрыть</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="messages.en">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>Müsait değil</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>Hata %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>İsteğinizi tamamlamayı engelleyen bilinmeyen bir hata (HTTP %status_code%) vardı.</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[Birkaç dakika sonra bu sayfayı tekrar yüklemeyi deneyin veya <a href="%url%">anasayfaya geri dönün</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>Bu kaynağa erişim izniniz yok.</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>Yöneticinizden veya sistem yöneticinizden size bu kaynağa erişim izni vermesini isteyin.</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>İstediğiniz sayfayı bulamadık.</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[URL’deki yazım hatalarını kontrol edin veya <a href="%url%">ana sayfaya dönün</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>Dahili bir sunucu hatası oluştu.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[Birkaç dakika sonra bu sayfayı tekrar yüklemeyi deneyin veya <a href="%url%">anasayfaya geri dönün</a>.]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>Bu sayfayı oluşturmak için kaynak kodu kullanıldı</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>Denetleyici kodu</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig şablon kodu</target>
-      </segment>
-    </unit>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="tr">
+  <file id="messages.tr">
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>Kullanıcıyı düzenle</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>Kodu göster</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
       <segment>
         <source>action.do_something</source>
         <target>Bir şey yap</target>
       </segment>
     </unit>
-    <unit id="etGJjTo" name="action.edit_user">
-      <notes>
-        <note>templates/users/change_password.twig:26</note>
-      </notes>
-      <segment>
-        <source>action.edit_user</source>
-        <target>Kullanıcıyı düzenle</target>
-      </segment>
-    </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>Düzenle</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>Kullanıcı adı</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[<strong>Denetleyicinin</strong> kaynak kodunu ve bu sayfayı oluşturmak için kullanılan <strong>şablonunu</strong> göstermek için bu düğmeyi tıklayın.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>Şifrenizi değiştirdikten sonra uygulamadan çıkış yapacaksınız.</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>İçerik listesi</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>Parolayı değiştir</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,7 +279,7 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
@@ -412,7 +288,7 @@
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,37 +297,36 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>Bolt tarafından kullanılan üçüncü parti kütüphaneleri aşağıdadır.</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>Ad Soyad</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>E-posta adresi</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Hakkında</target>
+      </segment>
+    </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -460,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -471,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -481,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -490,511 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>Dil</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>Yönetici teması</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>İngilizce (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Hollandaca (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>İspanyolca (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>Fransızca (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Almanca (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Lehçe (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brezilya Portekizcesi (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>İtalyanca (Italian, it)</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>Varsayılan tema</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>Varsayılan Koyu tema</target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
         <target>WoordPers: Diğer CMS'ye benziyor</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>Bolt Kontrol Paneli</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>caption.translations: messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>Önbelleği temizle</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>Veritabanını kontrol et</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>caption.routing set up</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>Menü kurulumu</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>Sınıflandırmalar</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>İçetik Tipleri</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>Ana Yapılandırma</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
         <target><![CDATA[Kullanıcılar & İzinler]]></target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>Yapılandırma</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>Ayarlar</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>İçerik</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>Dosya yönetimi</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>Uzantılar</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
         <target><![CDATA[Şablonları Görüntüle & Düzenle]]></target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>Yüklenmiş dosyalar</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>Yönlendirme yapılandırması</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>Çeviriler / Etiketler</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>Bolt Hakkında</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
-        <target><![CDATA[Gelişmiş, hafif ve basit CMS]]></target>
+        <target>Gelişmiş, hafif ve basit CMS</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>Düzenle</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>Dosya yükleyici</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Meta bilgisi</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>Tarih</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>Boyut</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
         <target>Küçük resim</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>Dosya adı</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
         <target>Eylemler</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>Klasör adı</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Git</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>Düzenlemek için hızlıca bir dosya seçin…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>Hızlı seçim</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>Yol</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>Dosya adı</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>Siteyi ziyaret et</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>Yeni bir tane oluştur</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
         <target>Merhaba, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>Çıkış yap</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>Profili düzenle</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>Kapat</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>Tüm yapılandırma dosyaları</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>Bakım</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fikstürler (Hazır İçerik)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>Dosyayı Düzenle</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>Kurulum kontrolleri</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>Dil seç</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>Dil</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>Mevcut dil</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>Dil değiştir</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>Yazar</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>Düzenle</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>Bilinmeyen</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>%date% tarihinde %name% tarafından yazıldı.</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>"Hakkında" sayfası eksik</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>"Hakkında" bloğu eksik</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>En son %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>Ara</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[Bu internet sitesi <a href='%url%' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>%contenttypes% içerik tipine genel bakış</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>Yakın zamanda eklenen %contenttype% içerik tipi bulunamadı</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
-        <target>Menu</target>
+        <target>Menü</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>Ara</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>Kalıcı bağlantı</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>Ekran adı</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>Önbellek başarıyla temizlendi!</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
       <segment>
         <source>caption.kitchensink</source>
         <target>Mutfak lavabosu</target>
       </segment>
     </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-      <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
-      </notes>
-      <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>'%search%' için arama sonuçları.</target>
-      </segment>
-    </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1003,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1012,1359 +1018,2420 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>Lütfen ilgili sonuçları görüntülemek için bir arama terimi girin.</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>Devamını oku</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Bu internet sitesi <a href='%url%' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
+        <target><![CDATA[Bu internet sitesi <a href='https://boltcms.io' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
         <target>Son Bolt Haberleri</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>Önizleme</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>Kaydedilen versiyonu görüntüle</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>Ekran Adı</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
         <target>Kopyala</target>
       </segment>
     </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>Eski Parola</target>
-      </segment>
-    </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>Yeni Parola</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>Yeni Parola (onayla)</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>Dosya başarıyla güncellendi!</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>Kullanıcı Ekle</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>Başarılı!</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>Kullanıcı Profili güncellendi!</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>Roller</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>Yeni Kullanıcı</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>Görüntüle</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>Klasörler</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>Kilitli</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>Düzenle</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>Oluşturulduğu alan</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>Yükle</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
         <target>Kütüphaneden</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>Sitede Görüntüle</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>Durumu 'yayınla' olarak değiştir</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>Durumu 'tut' olarak değiştir</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>Durumu 'taslak' olarak değiştir</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
       <segment>
         <source>listing_table.actions.duplicate</source>
         <target>Kopyala</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>Sil</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>Oluşturulma tarihi</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>Yayınlanma tarihi</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>Son düzenlenme tarihi</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>Seçilen</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>seçilen kayıt kimlikleri geçti</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(bunları, toplu olarak değiştirmek / silmek için aksiyolar gibi bir şeyle kullanılabilir)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>Yerleştirilecek içeriğin URL'si</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
         <target>Facebook, Twitter, Soundcloud, Youtube, Vimeo'daki içeriğin URL'si…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>Yükseklik</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>piksel</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>Eşleşen Yerleştirme</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>Önizleme</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>Boyut</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>Dosya adı (yeni bir dosya yükleyin veya mevcut bir dosyayı seçin)</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Alt niteliği</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>Başlık niteliği</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>Kenar çubuğu genişliğini değiştir</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
       <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[menüyü <span class="sr-only">Değiştir </span>]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
       <segment>
         <source>editor_date.toggle</source>
         <target>Değiştir</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>Dosya adı</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>Başlık</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>Resmi görüntüle</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>Bir resim yükle</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Not: Bu alan pratikte <code>image</code>-alanı ile aynıdır.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Not: Bu alan pratikte <code>imagelist</code>-alanı ile aynıdır.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>Coğrafi konum:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>Adres araması</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>Sokak, posta kodu, şehir veya başka bir konum…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>Enlem</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>Eşleşen adres</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>İşaretçi yerleşimi</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>En yakın adrese yasla</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>Boylam</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Not: Bu alan pratikte <code>filelist</code>-alanı ile aynıdır.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>Bildirim</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Açılır Menüyü Aç / Kapat</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
       <segment>
         <source>localeswitcher.button_info</source>
         <target>Dil bilgilerini görün</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>Göre sırala</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>Öğe seç</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>Başlık</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>Filtrelenecek anahtar kelime…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>Filtrele</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
       <segment>
         <source>listing.button_clear</source>
         <target>Sıralamayı / filtrelemeyi temizle</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>Varsayılan</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>Tamam</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
         <target>Eksik</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
         <target>Açılır Menüyü Aç / Kapat</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>Resim bilgilerini düzenle</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>Dosyayı düzenleyicide düzenle</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>Orjinali görüntüle</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
       <segment>
         <source>files_cards.action_duplicate</source>
         <target>Kopyala</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>Sil</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>Dosya adı:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>Başlık:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>Boyutlar:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>Dosya boyutu:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>Oluşturulma tarihi:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>Bu klasörde dosya yok. Gezinmek için bir klasör seçin.</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>Bir dosya seç:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>Liste</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>Kartlar</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>Açıklama:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>Yazar:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
         <target>Paket / Sınıf adı:</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>Versiyon:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>Bu, Composer aracılığıyla yüklenmeyen yerel bir paket</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
         <target>Sınıf adı:</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>Yapılandırma</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
         <target>Kaynak</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>Uzantıyı kaldır</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>Uzantıyı devre dışı bırak</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
         <target>Bolt » Oturum aç</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
       <segment>
         <source>extensions.message_not_implemented</source>
         <target>Henüz uygulanmadı. Üzgünüm!</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>Genel bakış: </target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>Bu klasörde dosya yok. Gezinmek için bir klasör seçin.</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>listing_filter.button_compact</source>
         <target>Kompakt</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
       <segment>
         <source>listing_filter.button_expanded</source>
         <target>Genişletilmiş</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>Görüntüle:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>Düzenle</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
         <target><![CDATA[Kullanıcılar & İzinler]]></target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>Kullanıcıları ve izinlerini düzenlemek için</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>Veritabanı Kontrol Et</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>Veritabanını kontrol etmek için</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>Veritabanı Güncelleme</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>Veritabanını güncellemek için</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>Omni benzeri bir şekilde aramak için</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>Ekran adı</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>Kullanıcı adı</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
         <target>E-posta</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>Roller</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
         <target>Oturum yaşı</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
         <target>Son IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
         <target>Eylemler</target>
       </segment>
     </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Geçersiz e-posta.</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Geçersiz parola. Parola en az 6 karakter içermelidir.</target>
-      </segment>
-    </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>Bilinmeyen kullanıcı</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>Resimdeki baskın renkler</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>'%slug%' için genel bakış</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>Benzer içerik</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>Ara</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>Yeni %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>Başlıksız %contenttype%</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>Kullanıcı profilini düzenle</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>Yönlendirme sayfası</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>Resmi Düzenle</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>Dil seç</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[Önerilen güvenli parola: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
         <target>Kırp X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>Kırpmanın X eksenindeki konumu, 0-100 aralığında. </target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Kırpmanın Y eksenindeki konumu, 0-100 aralığında. </target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>Kırp Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>Kırpma yakınlaştırma faktörü</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>Kırpma yakınlaştırma seviyesi, 1-10 aralığında. </target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>İçerik Tipi</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>Sınıflandırma</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>Sonuç bulunamadı. Filtreleme kriterlerini genişletin veya biraz daha içerik ekleyin.</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>Sıralamak için Alan seçin…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>Birincil Eylemler</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>Seçenekler</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>Sil</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>Etkinleştir</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>Devre dışı bırak</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>Kullanıcı başarıyla etkinleştirildi!</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment>
-        <source>user.disabled_successfully</source>
-        <target>Kullanıcı başarıyla devre dışı bırakıldı!</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Oturum sona erme</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>IP adresi</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>Tarayıcı / platform</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>Kaldır</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>Nitelikleri düzenle</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>Yukarı taşı</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>Aşağı taşı</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>Yeni resim ekle</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>Yeni dosya ekle</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>Öğeyi kaldır</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>'%name%' için yeni bir öğe ekleyin</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>Yukarı taşı</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>Aşağı taşı</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>Detayları göster</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>Yapılandırma dosyası</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>Dosyaları yüklemek için buraya bırakın</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>Sonraki</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>Önceki</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
         <target>Yukarı</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
         <target>Aşağı</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>İndir</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>Günlük Görüntüleyici</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
         <target>İstek</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
         <target>İzleme</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
         <target>Bağlam</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>Seviye</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>Mesaj</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
       <segment>
         <source>label.timestamp</source>
         <target>Zaman damgası</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>Kullanıcı</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing.disabled</source>
         <target>Devre dışı</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>Kilitli değil</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>İçerik bulunamadı</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>Veritabanı boş görünüyor. Bolt yönetim panelinden içerik yazın, veya fikstürler (örnek içerik) eklemek için komut çalıştırın. </target>
+        <source>general.phrase.none</source>
+        <target>Yok</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
         <target>Boş</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>Hepsine uygula</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>Sistem Bilgisi</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Geçersiz görüntüleme adı</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>Bu içeriği silmek istediğinizden emin misiniz?</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>kullanıcı adınız veya e-postanız</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>parolanız</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>Diğer İçerik</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>Hedef dosya yazılabilir olmadığı için kaydetme devre dışı bırakıldı.</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>Bu alan çevrilebilir</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>İçerik</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
         <source>file.delete_success</source>
         <target>Dosya başarıyla silindi!</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>Bu dosyayı silmek istediğinizden emin misiniz?</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>Ara / Filtrele</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
       <segment>
         <source>content.status_changed_successfully</source>
         <target>Durum başarıyla değiştirildi</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
       <segment>
         <source>content.deleted_successfully</source>
         <target>İçerik başarıyla silindi</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>Şu anki durum</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>Yayınlandı</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>Taslak</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>Zamanlı</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>Tut</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>Bu koleksiyon öğesini silmek istediğinizden emin misiniz?</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
       <segment>
         <source>upload.allow_file_types</source>
         <target>Yüklemeye izin verilen dosya türleri</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>Maksimum yükleme boyutu</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>Anahtar kelime ara…</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[Tüm içerikler, <em>'%filter%'</em> göre filtrelendi.]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>İnternet sayfasını görüntüle</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>Yeni</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>Bilinen bağımlılık yok</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>Bağımlılıklar</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>Hepsini genişlet</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>Hepsini daralt</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
         <target>Bu İçerikTipinin tanımı eksik! Bu kaydı düzenlemek beklendiği gibi çalışmayacaktır. Lütfen %contenttype% içerdiğinden emin olmak için contenttypes.yaml dosyanızı kontrol edin.</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>Seç …</target>
       </segment>
     </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Lütfen kullanıcı adınızı veya e-postanızı girin</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Lütfen parolanızı girin</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Lütfen e-postanızı girin</target>
+      </segment>
+    </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>Alana göre filtrele</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>URL'den</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Dosya bağlantısını kopyala</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Uyarı</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Klasör zaten mevcut</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Klasör oluşturulamadı</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Klasör başarıyla oluşturuldu.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Klasör başarıyla silindi</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Yeni klasör</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Avatar</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Parolamı Unuttum</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Parolayı Sıfırla</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>E-posta adresinizi girin, size parolanızı sıfırlamanız için bir bağlantı gönderelim.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Gönder</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>E-posta</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Girişe Dön</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Parolanızı sıfırlayın</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Parola Sıfırlama E-postası Gönderildi</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Parolanızı sıfırlamak için tıklayabileceğiniz bir bağlantı içeren bir e-posta gönderildi. Bu bağlantının süresi %hours% saat içinde dolacaktır.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>E-posta almadıysanız lütfen spam klasörünüzü kontrol edin veya %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Parolayı Sıfırla</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Merhaba!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Parolanızı sıfırlamak için lütfen aşağıdaki bağlantıyı ziyaret edin</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Bu bağlantının süresi %hours% saat içinde dolacaktır.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Teşekkürler!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Lütfen bir parola girin</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Parolayı Tekrarla</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Parola alanları eşleşmelidir.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Parolanız en az %s karakter olmalıdır</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>URL'de veya oturumda parola sıfırlama belirteci bulunamadı.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Parolanız başarıyla sıfırlandı.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Parola sıfırlama isteğiniz işlenirken bir sorun oluştu - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>Şuna göre filtrelendi</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Güvenli önizleme bağlantısını paylaş</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Kimliğe bürünmeyi durdur</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Kimliğine bürün</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Bakım modu etkinleştirildi</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Yenile</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>%total% kayıttan %current% tanesi gösteriliyor</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Ad: %name% (tekil: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (tekil: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Kayıt şablonu: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Liste şablonu: %template% (%listingRecords% kayıt)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Yereller: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>İzinleri Düzenle</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Arama</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Görseli önizle</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Tümünü seç</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Beni hatırla? (%duration% gün)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Geçerli oturumlar</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Yükleme Seçenekleri</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Sıralama</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>e-postanız</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Bir dosya seçin</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Bir görsel seçin</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>URL'den yükle</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Yükleniyor...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Kaydet</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Kapat</target>
       </segment>
     </unit>
   </file>

--- a/translations/messages.uk.xlf
+++ b/translations/messages.uk.xlf
@@ -1,2443 +1,3438 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="uk" trgLang="uk">
-    <file id="messages.en">
-        <unit id="tbB2gib" name="not_available">
-            <notes>
-                <note>templates/debug/source_code.twig:26</note>
-            </notes>
-            <segment>
-                <source>not_available</source>
-                <target>Недоступно</target>
-            </segment>
-        </unit>
-        <unit id="DF34uM2" name="http_error.name">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-                <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-                <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-                <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-            </notes>
-            <segment>
-                <source>http_error.name</source>
-                <target>Помилка %status_code%</target>
-            </segment>
-        </unit>
-        <unit id="e3w.2Rf" name="http_error.description">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-            </notes>
-            <segment>
-                <source>http_error.description</source>
-                <target>Виникла невідома помилка (HTTP %status_code%), яка завадила виконати ваш запит.</target>
-            </segment>
-        </unit>
-        <unit id="ru5FEGk" name="http_error.suggestion">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-            </notes>
-            <segment>
-                <source>http_error.suggestion</source>
-                <target><![CDATA[Спробувати завантажити цю сторінку ще раз через декілька хвилин або <a href="%url%">поверніться на головну сторінку</a>.]]></target>
-            </segment>
-        </unit>
-        <unit id="Qn5rwdU" name="http_error_403.description">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-            </notes>
-            <segment>
-                <source>http_error_403.description</source>
-                <target>У вас немає доступу до цього ресурсу.</target>
-            </segment>
-        </unit>
-        <unit id="zDeeh7L" name="http_error_403.suggestion">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-            </notes>
-            <segment>
-                <source>http_error_403.suggestion</source>
-                <target>Потрібно запитати доступ до цього ресурсу вашого менеджера або системного адміністратора.</target>
-            </segment>
-        </unit>
-        <unit id="_W1eNz2" name="http_error_404.description">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-            </notes>
-            <segment>
-                <source>http_error_404.description</source>
-                <target>Нам не вдалося знайти запитаної вами сторінки.</target>
-            </segment>
-        </unit>
-        <unit id="MWNS5dg" name="http_error_404.suggestion">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-            </notes>
-            <segment>
-                <source>http_error_404.suggestion</source>
-                <target><![CDATA[Перевірте правильність написання URL-адреси або <a href="%url%">поверніться на головну сторінку</a>.]]></target>
-            </segment>
-        </unit>
-        <unit id="ZYXSW95" name="http_error_500.description">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-            </notes>
-            <segment>
-                <source>http_error_500.description</source>
-                <target>Произошла внутренняя ошибка сервера.</target>
-            </segment>
-        </unit>
-        <unit id="VVs_J1c" name="http_error_500.suggestion">
-            <notes>
-                <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-            </notes>
-            <segment>
-                <source>http_error_500.suggestion</source>
-                <target><![CDATA[Try loading this page again in some minutes or <a href="%url%">поверніться на головну сторінку</a>.]]></target>
-            </segment>
-        </unit>
-        <unit id="9RwuNlf" name="title.source_code">
-            <notes>
-                <note>templates/debug/source_code.twig:17</note>
-            </notes>
-            <segment>
-                <source>title.source_code</source>
-                <target>Сирцевий код, що використовується для показу цієї сторінки</target>
-            </segment>
-        </unit>
-        <unit id="jaB3QjG" name="title.controller_code">
-            <notes>
-                <note>templates/debug/source_code.twig:22</note>
-                <note>templates/debug/source_code.twig:25</note>
-            </notes>
-            <segment>
-                <source>title.controller_code</source>
-                <target>Код контролера</target>
-            </segment>
-        </unit>
-        <unit id="2bH7SjO" name="title.twig_template_code">
-            <notes>
-                <note>templates/debug/source_code.twig:29</note>
-            </notes>
-            <segment>
-                <source>title.twig_template_code</source>
-                <target>Twig код шаблону</target>
-            </segment>
-        </unit>
-        <unit id="1sstKF9" name="title.edit_user">
-            <notes>
-                <note>templates/users/edit.twig:4</note>
-            </notes>
-            <segment>
-                <source>title.edit_user</source>
-                <target>Редагувати користувача</target>
-            </segment>
-        </unit>
-        <unit id="QbohvW1" name="action.show_code">
-            <notes>
-                <note>templates/debug/source_code.twig:7</note>
-            </notes>
-            <segment>
-                <source>action.show_code</source>
-                <target>Відобразити код</target>
-            </segment>
-        </unit>
-        <unit id="HLtdhYw" name="action.save">
-            <notes>
-                <note>templates/users/change_password.twig:18</note>
-                <note>templates/users/edit.twig:15</note>
-            </notes>
-            <segment>
-                <source>action.save</source>
-                <target>Зберегти зміни</target>
-            </segment>
-        </unit>
-        <unit id="a2vzLi7" name="action.do_something">
-            <segment>
-                <source>action.do_something</source>
-                <target>Зробіть що-небудь</target>
-            </segment>
-        </unit>
-        <unit id="etGJjTo" name="action.edit_user">
-            <notes>
-                <note>templates/users/change_password.twig:26</note>
-            </notes>
-            <segment>
-                <source>action.edit_user</source>
-                <target>Редагувати користувача</target>
-            </segment>
-        </unit>
-        <unit id="ovKkXwU" name="action.edit">
-            <segment>
-                <source>action.edit</source>
-                <target>Редагувати</target>
-            </segment>
-        </unit>
-        <unit id="LDhDPrF" name="label.username">
-            <notes>
-                <note>templates/security/login.twig:66</note>
-                <note>src/Form/UserType.php:31</note>
-            </notes>
-            <segment>
-                <source>label.username</source>
-                <target>Імʼя користувача</target>
-            </segment>
-        </unit>
-        <unit id="VgeTgE2" name="help.show_code">
-            <notes>
-                <note>templates/debug/source_code.twig:3</note>
-            </notes>
-            <segment>
-                <source>help.show_code</source>
-                <target><![CDATA[Натисніть цю кнопку, щоб показати сирцевий код <strong>Контролера</strong> and <strong>шаблону</strong>, які використовуються для рендерингу цієї сторінки.]]></target>
-            </segment>
-        </unit>
-        <unit id="wtG.cxy" name="info.change_password">
-            <notes>
-                <note>templates/users/change_password.twig:12</note>
-            </notes>
-            <segment>
-                <source>info.change_password</source>
-                <target>Після зміни паролю ви будете змушені вийти з програми.</target>
-            </segment>
-        </unit>
-        <unit id="80JoLd0" name="title.login">
-            <notes>
-                <note>templates/security/login.twig:4</note>
-            </notes>
-            <segment>
-                <source>title.login</source>
-                <target>Авторизація</target>
-            </segment>
-        </unit>
-        <unit id="9pvowqn" name="label.password">
-            <notes>
-                <note>templates/security/login.twig:70</note>
-                <note>templates/security/login.twig:75</note>
-            </notes>
-            <segment>
-                <source>label.password</source>
-                <target>Пароль</target>
-            </segment>
-        </unit>
-        <unit id="gLN0C81" name="action.log_in">
-            <notes>
-                <note>templates/security/login.twig:84</note>
-            </notes>
-            <segment>
-                <source>action.log_in</source>
-                <target>Увійти</target>
-            </segment>
-        </unit>
-        <unit id="vJwSCBO" name="title.contentlisting">
-            <notes>
-                <note>templates/content/listing.twig:9</note>
-            </notes>
-            <segment>
-                <source>title.contentlisting</source>
-                <target>Перелік вмісту</target>
-            </segment>
-        </unit>
-        <unit id="CX_oSFd" name="action.change_password">
-            <notes>
-                <note>templates/users/edit.twig:24</note>
-            </notes>
-            <segment>
-                <source>action.change_password</source>
-                <target>Замініть пароль</target>
-            </segment>
-        </unit>
-        <unit id="SNELzJ2" name="field.id">
-            <notes>
-                <note>templates/editcontent/edit.twig:118</note>
-                <note>templates/editcontent/media_edit.twig:98</note>
-            </notes>
-            <segment>
-                <source>field.id</source>
-                <target>ID</target>
-            </segment>
-        </unit>
-        <unit id="FuCyk5C" name="field.status">
-            <notes>
-                <note>templates/editcontent/edit.twig:76</note>
-            </notes>
-            <segment>
-                <source>field.status</source>
-                <target>Статус</target>
-            </segment>
-        </unit>
-        <unit id="O9wtVOp" name="field.createdAt">
-            <notes>
-                <note>templates/editcontent/edit.twig:86</note>
-                <note>templates/editcontent/media_edit.twig:128</note>
-            </notes>
-            <segment>
-                <source>field.createdAt</source>
-                <target>Створено</target>
-            </segment>
-        </unit>
-        <unit id="eVkSIKu" name="field.modifiedAt">
-            <notes>
-                <note>templates/editcontent/edit.twig:94</note>
-                <note>templates/editcontent/media_edit.twig:135</note>
-            </notes>
-            <segment>
-                <source>field.modifiedAt</source>
-                <target>Змінено</target>
-            </segment>
-        </unit>
-        <unit id="3gdi1dy" name="field.publishedAt">
-            <notes>
-                <note>templates/editcontent/edit.twig:102</note>
-            </notes>
-            <segment>
-                <source>field.publishedAt</source>
-                <target>Опубліковано</target>
-            </segment>
-        </unit>
-        <unit id="eN7IfEL" name="field.depublishedAt">
-            <notes>
-                <note>templates/editcontent/edit.twig:110</note>
-            </notes>
-            <segment>
-                <source>field.depublishedAt</source>
-                <target>Знято з публікації</target>
-            </segment>
-        </unit>
-        <unit id="VKhfRZB" name="field.title">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:47</note>
-            </notes>
-            <segment>
-                <source>field.title</source>
-                <target>Заголовок</target>
-            </segment>
-        </unit>
-        <unit id="7_wwX8J" name="field.description">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:53</note>
-            </notes>
-            <segment>
-                <source>field.description</source>
-                <target>Опис</target>
-            </segment>
-        </unit>
-        <unit id="hjDmcPC" name="field.copyright">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:59</note>
-            </notes>
-            <segment>
-                <source>field.copyright</source>
-                <target>Авторські права</target>
-            </segment>
-        </unit>
-        <unit id="v0sitU8" name="field.originalFilename">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:66</note>
-            </notes>
-            <segment>
-                <source>field.originalFilename</source>
-                <target>Початкове ім'я файлу</target>
-            </segment>
-        </unit>
-        <unit id="vlRe8Tx" name="field.width">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:105</note>
-            </notes>
-            <segment>
-                <source>field.width</source>
-                <target>ширина</target>
-            </segment>
-        </unit>
-        <unit id="CZbXbM_" name="field.height">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:112</note>
-            </notes>
-            <segment>
-                <source>field.height</source>
-                <target>висота</target>
-            </segment>
-        </unit>
-        <unit id="Sz_u.OS" name="field.filesize">
-            <notes>
-                <note>templates/editcontent/media_edit.twig:119</note>
-            </notes>
-            <segment>
-                <source>field.filesize</source>
-                <target>Filesize</target>
-            </segment>
-        </unit>
-        <unit id="RMPnq6o" name="label.username_or_email">
-            <notes>
-                <note>templates/security/login.twig:61</note>
-            </notes>
-            <segment>
-                <source>label.username_or_email</source>
-                <target>Імʼя користувача або email</target>
-            </segment>
-        </unit>
-        <unit id="IaF1MjB" name="label.rememberme">
-            <notes>
-                <note>templates/security/login.twig:80</note>
-            </notes>
-            <segment>
-                <source>label.rememberme</source>
-                <target>Запамʼятати?</target>
-            </segment>
-        </unit>
-        <unit id="k.JymqB" name="about.visit_bolt">
-            <notes>
-                <note>templates/pages/about.twig:25</note>
-            </notes>
-            <segment>
-                <source>about.visit_bolt</source>
-                <target>Перейти на Boltcms.io</target>
-            </segment>
-        </unit>
-        <unit id="UZFanGF" name="about.bolt_documentation">
-            <notes>
-                <note>templates/pages/about.twig:28</note>
-            </notes>
-            <segment>
-                <source>about.bolt_documentation</source>
-                <target>Документація з Bolt</target>
-            </segment>
-        </unit>
-        <unit id="FO7zDub" name="about.bolt_on_github">
-            <notes>
-                <note>templates/pages/about.twig:31</note>
-            </notes>
-            <segment>
-                <source>about.bolt_on_github</source>
-                <target>Bolt на Github</target>
-            </segment>
-        </unit>
-        <unit id="_9fS00R" name="about.used_libraries">
-            <notes>
-                <note>templates/pages/about.twig:35</note>
-            </notes>
-            <segment>
-                <source>about.used_libraries</source>
-                <target>Бібліотеки / компоненти, що використовуються</target>
-            </segment>
-        </unit>
-        <unit id="tgLgLDQ" name="about.list_of_used_libraries">
-            <notes>
-                <note>templates/pages/about.twig:37</note>
-            </notes>
-            <segment>
-                <source>about.list_of_used_libraries</source>
-                <target>Нижче наведені сторонні бібліотеки, які використовує Bolt.</target>
-            </segment>
-        </unit>
-        <unit id="aYnbvsn" name="label.fullname">
-            <notes>
-                <note>src/Form/UserType.php:35</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>label.fullname</source>
-                <target>Повне імʼя</target>
-            </segment>
-        </unit>
-        <unit id="D2N6_cP" name="label.email">
-            <notes>
-                <note>src/Form/UserType.php:38</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>label.email</source>
-                <target>Адреса електронної пошти</target>
-            </segment>
-        </unit>
-        <unit id="OBmPOoB" name="user.updated_successfully">
-            <notes>
-                <note>src/Controller/Backend/UserController.php:33</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>user.updated_successfully</source>
-                <target>Оновлення успішне</target>
-            </segment>
-        </unit>
-        <unit id="3hkt.eH" name="content.updated_successfully">
-            <notes>
-                <note>src/Controller/Backend/EditMediaController.php:126</note>
-                <note>src/Controller/Backend/EditRecordController.php:86</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>content.updated_successfully</source>
-                <target>Контент успішно оновлено</target>
-            </segment>
-        </unit>
-        <unit id="IB0mNQh" name="content.created_successfully">
-            <notes>
-                <note>src/Controller/Backend/EditMediaController.php:157</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>content.created_successfully</source>
-                <target>Медіа-елемент успішно створено</target>
-            </segment>
-        </unit>
-        <unit id="b1jqjUC" name="editfile.could_not_write">
-            <notes>
-                <note>src/Controller/Backend/EditFileController.php:101</note>
-                <note>new</note>
-            </notes>
-            <segment>
-                <source>editfile.could_not_write</source>
-                <target>Не вдалося записати Медіа-елемент</target>
-            </segment>
-        </unit>
-        <unit id="mEDsKHk" name="label.locale">
-            <segment>
-                <source>label.locale</source>
-                <target>Локаль</target>
-            </segment>
-        </unit>
-        <unit id="98Q5SA2" name="label.backend_theme">
-            <segment>
-                <source>label.backend_theme</source>
-                <target>Бекенд-тема</target>
-            </segment>
-        </unit>
-        <unit id="Z84BVRW" name="English (en)">
-            <segment>
-                <source>English (en)</source>
-                <target>English (en)</target>
-            </segment>
-        </unit>
-        <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-            <segment>
-                <source>Nederlands (dutch, nl)</source>
-                <target>Nederlands (dutch, nl)</target>
-            </segment>
-        </unit>
-        <unit id="57LcBXV" name="Español (Spanish, es)">
-            <segment>
-                <source>Español (Spanish, es)</source>
-                <target>Español (Spanish, es)</target>
-            </segment>
-        </unit>
-        <unit id="e7RdvJ0" name="français (French, fr)">
-            <segment>
-                <source>français (French, fr)</source>
-                <target>français (French, fr)</target>
-            </segment>
-        </unit>
-        <unit id="U1vrep2" name="Deutsch (German, de)">
-            <segment>
-                <source>Deutsch (German, de)</source>
-                <target>Deutsch (German, de)</target>
-            </segment>
-        </unit>
-        <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-            <segment>
-                <source>Język Polski (Polish, pl)</source>
-                <target>Język Polski (Polish, pl)</target>
-            </segment>
-        </unit>
-        <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-            <segment>
-                <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-                <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-            </segment>
-        </unit>
-        <unit id="pBUPCm9" name="Italiano (Italian, it)">
-            <segment>
-                <source>Italiano (Italian, it)</source>
-                <target>Italiano (Italian, it)</target>
-            </segment>
-        </unit>
-        <unit id="Oiwdkpg" name="The Default theme">
-            <segment>
-                <source>The Default theme</source>
-                <target>Тема за змовчанням</target>
-            </segment>
-        </unit>
-        <unit id="C389Knp" name="The Default Dark theme">
-            <segment>
-                <source>The Default Dark theme</source>
-                <target>Темна тема за змовчанням</target>
-            </segment>
-        </unit>
-        <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
-            <segment>
-                <source>WoordPers: Kinda looks like that other CMS</source>
-                <target>WoordPers: Kinda looks like that other CMS</target>
-            </segment>
-        </unit>
-        <unit id="7aLIA3c" name="caption.dashboard">
-            <segment>
-                <source>caption.dashboard</source>
-                <target>Панель Bolt</target>
-            </segment>
-        </unit>
-        <unit id="xuNRuUu" name="caption.translations: messages">
-            <segment>
-                <source>caption.translations: messages</source>
-                <target>caption.translations: messages</target>
-            </segment>
-        </unit>
-        <unit id="K6TmK4B" name="caption.clear_cache">
-            <segment>
-                <source>caption.clear_cache</source>
-                <target>Очистити кеш</target>
-            </segment>
-        </unit>
-        <unit id="RRQ1EJ3" name="caption.check_database">
-            <segment>
-                <source>caption.check_database</source>
-                <target>Перевірити базу даних</target>
-            </segment>
-        </unit>
-        <unit id="cIiIXu_" name="caption.routing set up">
-            <segment>
-                <source>caption.routing set up</source>
-                <target>caption.routing set up</target>
-            </segment>
-        </unit>
-        <unit id="2RUXD4A" name="caption.menu_setup">
-            <segment>
-                <source>caption.menu_setup</source>
-                <target>Налаштування меню</target>
-            </segment>
-        </unit>
-        <unit id="drK.0GZ" name="caption.taxonomies">
-            <segment>
-                <source>caption.taxonomies</source>
-                <target>Категоризація</target>
-            </segment>
-        </unit>
-        <unit id="_w7J5rZ" name="caption.contenttypes">
-            <segment>
-                <source>caption.contenttypes</source>
-                <target>Типи контенту</target>
-            </segment>
-        </unit>
-        <unit id="kXNBV9S" name="caption.main_configuration">
-            <segment>
-                <source>caption.main_configuration</source>
-                <target>Основна конфігурація</target>
-            </segment>
-        </unit>
-        <unit id="ipmA6Ah" name="caption.users_permissions">
-            <segment>
-                <source>caption.users_permissions</source>
-                <target>Користувачі та права</target>
-            </segment>
-        </unit>
-        <unit id="zOLL.7E" name="caption.configuration">
-            <segment>
-                <source>caption.configuration</source>
-                <target>Конфігурація</target>
-            </segment>
-        </unit>
-        <unit id="ZO.uqIZ" name="caption.settings">
-            <segment>
-                <source>caption.settings</source>
-                <target>Налаштування</target>
-            </segment>
-        </unit>
-        <unit id="1xlE8ex" name="caption.content">
-            <segment>
-                <source>caption.content</source>
-                <target>Контент</target>
-            </segment>
-        </unit>
-        <unit id="l4yt0BE" name="caption.file_management">
-            <segment>
-                <source>caption.file_management</source>
-                <target>Файли</target>
-            </segment>
-        </unit>
-        <unit id="mfvtHPQ" name="caption.extensions">
-            <segment>
-                <source>caption.extensions</source>
-                <target>Розширення</target>
-            </segment>
-        </unit>
-        <unit id="K4D568R" name="caption.view_edit_templates">
-            <segment>
-                <source>caption.view_edit_templates</source>
-                <target>Шаблони</target>
-            </segment>
-        </unit>
-        <unit id="bq6bSf4" name="caption.uploaded_files">
-            <segment>
-                <source>caption.uploaded_files</source>
-                <target>Завантажені файли</target>
-            </segment>
-        </unit>
-        <unit id="wBKDkwl" name="caption.routing_setup">
-            <segment>
-                <source>caption.routing_setup</source>
-                <target>Конфігурація маршрутизації</target>
-            </segment>
-        </unit>
-        <unit id="dd5MzCM" name="caption.translations">
-            <segment>
-                <source>caption.translations</source>
-                <target>Переклади / Ярлики</target>
-            </segment>
-        </unit>
-        <unit id="wLaDaK5" name="caption.about_bolt">
-            <segment>
-                <source>caption.about_bolt</source>
-                <target>Про Bolt</target>
-            </segment>
-        </unit>
-        <unit id="xN1kSQQ" name="caption.bolt_payoff">
-            <segment>
-                <source>caption.bolt_payoff</source>
-                <target><![CDATA[Вишукана, легка і проста CMS]]></target>
-            </segment>
-        </unit>
-        <unit id="HK7XTUX" name="caption.edit">
-            <segment>
-                <source>caption.edit</source>
-                <target>Редагувати</target>
-            </segment>
-        </unit>
-        <unit id="QZYjRy0" name="caption.file_uploader">
-            <segment>
-                <source>caption.file_uploader</source>
-                <target>Завантажувач файлів</target>
-            </segment>
-        </unit>
-        <unit id="LaDIuZA" name="caption.meta_information">
-            <segment>
-                <source>caption.meta_information</source>
-                <target>Мета інформація</target>
-            </segment>
-        </unit>
-        <unit id="DodjLNR" name="date">
-            <segment>
-                <source>date</source>
-                <target>Дата</target>
-            </segment>
-        </unit>
-        <unit id="zNy_hG8" name="size">
-            <segment>
-                <source>size</source>
-                <target>Розмір</target>
-            </segment>
-        </unit>
-        <unit id="gPYflhh" name="thumbnail">
-            <segment>
-                <source>thumbnail</source>
-                <target>Ескіз</target>
-            </segment>
-        </unit>
-        <unit id="_XSgfqS" name="filename">
-            <segment>
-                <source>filename</source>
-                <target>Імʼя файлу</target>
-            </segment>
-        </unit>
-        <unit id="Kw3N1AA" name="actions">
-            <segment>
-                <source>actions</source>
-                <target>Дії</target>
-            </segment>
-        </unit>
-        <unit id="KHvGNGW" name="directoryname">
-            <segment>
-                <source>directoryname</source>
-                <target>Імʼя каталогу</target>
-            </segment>
-        </unit>
-        <unit id="ZV7_x5F" name="action.go">
-            <segment>
-                <source>action.go</source>
-                <target>Старт</target>
-            </segment>
-        </unit>
-        <unit id="C15MbYY" name="form.quick_select_file">
-            <segment>
-                <source>form.quick_select_file</source>
-                <target>Вибір файлу для редагування…</target>
-            </segment>
-        </unit>
-        <unit id="gFcV5nW" name="label.quick_select">
-            <segment>
-                <source>label.quick_select</source>
-                <target>Вибір</target>
-            </segment>
-        </unit>
-        <unit id="FSroufa" name="caption.path">
-            <segment>
-                <source>caption.path</source>
-                <target>Шлях</target>
-            </segment>
-        </unit>
-        <unit id="y5otxEK" name="caption.filename">
-            <segment>
-                <source>caption.filename</source>
-                <target>Імʼя файлу</target>
-            </segment>
-        </unit>
-        <unit id="XNTbZW6" name="action.visit_site">
-            <segment>
-                <source>action.visit_site</source>
-                <target>Завітайте на сайт</target>
-            </segment>
-        </unit>
-        <unit id="KfVJho2" name="action.create_new">
-            <segment>
-                <source>action.create_new</source>
-                <target>Створити</target>
-            </segment>
-        </unit>
-        <unit id="b_RPpcB" name="general.greeting">
-            <segment>
-                <source>general.greeting</source>
-                <target>Привіт, %name%!</target>
-            </segment>
-        </unit>
-        <unit id="bmdn3u9" name="action.logout">
-            <segment>
-                <source>action.logout</source>
-                <target>Вийти</target>
-            </segment>
-        </unit>
-        <unit id="zOfpTLD" name="action.edit_profile">
-            <segment>
-                <source>action.edit_profile</source>
-                <target>Профіль</target>
-            </segment>
-        </unit>
-        <unit id="N_0yRcH" name="action.close_alert">
-            <segment>
-                <source>action.close_alert</source>
-                <target>закрити</target>
-            </segment>
-        </unit>
-        <unit id="Dvu2HQx" name="caption.api">
-            <segment>
-                <source>caption.api</source>
-                <target>API</target>
-            </segment>
-        </unit>
-        <unit id="i4cbdta" name="caption.all_configuration_files">
-            <segment>
-                <source>caption.all_configuration_files</source>
-                <target>Файли конфігурацій</target>
-            </segment>
-        </unit>
-        <unit id="OpKTKAL" name="caption.maintenance">
-            <segment>
-                <source>caption.maintenance</source>
-                <target>Обслуговування</target>
-            </segment>
-        </unit>
-        <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-            <segment>
-                <source>caption.fixtures_dummy_content</source>
-                <target>Фікстури (Контент для прикладу)</target>
-            </segment>
-        </unit>
-        <unit id="P1FHg3Q" name="caption.edit_file">
-            <segment>
-                <source>caption.edit_file</source>
-                <target>Редагувати файл</target>
-            </segment>
-        </unit>
-        <unit id="_ef0RBR" name="caption.installation_checks">
-            <segment>
-                <source>caption.installation_checks</source>
-                <target>Перевірки встановлення</target>
-            </segment>
-        </unit>
-        <unit id="pNPctrH" name="form.select_language">
-            <segment>
-                <source>form.select_language</source>
-                <target>Виберіть мову</target>
-            </segment>
-        </unit>
-        <unit id="9lJhqvA" name="field.locale">
-            <segment>
-                <source>field.locale</source>
-                <target>Локаль</target>
-            </segment>
-        </unit>
-        <unit id="8zEzq8N" name="field.current_locale">
-            <segment>
-                <source>field.current_locale</source>
-                <target>Поточна локаль</target>
-            </segment>
-        </unit>
-        <unit id="ahZvOJz" name="field.switch_to_locale">
-            <segment>
-                <source>field.switch_to_locale</source>
-                <target>Перемкнути локаль</target>
-            </segment>
-        </unit>
-        <unit id="aQX4Emy" name="field.author">
-            <segment>
-                <source>field.author</source>
-                <target>Автор</target>
-            </segment>
-        </unit>
-        <unit id="UNBaDz." name="general.phrase.edit">
-            <segment>
-                <source>general.phrase.edit</source>
-                <target>Редагування</target>
-            </segment>
-        </unit>
-        <unit id="t2TNwOq" name="Unknown">
-            <segment>
-                <source>Unknown</source>
-                <target>Невідомо</target>
-            </segment>
-        </unit>
-        <unit id="A_d5KPt" name="general.phrase.written-by-on">
-            <segment>
-                <source>general.phrase.written-by-on</source>
-                <target>Написано %name% , %date%.</target>
-            </segment>
-        </unit>
-        <unit id="TVU.FCV" name="general.phrase.missing-about-page">
-            <segment>
-                <source>general.phrase.missing-about-page</source>
-                <target>Сторінка "About" відсутня.</target>
-            </segment>
-        </unit>
-        <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
-            <segment>
-                <source>general.phrase.missing-about-page-block</source>
-                <target>Блок "About" відсутня.</target>
-            </segment>
-        </unit>
-        <unit id="AGegYAN" name="contenttypes.generic.recent">
-            <segment>
-                <source>contenttypes.generic.recent</source>
-                <target>Нещодавно використовувані %contenttypes%</target>
-            </segment>
-        </unit>
-        <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
-            <segment>
-                <source>general.phrase.search-ellipsis</source>
-                <target>…</target>
-            </segment>
-        </unit>
-        <unit id="wGlnx8X" name="general.phrase.search">
-            <segment>
-                <source>general.phrase.search</source>
-                <target>Пошук</target>
-            </segment>
-        </unit>
-        <unit id="z0k8hRg" name="9fb3e6e">
-            <segment>
-                <source>9fb3e6e</source>
-                <target>Цей сайт &lt;a href='https://boltcms.io' target='_blank' title='Вишукана, легка та проста CMS'&gt;сделан на Bolt&lt;/a&gt;.</target>
-            </segment>
-        </unit>
-        <unit id="wNEwZy_" name="contenttypes.generic.overview">
-            <segment>
-                <source>contenttypes.generic.overview</source>
-                <target>Перелік записів %contenttypes%</target>
-            </segment>
-        </unit>
-        <unit id="skuzBpI" name="contenttypes.generic.no-recent">
-            <segment>
-                <source>contenttypes.generic.no-recent</source>
-                <target>Останні записи %contenttype% не виявлено</target>
-            </segment>
-        </unit>
-        <unit id="ma9mBv_" name="Menu">
-            <segment>
-                <source>Menu</source>
-                <target>Меню</target>
-            </segment>
-        </unit>
-        <unit id="ScJmuqq" name="Search">
-            <segment>
-                <source>Search</source>
-                <target>Пошук</target>
-            </segment>
-        </unit>
-        <unit id="k.xuYv2" name="general.phrase.permalink">
-            <segment>
-                <source>general.phrase.permalink</source>
-                <target>Постійне посилання</target>
-            </segment>
-        </unit>
-        <unit id="zsyp43M" name="label.displayname">
-            <segment>
-                <source>label.displayname</source>
-                <target>Відображене імʼя</target>
-            </segment>
-        </unit>
-        <unit id="2MMvCKK" name="label.cache_cleared">
-            <segment>
-                <source>label.cache_cleared</source>
-                <target>Кеш успішно очищено!</target>
-            </segment>
-        </unit>
-        <unit id="Wou02nK" name="caption.kitchensink">
-            <segment>
-                <source>caption.kitchensink</source>
-                <target>The Kitchensink</target>
-            </segment>
-        </unit>
-        <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
-            <notes>
-                <note>parameters:</note>
-                <note> '%search%': consequatur</note>
-            </notes>
-            <segment>
-                <source>general.phrase.search-results-for-variable</source>
-                <target>Результати пошуку за запитом "% search%".</target>
-            </segment>
-        </unit>
-        <unit id="2CfJ3WY" name="general.phrase.search-results-for">
-            <notes>
-                <note>parameters:</note>
-                <note> '%search%': ymnrubeyrvwearsytevsf</note>
-            </notes>
-            <segment>
-                <source>general.phrase.search-results-for</source>
-                <target>Результати пошуку за запитом "% search%".</target>
-            </segment>
-        </unit>
-        <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
-            <notes>
-                <note>parameters:</note>
-                <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
-            </notes>
-            <segment>
-                <source>general.phrase.no-search-results-for</source>
-                <target>За запитом '%search%' нічого не знайдено.</target>
-            </segment>
-        </unit>
-        <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
-            <segment>
-                <source>general.phrase.no-search-term-provided</source>
-                <target>Введіть пошуковий запит, щоб показати релевантні результати.</target>
-            </segment>
-        </unit>
-        <unit id="Pily_qo" name="general.phrase.read-more">
-            <segment>
-                <source>general.phrase.read-more</source>
-                <target>Подробнее</target>
-            </segment>
-        </unit>
-        <unit id="psOa_9x" name="general.phrase.built-with-bolt">
-            <segment>
-                <source>general.phrase.built-with-bolt</source>
-                <target><![CDATA[Цей сайт <a href='https://boltcms.io' target='_blank' title='Вишукана, легка та проста CMS'>сделан на Bolt</a>.]]></target>
-            </segment>
-        </unit>
-        <unit id="5IxD63c" name="general.latest_bolt_news">
-            <segment>
-                <source>general.latest_bolt_news</source>
-                <target>Новини Bolt</target>
-            </segment>
-        </unit>
-        <unit id="dQIY7_J" name="action.preview">
-            <segment>
-                <source>action.preview</source>
-                <target>Перелік</target>
-            </segment>
-        </unit>
-        <unit id="ok6YulQ" name="action.view_saved">
-            <segment>
-                <source>action.view_saved</source>
-                <target>Переглянути збережену версію</target>
-            </segment>
-        </unit>
-        <unit id="SeTqePC" name="label.display_name">
-            <segment>
-                <source>label.display_name</source>
-                <target>Відображене імʼя</target>
-            </segment>
-        </unit>
-        <unit id="EvAqL__" name="caption.duplicate">
-            <segment>
-                <source>caption.duplicate</source>
-                <target>Дублікат</target>
-            </segment>
-        </unit>
-        <unit id="pGkejkU" name="label.current_password">
-            <segment>
-                <source>label.current_password</source>
-                <target>Поточний пароль</target>
-            </segment>
-        </unit>
-        <unit id="iiWFLaI" name="label.new_password">
-            <segment>
-                <source>label.new_password</source>
-                <target>Новий пароль</target>
-            </segment>
-        </unit>
-        <unit id="Ucl9Jfc" name="label.new_password_confirm">
-            <segment>
-                <source>label.new_password_confirm</source>
-                <target>Новий пароль (підтвердження)</target>
-            </segment>
-        </unit>
-        <unit id="Iyry5.g" name="editfile.updated_successfully">
-            <segment>
-                <source>editfile.updated_successfully</source>
-                <target>Файл оновлено успішно!</target>
-            </segment>
-        </unit>
-        <unit id="3zlZmRK" name="action.add_user">
-            <segment>
-                <source>action.add_user</source>
-                <target>Додати користувача</target>
-            </segment>
-        </unit>
-        <unit id="ruQIhH0" name="success">
-            <segment>
-                <source>success</source>
-                <target>Успішно!</target>
-            </segment>
-        </unit>
-        <unit id="YDH.7uR" name="user.updated_profile">
-            <segment>
-                <source>user.updated_profile</source>
-                <target>Профіль користувача оновлено!</target>
-            </segment>
-        </unit>
-        <unit id="iD6CNOO" name="label.roles">
-            <segment>
-                <source>label.roles</source>
-                <target>Ролі</target>
-            </segment>
-        </unit>
-        <unit id="7whLbH8" name="user.new_user">
-            <segment>
-                <source>user.new_user</source>
-                <target>Новий користувач</target>
-            </segment>
-        </unit>
-        <unit id="TtmWqX3" name="action.view">
-            <segment>
-                <source>action.view</source>
-                <target>Перелік</target>
-            </segment>
-        </unit>
-        <unit id="I2ykiIZ" name="caption.folders">
-            <segment>
-                <source>caption.folders</source>
-                <target>Теки</target>
-            </segment>
-        </unit>
-        <unit id="kaK5Wdr" name="slug.button_locked">
-            <segment>
-                <source>slug.button_locked</source>
-                <target>Заблоковано</target>
-            </segment>
-        </unit>
-        <unit id="qcDEz5O" name="slug.button_edit">
-            <segment>
-                <source>slug.button_edit</source>
-                <target>Редагувати</target>
-            </segment>
-        </unit>
-        <unit id="raO5QSf" name="slug.generate_from">
-            <segment>
-                <source>slug.generate_from</source>
-                <target>Створити за основою поля:</target>
-            </segment>
-        </unit>
-        <unit id="vptPhch" name="image.button_upload">
-            <segment>
-                <source>image.button_upload</source>
-                <target>Завантажити</target>
-            </segment>
-        </unit>
-        <unit id="vIVO1lU" name="image.button_from_library">
-            <segment>
-                <source>image.button_from_library</source>
-                <target>З бібліотеки</target>
-            </segment>
-        </unit>
-        <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
-            <segment>
-                <source>listing_table.actions.view_on_site</source>
-                <target>Перегляд на сайті</target>
-            </segment>
-        </unit>
-        <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
-            <segment>
-                <source>listing_table.actions.status_to_publish</source>
-                <target>Замініть статус на "опублікувати"</target>
-            </segment>
-        </unit>
-        <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
-            <segment>
-                <source>listing_table.actions.status_to_held</source>
-                <target>Змінити статус на "не активне"</target>
-            </segment>
-        </unit>
-        <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
-            <segment>
-                <source>listing_table.actions.status_to_draft</source>
-                <target>Змінити статус на "чернетка"</target>
-            </segment>
-        </unit>
-        <unit id="5H60Xq6" name="listing_table.actions.duplicate">
-            <segment>
-                <source>listing_table.actions.duplicate</source>
-                <target>Клонувати</target>
-            </segment>
-        </unit>
-        <unit id="hR8ri.m" name="listing_table.actions.delete">
-            <segment>
-                <source>listing_table.actions.delete</source>
-                <target>Видалити</target>
-            </segment>
-        </unit>
-        <unit id="5zbX1vo" name="listing_table.actions.slug">
-            <segment>
-                <source>listing_table.actions.slug</source>
-                <target>Сегмент адреси</target>
-            </segment>
-        </unit>
-        <unit id="wKDOBOC" name="listing_table.actions.created_on">
-            <segment>
-                <source>listing_table.actions.created_on</source>
-                <target>Створено</target>
-            </segment>
-        </unit>
-        <unit id="tVX01Xl" name="listing_table.actions.published_on">
-            <segment>
-                <source>listing_table.actions.published_on</source>
-                <target>Опубліковано</target>
-            </segment>
-        </unit>
-        <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
-            <segment>
-                <source>listing_table.actions.last_modified_on</source>
-                <target>Змінений</target>
-            </segment>
-        </unit>
-        <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
-            <segment>
-                <source>listing_select_box.card_header.selected</source>
-                <target>Вибрано</target>
-            </segment>
-        </unit>
-        <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-            <segment>
-                <source>listing_select_box.card_body.records_passed</source>
-                <target>передані ідентифікатори обраних записів</target>
-            </segment>
-        </unit>
-        <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-            <segment>
-                <source>listing_select_box.card_body.remark</source>
-                <target>(це можна використовувати з чимось на кшталт axios для масової зміни / видалення)</target>
-            </segment>
-        </unit>
-        <unit id="kHeY93_" name="editor_embed.content_url">
-            <segment>
-                <source>editor_embed.content_url</source>
-                <target>URL-адреса контенту для вбудовування</target>
-            </segment>
-        </unit>
-        <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
-            <segment>
-                <source>editor_embed.placeholder_content_url</source>
-                <target>URL-адреса контенту в Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
-            </segment>
-        </unit>
-        <unit id="1.Eb1GS" name="editor_embed.label_height">
-            <segment>
-                <source>editor_embed.label_height</source>
-                <target>Висота</target>
-            </segment>
-        </unit>
-        <unit id="eWLSFJs" name="editor_embed.label_pixel">
-            <segment>
-                <source>editor_embed.label_pixel</source>
-                <target>піксель</target>
-            </segment>
-        </unit>
-        <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
-            <segment>
-                <source>editor_embed.label_matched_embed</source>
-                <target>Відповідний вбудований елемент</target>
-            </segment>
-        </unit>
-        <unit id="zATju4V" name="editor_embed.label_preview">
-            <segment>
-                <source>editor_embed.label_preview</source>
-                <target>Попередній перегляд</target>
-            </segment>
-        </unit>
-        <unit id="9SQ0oaR" name="editor_embed.label_size">
-            <segment>
-                <source>editor_embed.label_size</source>
-                <target>Розмір</target>
-            </segment>
-        </unit>
-        <unit id="oOuVKRv" name="image.placeholder_filename">
-            <segment>
-                <source>image.placeholder_filename</source>
-                <target>Імʼя файлу (завантажте новий файл або виберіть наявний)</target>
-            </segment>
-        </unit>
-        <unit id="BWubOnS" name="image.placeholder_alt_text">
-            <segment>
-                <source>image.placeholder_alt_text</source>
-                <target>Атрибут Alt</target>
-            </segment>
-        </unit>
-        <unit id="VPV0lFM" name="image.placeholder_title">
-            <segment>
-                <source>image.placeholder_title</source>
-                <target>Заголовок</target>
-            </segment>
-        </unit>
-        <unit id="Gabafxx" name="admin_sidebar.toggler">
-            <segment>
-                <source>admin_sidebar.toggler</source>
-                <target>Перемкнути ширину бокової панелі</target>
-            </segment>
-        </unit>
-        <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
-            <segment>
-                <source>admin_sidebar_toggler.toggle</source>
-                <target><![CDATA[<span class="sr-only">Вкл./Вимк. </span>меню]]></target>
-            </segment>
-        </unit>
-        <unit id="BINgtmK" name="editor_date.toggle">
-            <segment>
-                <source>editor_date.toggle</source>
-                <target>Вкл./Вимк.</target>
-            </segment>
-        </unit>
-        <unit id="VQ2t655" name="file.label_filename">
-            <segment>
-                <source>file.label_filename</source>
-                <target>Імʼя файлу</target>
-            </segment>
-        </unit>
-        <unit id="tvpSmD7" name="file.label_title">
-            <segment>
-                <source>file.label_title</source>
-                <target>Заголовок</target>
-            </segment>
-        </unit>
-        <unit id="hXT_hI." name="file.button_view">
-            <segment>
-                <source>file.button_view</source>
-                <target>Перегляд зображення</target>
-            </segment>
-        </unit>
-        <unit id="QKIqqOw" name="file.button_upload">
-            <segment>
-                <source>file.button_upload</source>
-                <target>Загрузіть зображення</target>
-            </segment>
-        </unit>
-        <unit id="4_JdYp1" name="file.remark">
-            <segment>
-                <source>file.remark</source>
-                <target><![CDATA[Примітка. Це поле практично таке ж, як поле <code>image</code>.]]></target>
-            </segment>
-        </unit>
-        <unit id="TJDc9vQ" name="file.label_alt">
-            <segment>
-                <source>file.label_alt</source>
-                <target>Alt</target>
-            </segment>
-        </unit>
-        <unit id="M.3olSc" name="filelist.remark">
-            <segment>
-                <source>filelist.remark</source>
-                <target><![CDATA[Примітка. Це поле практично таке ж, як поле <code>imagelist</code>.]]></target>
-            </segment>
-        </unit>
-        <unit id="zg5Dum5" name="geolocation.label_geolocation">
-            <segment>
-                <source>geolocation.label_geolocation</source>
-                <target>Геолокація:</target>
-            </segment>
-        </unit>
-        <unit id="Com0pbc" name="geolocation.label_address">
-            <segment>
-                <source>geolocation.label_address</source>
-                <target>Пошук адреси</target>
-            </segment>
-        </unit>
-        <unit id="3o0LPHj" name="geolocation.placeholder_address">
-            <segment>
-                <source>geolocation.placeholder_address</source>
-                <target>Вулиця, поштовий індекс, місто або інше…</target>
-            </segment>
-        </unit>
-        <unit id="CC5QTmy" name="geolocation.label_lat">
-            <segment>
-                <source>geolocation.label_lat</source>
-                <target>Широта</target>
-            </segment>
-        </unit>
-        <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-            <segment>
-                <source>geolocation.label_address_matched</source>
-                <target>Відповідна адреса</target>
-            </segment>
-        </unit>
-        <unit id="WJGjWG8" name="geolocation.label_marker">
-            <segment>
-                <source>geolocation.label_marker</source>
-                <target>Розміщення маркеру</target>
-            </segment>
-        </unit>
-        <unit id="SaP3OOf" name="geolocation.label_control">
-            <segment>
-                <source>geolocation.label_control</source>
-                <target>Прив'язати до найбличої адреси</target>
-            </segment>
-        </unit>
-        <unit id="AHaenW3" name="geolocation.label_long">
-            <segment>
-                <source>geolocation.label_long</source>
-                <target>Довгота</target>
-            </segment>
-        </unit>
-        <unit id="TkryUve" name="imagelist.remark">
-            <segment>
-                <source>imagelist.remark</source>
-                <target><![CDATA[Примітка. Це поле практично таке ж, як поле <code>filelist</code>.]]></target>
-            </segment>
-        </unit>
-        <unit id="z2AgHGp" name="flash_messages.notification">
-            <segment>
-                <source>flash_messages.notification</source>
-                <target>Сповіщення</target>
-            </segment>
-        </unit>
-        <unit id="qQKx1lR" name="buttons.button_toggle">
-            <segment>
-                <source>buttons.button_toggle</source>
-                <target>Перемкнути перелік, що розкривається</target>
-            </segment>
-        </unit>
-        <unit id="ypPzS03" name="localeswitcher.button_info">
-            <segment>
-                <source>localeswitcher.button_info</source>
-                <target>Див. Інформацію про локалізацію</target>
-            </segment>
-        </unit>
-        <unit id="wQ0WYAT" name="listing.title_sortby">
-            <segment>
-                <source>listing.title_sortby</source>
-                <target>Сортувати по</target>
-            </segment>
-        </unit>
-        <unit id="ZGv90X8" name="listing.option_select_item">
-            <segment>
-                <source>listing.option_select_item</source>
-                <target>Вибрати елемент</target>
-            </segment>
-        </unit>
-        <unit id="TIyjgb6" name="listing.title_title">
-            <segment>
-                <source>listing.title_title</source>
-                <target>Заголовок</target>
-            </segment>
-        </unit>
-        <unit id="pn22p7q" name="listing.placeholder_filter">
-            <segment>
-                <source>listing.placeholder_filter</source>
-                <target>Ключове слово для фільтрації…</target>
-            </segment>
-        </unit>
-        <unit id="ni4zApC" name="listing.button_filter">
-            <segment>
-                <source>listing.button_filter</source>
-                <target>Відфільтрувати</target>
-            </segment>
-        </unit>
-        <unit id="doNsgm0" name="listing.button_clear">
-            <segment>
-                <source>listing.button_clear</source>
-                <target>Очистити сортування/фільтр</target>
-            </segment>
-        </unit>
-        <unit id="37kJiIe" name="view_locales.badge_default">
-            <segment>
-                <source>view_locales.badge_default</source>
-                <target>За змовчанням</target>
-            </segment>
-        </unit>
-        <unit id="JTRCo_U" name="view_locales.badge_ok">
-            <segment>
-                <source>view_locales.badge_ok</source>
-                <target>OK</target>
-            </segment>
-        </unit>
-        <unit id="ufFUPp7" name="view_locales.badge_missing">
-            <segment>
-                <source>view_locales.badge_missing</source>
-                <target>Відсутній</target>
-            </segment>
-        </unit>
-        <unit id="QQvRJe." name="files_cards.button_toggle">
-            <segment>
-                <source>files_cards.button_toggle</source>
-                <target>Перемкнути перелік, що розкривається</target>
-            </segment>
-        </unit>
-        <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
-            <segment>
-                <source>files_cards.action_edit_image_info</source>
-                <target>Редагувати інфо. про зображення</target>
-            </segment>
-        </unit>
-        <unit id="5LXvJfE" name="files_cards.action_edit_file">
-            <segment>
-                <source>files_cards.action_edit_file</source>
-                <target>Змінити файл у редакторі</target>
-            </segment>
-        </unit>
-        <unit id="H1pgP94" name="files_cards.action_view_original">
-            <segment>
-                <source>files_cards.action_view_original</source>
-                <target>Перегляд</target>
-            </segment>
-        </unit>
-        <unit id="ZoY6ADX" name="files_cards.action_duplicate">
-            <segment>
-                <source>files_cards.action_duplicate</source>
-                <target>Клонувати</target>
-            </segment>
-        </unit>
-        <unit id="JjU6ZQP" name="files_cards.action_delete">
-            <segment>
-                <source>files_cards.action_delete</source>
-                <target>Видалити</target>
-            </segment>
-        </unit>
-        <unit id="3jdNwuk" name="files_cards.label_filename">
-            <segment>
-                <source>files_cards.label_filename</source>
-                <target>Імʼя файлу:</target>
-            </segment>
-        </unit>
-        <unit id="Y90_Pn1" name="files_cards.label_title">
-            <segment>
-                <source>files_cards.label_title</source>
-                <target>Заголовок:</target>
-            </segment>
-        </unit>
-        <unit id="EdCfIKX" name="files_cards.label_dimensions">
-            <segment>
-                <source>files_cards.label_dimensions</source>
-                <target>Розміри:</target>
-            </segment>
-        </unit>
-        <unit id="eQBhceV" name="files_cards.label_filesize">
-            <segment>
-                <source>files_cards.label_filesize</source>
-                <target>Розмір файла:</target>
-            </segment>
-        </unit>
-        <unit id="uiCjlwk" name="files_cards.label_created_on">
-            <segment>
-                <source>files_cards.label_created_on</source>
-                <target>Створено:</target>
-            </segment>
-        </unit>
-        <unit id=".fL0AbE" name="files_list.remark">
-            <segment>
-                <source>files_list.remark</source>
-                <target>В цій теці немає файлів. Виберіть теку для переходу.</target>
-            </segment>
-        </unit>
-        <unit id="v6cfPyt" name="quickselect.title_select">
-            <segment>
-                <source>quickselect.title_select</source>
-                <target>Вибір файлу:</target>
-            </segment>
-        </unit>
-        <unit id="m3tNvJb" name="finder.button_list">
-            <segment>
-                <source>finder.button_list</source>
-                <target>Перелік</target>
-            </segment>
-        </unit>
-        <unit id="tRLgeoX" name="finder.button_cards">
-            <segment>
-                <source>finder.button_cards</source>
-                <target>Картки</target>
-            </segment>
-        </unit>
-        <unit id="nrWBJNm" name="extensions.title_desc">
-            <segment>
-                <source>extensions.title_desc</source>
-                <target>Опис:</target>
-            </segment>
-        </unit>
-        <unit id="7raDJAR" name="extensions.title_author">
-            <segment>
-                <source>extensions.title_author</source>
-                <target>Автор:</target>
-            </segment>
-        </unit>
-        <unit id="UP8pNGy" name="extensions.title_package">
-            <segment>
-                <source>extensions.title_package</source>
-                <target>Пакет / імʼя класса:</target>
-            </segment>
-        </unit>
-        <unit id="QFQ1uTC" name="extensions.title_version">
-            <segment>
-                <source>extensions.title_version</source>
-                <target>Версія:</target>
-            </segment>
-        </unit>
-        <unit id="piuatxC" name="extensions.info_not_installed">
-            <segment>
-                <source>extensions.info_not_installed</source>
-                <target>Це локальный пакет, не встановлений через Composer</target>
-            </segment>
-        </unit>
-        <unit id="3j1gEmk" name="extensions.title_class">
-            <segment>
-                <source>extensions.title_class</source>
-                <target>Імʼя класса:</target>
-            </segment>
-        </unit>
-        <unit id="mjhFljb" name="extensions.button_configuration">
-            <segment>
-                <source>extensions.button_configuration</source>
-                <target>Конфігурація</target>
-            </segment>
-        </unit>
-        <unit id="r3ryNTG" name="extensions.button_source">
-            <segment>
-                <source>extensions.button_source</source>
-                <target>Джерело</target>
-            </segment>
-        </unit>
-        <unit id="qc3rFkZ" name="extensions.button_remove">
-            <segment>
-                <source>extensions.button_remove</source>
-                <target>Видалити розширення</target>
-            </segment>
-        </unit>
-        <unit id="SLZyVzU" name="extensions.button_disable">
-            <segment>
-                <source>extensions.button_disable</source>
-                <target>Вимкнути розширення</target>
-            </segment>
-        </unit>
-        <unit id="beqzCkE" name="login.header_login">
-            <segment>
-                <source>login.header_login</source>
-                <target>Bolt » Вхід</target>
-            </segment>
-        </unit>
-        <unit id="7JK6jNv" name="extensions.message_not_implemented">
-            <segment>
-                <source>extensions.message_not_implemented</source>
-                <target>Ще не реалізовано.</target>
-            </segment>
-        </unit>
-        <unit id="Hlf9c1s" name="listing.title_overview">
-            <segment>
-                <source>listing.title_overview</source>
-                <target>Перелік записів</target>
-            </segment>
-        </unit>
-        <unit id="8JeahIj" name="files_cards.message_no_files">
-            <segment>
-                <source>files_cards.message_no_files</source>
-                <target>В цій теці немає файлів. Виберіть теку для переходу з правої сторони.</target>
-            </segment>
-        </unit>
-        <unit id="pcq1NGk" name="listing_filter.button_compact">
-            <segment>
-                <source>listing_filter.button_compact</source>
-                <target>Згорнуто</target>
-            </segment>
-        </unit>
-        <unit id="xIztVmp" name="listing_filter.button_expanded">
-            <segment>
-                <source>listing_filter.button_expanded</source>
-                <target>Розгорнуто</target>
-            </segment>
-        </unit>
-        <unit id="73A2bWM" name="finder.label_view">
-            <segment>
-                <source>finder.label_view</source>
-                <target>Перегляд:</target>
-            </segment>
-        </unit>
-        <unit id="Em.C0bV" name="listing_table.actions.button_edit">
-            <segment>
-                <source>listing_table.actions.button_edit</source>
-                <target>Редагувати</target>
-            </segment>
-        </unit>
-        <unit id="Iy4HXCU" name="controller.user.title">
-            <segment>
-                <source>controller.user.title</source>
-                <target>Користувачі і права</target>
-            </segment>
-        </unit>
-        <unit id="HBwIQ9b" name="controller.user.subtitle">
-            <segment>
-                <source>controller.user.subtitle</source>
-                <target>Для редагування користувачів і їх прав</target>
-            </segment>
-        </unit>
-        <unit id="0Gyf5xr" name="controller.database.check_title">
-            <segment>
-                <source>controller.database.check_title</source>
-                <target>Перевірки бази даних</target>
-            </segment>
-        </unit>
-        <unit id="SeDwjX6" name="controller.database.check_subtitle">
-            <segment>
-                <source>controller.database.check_subtitle</source>
-                <target>Щоб перевірити базу даних</target>
-            </segment>
-        </unit>
-        <unit id="nJnALPG" name="controller.database.update_title">
-            <segment>
-                <source>controller.database.update_title</source>
-                <target>Оновлення бази даних</target>
-            </segment>
-        </unit>
-        <unit id="nRE74_i" name="controller.database.update_subtitle">
-            <segment>
-                <source>controller.database.update_subtitle</source>
-                <target>Щоб оновити базу даних</target>
-            </segment>
-        </unit>
-        <unit id="a3UNsKw" name="controller.omnisearch.title">
-            <segment>
-                <source>controller.omnisearch.title</source>
-                <target>Всеспрямований пошук</target>
-            </segment>
-        </unit>
-        <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-            <segment>
-                <source>controller.omnisearch.subtitle</source>
-                <target>Шукати, подібно до всіх</target>
-            </segment>
-        </unit>
-        <unit id="7cXqH5s" name="listing.title_display_name">
-            <segment>
-                <source>listing.title_display_name</source>
-                <target>Відображене імʼя</target>
-            </segment>
-        </unit>
-        <unit id="Ay7xZ2h" name="listing.title_username">
-            <segment>
-                <source>listing.title_username</source>
-                <target>Імʼя користувача</target>
-            </segment>
-        </unit>
-        <unit id="RN1tdtJ" name="listing.title_email">
-            <segment>
-                <source>listing.title_email</source>
-                <target>Ел. адреса</target>
-            </segment>
-        </unit>
-        <unit id="0pjZ.GV" name="listing.title_roles">
-            <segment>
-                <source>listing.title_roles</source>
-                <target>Ролі</target>
-            </segment>
-        </unit>
-        <unit id="hXEFV1n" name="listing.title_last_seen">
-            <segment>
-                <source>listing.title_last_seen</source>
-                <target>Вік сесії</target>
-            </segment>
-        </unit>
-        <unit id="pn7kE17" name="listing.title_last_ip">
-            <segment>
-                <source>listing.title_last_ip</source>
-                <target>Останній IP</target>
-            </segment>
-        </unit>
-        <unit id="GZ65uOC" name="listing.title_actions">
-            <segment>
-                <source>listing.title_actions</source>
-                <target>Дії</target>
-            </segment>
-        </unit>
-        <unit id="fkXL.k6" name="user.not_valid_email">
-            <segment>
-                <source>user.not_valid_email</source>
-                <target>Неправильна адреса електронної пошти</target>
-            </segment>
-        </unit>
-        <unit id="HjWW.NS" name="user.not_valid_password">
-            <segment>
-                <source>user.not_valid_password</source>
-                <target>Неправильний пароль. Пароль повинен містити не менше 6 символів.</target>
-            </segment>
-        </unit>
-        <unit id="TpGxDI3" name="user.unknown_user">
-            <segment>
-                <source>user.unknown_user</source>
-                <target>Невідомий користувач</target>
-            </segment>
-        </unit>
-        <unit id="EaqUUfe" name="label.predominant_colors__in_image">
-            <segment>
-                <source>label.predominant_colors__in_image</source>
-                <target>Переважаючі кольори в зображенні</target>
-            </segment>
-        </unit>
-        <unit id="8RPjZ5w" name="general.phrase.overview-for">
-            <segment>
-                <source>general.phrase.overview-for</source>
-                <target>Огляд для '%slug%'</target>
-            </segment>
-        </unit>
-        <unit id="6mze9DI" name="general.phrase.related-content">
-            <segment>
-                <source>general.phrase.related-content</source>
-                <target>Пов'язаний контент</target>
-            </segment>
-        </unit>
-        <unit id="odDw0du" name="action.search">
-            <segment>
-                <source>action.search</source>
-                <target>Шукати</target>
-            </segment>
-        </unit>
-        <unit id="QoeqyPT" name="caption.new_contenttype">
-            <segment>
-                <source>caption.new_contenttype</source>
-                <target>Створити %contenttype%</target>
-            </segment>
-        </unit>
-        <unit id="n.jOrkg" name="caption.untitled_contenttype">
-            <segment>
-                <source>caption.untitled_contenttype</source>
-                <target>%contenttype%  без назви</target>
-            </segment>
-        </unit>
-        <unit id="Dgtkgju" name="title.edit_user_profile">
-            <segment>
-                <source>title.edit_user_profile</source>
-                <target>Редагувати профіль користувача</target>
-            </segment>
-        </unit>
-        <unit id="rCKtTo5" name="caption.redirection_page">
-            <segment>
-                <source>caption.redirection_page</source>
-                <target>Сторінка переспрямовування</target>
-            </segment>
-        </unit>
-        <unit id="TtIlBDd" name="caption.edit_image">
-            <segment>
-                <source>caption.edit_image</source>
-                <target>Редагувати зображення</target>
-            </segment>
-        </unit>
-        <unit id="MClSUET" name="general.phrase.select_language">
-            <segment>
-                <source>general.phrase.select_language</source>
-                <target>Вибрати мову</target>
-            </segment>
-        </unit>
-        <unit id="hiE9jap" name="password.suggested">
-            <segment>
-                <source>password.suggested</source>
-                <target><![CDATA[Запропонований безпечний пароль: <code>%password%</code>]]></target>
-            </segment>
-        </unit>
-        <unit id="fLOd6Zd" name="field.cropX">
-            <segment>
-                <source>field.cropX</source>
-                <target>Обрізати X</target>
-            </segment>
-        </unit>
-        <unit id="Sd_AbmV" name="field.cropXPostfix">
-            <segment>
-                <source>field.cropXPostfix</source>
-                <target>Положення кадрування по осі X, діапазон 0-100.</target>
-            </segment>
-        </unit>
-        <unit id="BQBmQHT" name="field.cropYPostfix">
-            <segment>
-                <source>field.cropYPostfix</source>
-                <target>Положення кадрування по осі Y, діапазон 0-100. </target>
-            </segment>
-        </unit>
-        <unit id="hi98HIj" name="field.cropY">
-            <segment>
-                <source>field.cropY</source>
-                <target>Обрізати Y</target>
-            </segment>
-        </unit>
-        <unit id="PHOpD5y" name="field.cropZoom">
-            <segment>
-                <source>field.cropZoom</source>
-                <target>Коефіцієнт масштабування кадрування</target>
-            </segment>
-        </unit>
-        <unit id="tn6Z8wY" name="field.cropZoomPostfix">
-            <segment>
-                <source>field.cropZoomPostfix</source>
-                <target>Масштаб кадрування, діапазон 1-10. </target>
-            </segment>
-        </unit>
-        <unit id="n.3JZvX" name="title.contentType">
-            <segment>
-                <source>title.contentType</source>
-                <target>Тип контенту</target>
-            </segment>
-        </unit>
-        <unit id="TSkqRw3" name="listing.title_taxonomy">
-            <segment>
-                <source>listing.title_taxonomy</source>
-                <target>Категорії</target>
-            </segment>
-        </unit>
-        <unit id="Hr2E9Oa" name="listing_table.no_results">
-            <segment>
-                <source>listing_table.no_results</source>
-                <target>Нічого не знайдено. Розширте критерії фільтрації або додайте більше контенту.</target>
-            </segment>
-        </unit>
-        <unit id="hp554Ds" name="listing.option_select_sortby">
-            <segment>
-                <source>listing.option_select_sortby</source>
-                <target>Виберіть поле для сортування …</target>
-            </segment>
-        </unit>
-        <unit id="JEnqOi." name="title.primary_actions">
-            <segment>
-                <source>title.primary_actions</source>
-                <target>Основні дії</target>
-            </segment>
-        </unit>
-        <unit id="7616Os4" name="title.options">
-            <segment>
-                <source>title.options</source>
-                <target>Опції</target>
-            </segment>
-        </unit>
-        <unit id="hTKWQ6g" name="action.delete">
-            <segment>
-                <source>action.delete</source>
-                <target>Видалити</target>
-            </segment>
-        </unit>
-        <unit id="ezqx.4H" name="action.enable">
-            <segment>
-                <source>action.enable</source>
-                <target>Вкл.</target>
-            </segment>
-        </unit>
-        <unit id="ryXZRAu" name="action.disable">
-            <segment>
-                <source>action.disable</source>
-                <target>Вимк.</target>
-            </segment>
-        </unit>
-        <unit id="29MN3Ip" name="user.enabled_successfully">
-            <segment>
-                <source>user.enabled_successfully</source>
-                <target>Користувача успішно увімкнено!</target>
-            </segment>
-        </unit>
-        <unit id="nj8qBZ5" name="user.disabled_successfully">
-            <segment>
-                <source>user.disabled_successfully</source>
-                <target>Користувача успішно вимкнено!</target>
-            </segment>
-        </unit>
-        <unit id="Npkio79" name="listing.title_session_expires">
-            <segment>
-                <source>listing.title_session_expires</source>
-                <target>Сесія спливає</target>
-            </segment>
-        </unit>
-        <unit id="mmUDcto" name="listing.title_ip_address">
-            <segment>
-                <source>listing.title_ip_address</source>
-                <target>IP адреса</target>
-            </segment>
-        </unit>
-        <unit id="x9qAwrz" name="listing.title_browser">
-            <segment>
-                <source>listing.title_browser</source>
-                <target>Браузер / платформа</target>
-            </segment>
-        </unit>
-        <unit id="FqVh1Hv" name="image.button_remove">
-            <segment>
-                <source>image.button_remove</source>
-                <target>Видалити</target>
-            </segment>
-        </unit>
-        <unit id="eHV6ZJB" name="image.button_edit_attributes">
-            <segment>
-                <source>image.button_edit_attributes</source>
-                <target>Редагувати атрибути</target>
-            </segment>
-        </unit>
-        <unit id="s14vS9S" name="image.button_move_up">
-            <segment>
-                <source>image.button_move_up</source>
-                <target>Вгору</target>
-            </segment>
-        </unit>
-        <unit id="xoOPAPl" name="image.button_move_down">
-            <segment>
-                <source>image.button_move_down</source>
-                <target>Вниз</target>
-            </segment>
-        </unit>
-        <unit id="Oj2UZ5J" name="image.add_new_image">
-            <segment>
-                <source>image.add_new_image</source>
-                <target>Додати нове зображення</target>
-            </segment>
-        </unit>
-        <unit id="8Q4FxVw" name="file.add_new_file">
-            <segment>
-                <source>file.add_new_file</source>
-                <target>Додати новий файл</target>
-            </segment>
-        </unit>
-        <unit id=".t1ICS7" name="collection.remove_item">
-            <segment>
-                <source>collection.remove_item</source>
-                <target>Видалити елемент</target>
-            </segment>
-        </unit>
-        <unit id="0C9.Vmh" name="collection.add_item">
-            <segment>
-                <source>collection.add_item</source>
-                <target>Додати елемент до '%name%'</target>
-            </segment>
-        </unit>
-        <unit id="ApPu4P_" name="collection.move_item_up">
-            <segment>
-                <source>collection.move_item_up</source>
-                <target>Вгору</target>
-            </segment>
-        </unit>
-        <unit id="KzBtfHi" name="collection.move_item_down">
-            <segment>
-                <source>collection.move_item_down</source>
-                <target>Вниз</target>
-            </segment>
-        </unit>
-        <unit id="BFARQEU" name="extensions.button_detailed_view">
-            <segment>
-                <source>extensions.button_detailed_view</source>
-                <target>Переглянути деталі</target>
-            </segment>
-        </unit>
-        <unit id="hgNZLwW" name="extensions.title_configuration">
-            <segment>
-                <source>extensions.title_configuration</source>
-                <target>Файл конфігурації</target>
-            </segment>
-        </unit>
-        <unit id="283aB_E" name="caption.file_upload.upload_text">
-            <segment>
-                <source>caption.file_upload.upload_text</source>
-                <target>Перетягніть сюди файли для завантаження</target>
-            </segment>
-        </unit>
-        <unit id="L_YQKUn" name="pager.next">
-            <segment>
-                <source>pager.next</source>
-                <target>Далі</target>
-            </segment>
-        </unit>
-        <unit id="AMxTho9" name="pager.previous">
-            <segment>
-                <source>pager.previous</source>
-                <target>Назад</target>
-            </segment>
-        </unit>
-        <unit id="7aSD0Qr" name="image.button_up">
-            <segment>
-                <source>image.button_up</source>
-                <target>Вгору</target>
-            </segment>
-        </unit>
-        <unit id="WihD8Y5" name="image.button_down">
-            <segment>
-                <source>image.button_down</source>
-                <target>Вниз</target>
-            </segment>
-        </unit>
-        <unit id="fon6eNN" name="general.phrase.download">
-            <segment>
-                <source>general.phrase.download</source>
-                <target>Завантажити</target>
-            </segment>
-        </unit>
-        <unit id="2MtT_h0" name="caption.logviewer">
-            <segment>
-                <source>caption.logviewer</source>
-                <target>Перегляд логів</target>
-            </segment>
-        </unit>
-        <unit id="FlGE3qB" name="label.request">
-            <segment>
-                <source>label.request</source>
-                <target>Запит</target>
-            </segment>
-        </unit>
-        <unit id="l71Tprl" name="label.trace">
-            <segment>
-                <source>label.trace</source>
-                <target>Трасування</target>
-            </segment>
-        </unit>
-        <unit id="29ZEo1r" name="label.context">
-            <segment>
-                <source>label.context</source>
-                <target>Контекст</target>
-            </segment>
-        </unit>
-        <unit id="txRonia" name="label.id">
-            <segment>
-                <source>label.id</source>
-                <target>ID</target>
-            </segment>
-        </unit>
-        <unit id="IwLLxxx" name="label.level">
-            <segment>
-                <source>label.level</source>
-                <target>Рівень</target>
-            </segment>
-        </unit>
-        <unit id="51OQi14" name="label.message">
-            <segment>
-                <source>label.message</source>
-                <target>Повідомлення</target>
-            </segment>
-        </unit>
-        <unit id="S0f6iTL" name="label.timestamp">
-            <segment>
-                <source>label.timestamp</source>
-                <target>Timestamp</target>
-            </segment>
-        </unit>
-        <unit id="O2X4xZH" name="label.user">
-            <segment>
-                <source>label.user</source>
-                <target>Користувач</target>
-            </segment>
-        </unit>
-        <unit id="3MuwWwe" name="listing.disabled">
-            <segment>
-                <source>listing.disabled</source>
-                <target>Відображення вимкнено</target>
-            </segment>
-        </unit>
-        <unit id="XQ2U6fN" name="slug.button_unlocked">
-            <segment>
-                <source>slug.button_unlocked</source>
-                <target>Розблоковано</target>
-            </segment>
-        </unit>
-        <unit id="jz2qkbb" name="general.phrase.no-content-found">
-            <segment>
-                <source>general.phrase.no-content-found</source>
-                <target>Контент не знайдено</target>
-            </segment>
-        </unit>
-        <unit id="FM8B.gO" name="general.phrase.empty-database">
-            <segment>
-                <source>general.phrase.empty-database</source>
-                <target>Схоже, що база даних пуста. Внесіть контент в бекенді Bolt, або запустіть команду, щоб додати трохи фікстур (контенту для прикладу). </target>
-            </segment>
-        </unit>
-        <unit id="SGlj7K2" name="view_locales.badge_empty">
-            <segment>
-                <source>view_locales.badge_empty</source>
-                <target>Пусто</target>
-            </segment>
-        </unit>
-        <unit id="WeJxw6Z" name="action.update_all">
-            <segment>
-                <source>action.update_all</source>
-                <target>Застосувати до всіх</target>
-            </segment>
-        </unit>
-        <unit id="QVRwwK4" name="about.system_info">
-            <segment>
-                <source>about.system_info</source>
-                <target>Системна інформація</target>
-            </segment>
-        </unit>
-        <unit id="4oq.CNw" name="user.not_valid_display_name">
-            <segment>
-                <source>user.not_valid_display_name</source>
-                <target>Недійсне відображене імʼя</target>
-            </segment>
-        </unit>
-        <unit id="6Gw1lsE" name="action.confirm_delete">
-            <segment>
-                <source>action.confirm_delete</source>
-                <target>Ви впевнені, що хочете видалити цей контент?</target>
-            </segment>
-        </unit>
-        <unit id="z_tOHwq" name="placeholder.username_or_email">
-            <segment>
-                <source>placeholder.username_or_email</source>
-                <target>Ваше імʼя користувача або email</target>
-            </segment>
-        </unit>
-        <unit id="xgYhRkc" name="placeholder.password">
-            <segment>
-                <source>placeholder.password</source>
-                <target>Ваш пароль</target>
-            </segment>
-        </unit>
-        <unit id="KshyLfh" name="caption.other_content">
-            <segment>
-                <source>caption.other_content</source>
-                <target>Інший контент</target>
-            </segment>
-        </unit>
-        <unit id="wHOF8eG" name="editfile.target_not_writable">
-            <segment>
-                <source>editfile.target_not_writable</source>
-                <target>Збереження вимкнено, оскільки цільовий файл недоступний для запису.</target>
-            </segment>
-        </unit>
-        <unit id="hAysbHB" name="label.translatable">
-            <segment>
-                <source>label.translatable</source>
-                <target>Це поле можна перевести</target>
-            </segment>
-        </unit>
-        <unit id="qqpGLJl" name="label.content">
-            <segment>
-                <source>label.content</source>
-                <target>Контент</target>
-            </segment>
-        </unit>
-        <unit id="v7ZTnja" name="file.delete_success">
-            <segment>
-                <source>file.delete_success</source>
-                <target>Файл успішно видалено!</target>
-            </segment>
-        </unit>
-        <unit id="wHPoBzP" name="file.delete_confirm">
-            <segment>
-                <source>file.delete_confirm</source>
-                <target>Ви впевнені, що хочете видалити цей файл?</target>
-            </segment>
-        </unit>
-        <unit id="IWbf2by" name="listing.title_filterby">
-            <segment>
-                <source>listing.title_filterby</source>
-                <target>Шукати / фільтрувати по</target>
-            </segment>
-        </unit>
-        <unit id="Zssh7In" name="content.status_changed_successfully">
-            <segment>
-                <source>content.status_changed_successfully</source>
-                <target>Статус успішно змінено</target>
-            </segment>
-        </unit>
-        <unit id="GOhQBY9" name="content.deleted_successfully">
-            <segment>
-                <source>content.deleted_successfully</source>
-                <target>Контент успішно видалено</target>
-            </segment>
-        </unit>
-        <unit id=".I3mIHo" name="label.current_status">
-            <segment>
-                <source>label.current_status</source>
-                <target>Поточний статус</target>
-            </segment>
-        </unit>
-        <unit id="utGAKaQ" name="status.published">
-            <segment>
-                <source>status.published</source>
-                <target>Опубліковано</target>
-            </segment>
-        </unit>
-        <unit id="HJbHjee" name="status.draft">
-            <segment>
-                <source>status.draft</source>
-                <target>Чернетка</target>
-            </segment>
-        </unit>
-        <unit id="h7dP3WY" name="status.timed">
-            <segment>
-                <source>status.timed</source>
-                <target>Відстрочено</target>
-            </segment>
-        </unit>
-        <unit id="oxqDDuK" name="status.held">
-            <segment>
-                <source>status.held</source>
-                <target>Не активно</target>
-            </segment>
-        </unit>
-        <unit id="JpJFIFq" name="collection.confirm_delete">
-            <segment>
-                <source>collection.confirm_delete</source>
-                <target>Ви дійсно хочете видалити цей елемент колекції?</target>
-            </segment>
-        </unit>
-        <unit id="YZJO3Ul" name="upload.allow_file_types">
-            <segment>
-                <source>upload.allow_file_types</source>
-                <target>Типи файлів, разрешенные для завантаження</target>
-            </segment>
-        </unit>
-        <unit id="noOf4ML" name="upload.max_size">
-            <segment>
-                <source>upload.max_size</source>
-                <target>Максимальний розмір завантажуваного файлу</target>
-            </segment>
-        </unit>
-        <unit id="O_m7mx1" name="listing.placeholder_search">
-            <segment>
-                <source>listing.placeholder_search</source>
-                <target>Ключове слово…</target>
-            </segment>
-        </unit>
-        <unit id="munFS0n" name="title.filtered_by">
-            <segment>
-                <source>title.filtered_by</source>
-                <target><![CDATA[Увесь контент, відфільтрований за <em>'%filter%'</em>.]]></target>
-            </segment>
-        </unit>
-        <unit id="GPd6Hap" name="action.view_site">
-            <segment>
-                <source>action.view_site</source>
-                <target>Перейти на сайт</target>
-            </segment>
-        </unit>
-        <unit id="f.rvF6y" name="action.new">
-            <segment>
-                <source>action.new</source>
-                <target>Створити</target>
-            </segment>
-        </unit>
-        <unit id="60xy4WG" name="extensions.no_dependencies">
-            <segment>
-                <source>extensions.no_dependencies</source>
-                <target>Немає відомих залежностей</target>
-            </segment>
-        </unit>
-        <unit id="LfwezhR" name="extensions.title_dependencies">
-            <segment>
-                <source>extensions.title_dependencies</source>
-                <target>Залежності</target>
-            </segment>
-        </unit>
-        <unit id="H9knE.O" name="collection.expand_all">
-            <segment>
-                <source>collection.expand_all</source>
-                <target>Розгорнути все</target>
-            </segment>
-        </unit>
-        <unit id="JjvI6hp" name="collection.collapse_all">
-            <segment>
-                <source>collection.collapse_all</source>
-                <target>Згорнути все</target>
-            </segment>
-        </unit>
-        <unit id="pXtciRI" name="content.edit_missing_definition">
-            <segment>
-                <source>content.edit_missing_definition</source>
-                <target>Визначення цього Типу контенту відсутнє! Редагування цього запису не працюватиме належним чином. Будь ласка, перевірте свій contenttypes.yaml, щоб впевнитися, що він містить% contenttype%.</target>
-            </segment>
-        </unit>
-        <unit id="RBJ0NMl" name="collection.select">
-            <segment>
-                <source>collection.select</source>
-                <target>Вибрати …</target>
-            </segment>
-        </unit>
-        <unit id="2SSLP1K" name="form.empty_username_email">
-            <segment>
-                <source>form.empty_username_email</source>
-                <target>Будь ласка, введіть ваше імʼя користувача або адресу електронної пошти</target>
-            </segment>
-        </unit>
-        <unit id="5Qf_RiO" name="form.empty_password">
-            <segment>
-                <source>form.empty_password</source>
-                <target>Будь ласка, введіть ваш пароль</target>
-            </segment>
-        </unit>
-        <unit id="fAmcKUQ" name="listing.title_filterby_field">
-            <segment>
-                <source>listing.title_filterby_field</source>
-                <target>Фільтр за полем</target>
-            </segment>
-        </unit>
-        <unit id="kciiidS" name="image.button_from_url">
-            <segment>
-                <source>image.button_from_url</source>
-                <target>За URL</target>
-            </segment>
-        </unit>
-        <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
-            <segment>
-                <source>files_cards.copy_to_clipboard</source>
-                <target>Копіювати посилання на файл</target>
-            </segment>
-        </unit>
-        <unit id="S9k1S7Z" name="warning">
-            <segment>
-                <source>warning</source>
-                <target>Попередження</target>
-            </segment>
-        </unit>
-        <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
-            <segment>
-                <source>filemanager.create_folder_already_exists</source>
-                <target>Тека вже існує</target>
-            </segment>
-        </unit>
-        <unit id="aSxePCB" name="filemanager.create_folder_error">
-            <segment>
-                <source>filemanager.create_folder_error</source>
-                <target>Не вдалося створити теку</target>
-            </segment>
-        </unit>
-        <unit id="wbFKypA" name="filemanager.create_folder_success">
-            <segment>
-                <source>filemanager.create_folder_success</source>
-                <target>Тека успішно створена.</target>
-            </segment>
-        </unit>
-        <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
-            <segment>
-                <source>filemanager.delete_folder_successful</source>
-                <target>Тека успішно видалена</target>
-            </segment>
-        </unit>
-        <unit id="a6Xhtq0" name="folder.create_new">
-            <segment>
-                <source>folder.create_new</source>
-                <target>Нова папка</target>
-            </segment>
-        </unit>
-        <unit id="FcXvWL8" name="title.add_user">
-            <segment>
-                <source>title.add_user</source>
-                <target>Додати користувача</target>
-            </segment>
-        </unit>
-        <unit id="nWMH_Nr" name="label.avatar">
-            <segment>
-                <source>label.avatar</source>
-                <target>Аватар</target>
-            </segment>
-        </unit>
-    </file>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="uk">
+  <file id="messages.uk">
+    <unit id="1sstKF9" name="title.edit_user">
+      <notes>
+        <note>templates/users/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user</source>
+        <target>Редагувати користувача</target>
+      </segment>
+    </unit>
+    <unit id="HLtdhYw" name="action.save">
+      <notes>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
+      </notes>
+      <segment>
+        <source>action.save</source>
+        <target>Зберегти зміни</target>
+      </segment>
+    </unit>
+    <unit id="a2vzLi7" name="action.do_something">
+      <notes>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>action.do_something</source>
+        <target>Зробіть що-небудь</target>
+      </segment>
+    </unit>
+    <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>action.edit</source>
+        <target>Редагувати</target>
+      </segment>
+    </unit>
+    <unit id="LDhDPrF" name="label.username">
+      <notes>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>label.username</source>
+        <target>Імʼя користувача</target>
+      </segment>
+    </unit>
+    <unit id="80JoLd0" name="title.login">
+      <notes>
+        <note>templates/security/login.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>title.login</source>
+        <target>Авторизація</target>
+      </segment>
+    </unit>
+    <unit id="9pvowqn" name="label.password">
+      <notes>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>label.password</source>
+        <target>Пароль</target>
+      </segment>
+    </unit>
+    <unit id="gLN0C81" name="action.log_in">
+      <notes>
+        <note>templates/security/login.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>action.log_in</source>
+        <target>Увійти</target>
+      </segment>
+    </unit>
+    <unit id="vJwSCBO" name="title.contentlisting">
+      <notes>
+        <note>templates/content/listing.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>title.contentlisting</source>
+        <target>Перелік вмісту</target>
+      </segment>
+    </unit>
+    <unit id="SNELzJ2" name="field.id">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
+      </notes>
+      <segment>
+        <source>field.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="FuCyk5C" name="field.status">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
+      </notes>
+      <segment>
+        <source>field.status</source>
+        <target>Статус</target>
+      </segment>
+    </unit>
+    <unit id="O9wtVOp" name="field.createdAt">
+      <notes>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
+      </notes>
+      <segment>
+        <source>field.createdAt</source>
+        <target>Створено</target>
+      </segment>
+    </unit>
+    <unit id="eVkSIKu" name="field.modifiedAt">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
+      </notes>
+      <segment>
+        <source>field.modifiedAt</source>
+        <target>Змінено</target>
+      </segment>
+    </unit>
+    <unit id="3gdi1dy" name="field.publishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>field.publishedAt</source>
+        <target>Опубліковано</target>
+      </segment>
+    </unit>
+    <unit id="eN7IfEL" name="field.depublishedAt">
+      <notes>
+        <note>templates/content/_fields_aside.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>field.depublishedAt</source>
+        <target>Знято з публікації</target>
+      </segment>
+    </unit>
+    <unit id="VKhfRZB" name="field.title">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>field.title</source>
+        <target>Заголовок</target>
+      </segment>
+    </unit>
+    <unit id="7_wwX8J" name="field.description">
+      <notes>
+        <note>templates/media/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>field.description</source>
+        <target>Опис</target>
+      </segment>
+    </unit>
+    <unit id="hjDmcPC" name="field.copyright">
+      <notes>
+        <note>templates/media/edit.html.twig:51</note>
+      </notes>
+      <segment>
+        <source>field.copyright</source>
+        <target>Авторські права</target>
+      </segment>
+    </unit>
+    <unit id="v0sitU8" name="field.originalFilename">
+      <notes>
+        <note>templates/media/edit.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>field.originalFilename</source>
+        <target>Початкове ім'я файлу</target>
+      </segment>
+    </unit>
+    <unit id="vlRe8Tx" name="field.width">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
+      </notes>
+      <segment>
+        <source>field.width</source>
+        <target>ширина</target>
+      </segment>
+    </unit>
+    <unit id="CZbXbM_" name="field.height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
+      </notes>
+      <segment>
+        <source>field.height</source>
+        <target>висота</target>
+      </segment>
+    </unit>
+    <unit id="Sz_u.OS" name="field.filesize">
+      <notes>
+        <note>templates/media/edit.html.twig:142</note>
+      </notes>
+      <segment>
+        <source>field.filesize</source>
+        <target>Розмір файлу</target>
+      </segment>
+    </unit>
+    <unit id="RMPnq6o" name="label.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:31</note>
+      </notes>
+      <segment>
+        <source>label.username_or_email</source>
+        <target>Імʼя користувача або email</target>
+      </segment>
+    </unit>
+    <unit id="IaF1MjB" name="label.rememberme">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.rememberme</source>
+        <target>Запамʼятати?</target>
+      </segment>
+    </unit>
+    <unit id="k.JymqB" name="about.visit_bolt">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>about.visit_bolt</source>
+        <target>Перейти на Boltcms.io</target>
+      </segment>
+    </unit>
+    <unit id="UZFanGF" name="about.bolt_documentation">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
+      </notes>
+      <segment>
+        <source>about.bolt_documentation</source>
+        <target>Документація з Bolt</target>
+      </segment>
+    </unit>
+    <unit id="FO7zDub" name="about.bolt_on_github">
+      <notes>
+        <note>templates/pages/about.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>about.bolt_on_github</source>
+        <target>Bolt на Github</target>
+      </segment>
+    </unit>
+    <unit id="_9fS00R" name="about.used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>about.used_libraries</source>
+        <target>Бібліотеки / компоненти, що використовуються</target>
+      </segment>
+    </unit>
+    <unit id="tgLgLDQ" name="about.list_of_used_libraries">
+      <notes>
+        <note>templates/pages/about.html.twig:66</note>
+      </notes>
+      <segment>
+        <source>about.list_of_used_libraries</source>
+        <target>Нижче наведені сторонні бібліотеки, які використовує Bolt.</target>
+      </segment>
+    </unit>
+    <unit id="D2N6_cP" name="label.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
+      </notes>
+      <segment>
+        <source>label.email</source>
+        <target>Адреса електронної пошти</target>
+      </segment>
+    </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>Про користувача</target>
+      </segment>
+    </unit>
+    <unit id="OBmPOoB" name="user.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+      </notes>
+      <segment>
+        <source>user.updated_successfully</source>
+        <target>Оновлення успішне</target>
+      </segment>
+    </unit>
+    <unit id="3hkt.eH" name="content.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+      </notes>
+      <segment>
+        <source>content.updated_successfully</source>
+        <target>Контент успішно оновлено</target>
+      </segment>
+    </unit>
+    <unit id="IB0mNQh" name="content.created_successfully">
+      <notes>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+      </notes>
+      <segment>
+        <source>content.created_successfully</source>
+        <target>Медіа-елемент успішно створено</target>
+      </segment>
+    </unit>
+    <unit id="b1jqjUC" name="editfile.could_not_write">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+      </notes>
+      <segment>
+        <source>editfile.could_not_write</source>
+        <target>Не вдалося записати Медіа-елемент</target>
+      </segment>
+    </unit>
+    <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
+      <segment>
+        <source>label.locale</source>
+        <target>Локаль</target>
+      </segment>
+    </unit>
+    <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
+      <segment>
+        <source>The Default theme</source>
+        <target>Тема за змовчанням</target>
+      </segment>
+    </unit>
+    <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>The Default Dark theme</source>
+        <target>Темна тема за змовчанням</target>
+      </segment>
+    </unit>
+    <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>WoordPers: Kinda looks like that other CMS</source>
+        <target>WoordPers: Трохи схоже на ту іншу CMS</target>
+      </segment>
+    </unit>
+    <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.dashboard</source>
+        <target>Панель Bolt</target>
+      </segment>
+    </unit>
+    <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>caption.clear_cache</source>
+        <target>Очистити кеш</target>
+      </segment>
+    </unit>
+    <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
+      <segment>
+        <source>caption.menu_setup</source>
+        <target>Налаштування меню</target>
+      </segment>
+    </unit>
+    <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
+      <segment>
+        <source>caption.taxonomies</source>
+        <target>Категоризація</target>
+      </segment>
+    </unit>
+    <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
+      <segment>
+        <source>caption.contenttypes</source>
+        <target>Типи контенту</target>
+      </segment>
+    </unit>
+    <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
+      <segment>
+        <source>caption.main_configuration</source>
+        <target>Основна конфігурація</target>
+      </segment>
+    </unit>
+    <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
+      <segment>
+        <source>caption.users_permissions</source>
+        <target>Користувачі та права</target>
+      </segment>
+    </unit>
+    <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
+      <segment>
+        <source>caption.configuration</source>
+        <target>Конфігурація</target>
+      </segment>
+    </unit>
+    <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
+      <segment>
+        <source>caption.settings</source>
+        <target>Налаштування</target>
+      </segment>
+    </unit>
+    <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
+      <segment>
+        <source>caption.content</source>
+        <target>Контент</target>
+      </segment>
+    </unit>
+    <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.file_management</source>
+        <target>Файли</target>
+      </segment>
+    </unit>
+    <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.extensions</source>
+        <target>Розширення</target>
+      </segment>
+    </unit>
+    <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
+      <segment>
+        <source>caption.view_edit_templates</source>
+        <target>Шаблони</target>
+      </segment>
+    </unit>
+    <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
+      <segment>
+        <source>caption.uploaded_files</source>
+        <target>Завантажені файли</target>
+      </segment>
+    </unit>
+    <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
+      <segment>
+        <source>caption.routing_setup</source>
+        <target>Конфігурація маршрутизації</target>
+      </segment>
+    </unit>
+    <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>caption.translations</source>
+        <target>Переклади / Ярлики</target>
+      </segment>
+    </unit>
+    <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.about_bolt</source>
+        <target>Про Bolt</target>
+      </segment>
+    </unit>
+    <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.bolt_payoff</source>
+        <target>Вишукана, легка і проста CMS</target>
+      </segment>
+    </unit>
+    <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.edit</source>
+        <target>Редагувати</target>
+      </segment>
+    </unit>
+    <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>caption.file_uploader</source>
+        <target>Завантажувач файлів</target>
+      </segment>
+    </unit>
+    <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>caption.meta_information</source>
+        <target>Мета інформація</target>
+      </segment>
+    </unit>
+    <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
+      <segment>
+        <source>date</source>
+        <target>Дата</target>
+      </segment>
+    </unit>
+    <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>size</source>
+        <target>Розмір</target>
+      </segment>
+    </unit>
+    <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>thumbnail</source>
+        <target>Ескіз</target>
+      </segment>
+    </unit>
+    <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
+      <segment>
+        <source>filename</source>
+        <target>Імʼя файлу</target>
+      </segment>
+    </unit>
+    <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>actions</source>
+        <target>Дії</target>
+      </segment>
+    </unit>
+    <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>directoryname</source>
+        <target>Імʼя каталогу</target>
+      </segment>
+    </unit>
+    <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>form.quick_select_file</source>
+        <target>Вибір файлу для редагування…</target>
+      </segment>
+    </unit>
+    <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>caption.path</source>
+        <target>Шлях</target>
+      </segment>
+    </unit>
+    <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>caption.filename</source>
+        <target>Імʼя файлу</target>
+      </segment>
+    </unit>
+    <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>action.create_new</source>
+        <target>Створити</target>
+      </segment>
+    </unit>
+    <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>general.greeting</source>
+        <target>Привіт, %name%!</target>
+      </segment>
+    </unit>
+    <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>action.logout</source>
+        <target>Вийти</target>
+      </segment>
+    </unit>
+    <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>action.edit_profile</source>
+        <target>Профіль</target>
+      </segment>
+    </unit>
+    <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>action.close_alert</source>
+        <target>закрити</target>
+      </segment>
+    </unit>
+    <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
+      <segment>
+        <source>caption.api</source>
+        <target>API</target>
+      </segment>
+    </unit>
+    <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
+      <segment>
+        <source>caption.all_configuration_files</source>
+        <target>Файли конфігурацій</target>
+      </segment>
+    </unit>
+    <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
+      <segment>
+        <source>caption.maintenance</source>
+        <target>Обслуговування</target>
+      </segment>
+    </unit>
+    <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>caption.edit_file</source>
+        <target>Редагувати файл</target>
+      </segment>
+    </unit>
+    <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>field.current_locale</source>
+        <target>Поточна локаль</target>
+      </segment>
+    </unit>
+    <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>field.switch_to_locale</source>
+        <target>Перемкнути локаль</target>
+      </segment>
+    </unit>
+    <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>field.author</source>
+        <target>Автор</target>
+      </segment>
+    </unit>
+    <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>general.phrase.edit</source>
+        <target>Редагування</target>
+      </segment>
+    </unit>
+    <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
+      <segment>
+        <source>Unknown</source>
+        <target>Невідомо</target>
+      </segment>
+    </unit>
+    <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
+      <segment>
+        <source>general.phrase.written-by-on</source>
+        <target>Написано %name% , %date%.</target>
+      </segment>
+    </unit>
+    <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page</source>
+        <target>Сторінка "About" відсутня.</target>
+      </segment>
+    </unit>
+    <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
+      <segment>
+        <source>general.phrase.missing-about-page-block</source>
+        <target>Блок "About" відсутня.</target>
+      </segment>
+    </unit>
+    <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.recent</source>
+        <target>Нещодавно використовувані %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-ellipsis</source>
+        <target>…</target>
+      </segment>
+    </unit>
+    <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search</source>
+        <target>Пошук</target>
+      </segment>
+    </unit>
+    <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.overview</source>
+        <target>Перелік записів %contenttypes%</target>
+      </segment>
+    </unit>
+    <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
+      <segment>
+        <source>contenttypes.generic.no-recent</source>
+        <target>Останні записи %contenttype% не виявлено</target>
+      </segment>
+    </unit>
+    <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
+      <segment>
+        <source>Menu</source>
+        <target>Меню</target>
+      </segment>
+    </unit>
+    <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
+      <segment>
+        <source>Search</source>
+        <target>Пошук</target>
+      </segment>
+    </unit>
+    <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.permalink</source>
+        <target>Постійне посилання</target>
+      </segment>
+    </unit>
+    <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
+      <segment>
+        <source>label.cache_cleared</source>
+        <target>Кеш успішно очищено!</target>
+      </segment>
+    </unit>
+    <unit id="Wou02nK" name="caption.kitchensink">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
+      </notes>
+      <segment>
+        <source>caption.kitchensink</source>
+        <target>Демонстраційна сторінка</target>
+      </segment>
+    </unit>
+    <unit id="2CfJ3WY" name="general.phrase.search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:11</note>
+      </notes>
+      <segment>
+        <source>general.phrase.search-results-for</source>
+        <target>Результати пошуку за запитом "%search%".</target>
+      </segment>
+    </unit>
+    <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
+      <notes>
+        <note>public/theme/skeleton/search.twig:51</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-results-for</source>
+        <target>За запитом '%search%' нічого не знайдено.</target>
+      </segment>
+    </unit>
+    <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-search-term-provided</source>
+        <target>Введіть пошуковий запит, щоб показати релевантні результати.</target>
+      </segment>
+    </unit>
+    <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>general.phrase.read-more</source>
+        <target>Подробнее</target>
+      </segment>
+    </unit>
+    <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
+      <segment>
+        <source>general.phrase.built-with-bolt</source>
+        <target><![CDATA[Цей сайт <a href='https://boltcms.io' target='_blank' title='Вишукана, легка та проста CMS'>сделан на Bolt</a>.]]></target>
+      </segment>
+    </unit>
+    <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>general.latest_bolt_news</source>
+        <target>Новини Bolt</target>
+      </segment>
+    </unit>
+    <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>action.preview</source>
+        <target>Перелік</target>
+      </segment>
+    </unit>
+    <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>action.view_saved</source>
+        <target>Переглянути збережену версію</target>
+      </segment>
+    </unit>
+    <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>label.display_name</source>
+        <target>Відображене імʼя</target>
+      </segment>
+    </unit>
+    <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>caption.duplicate</source>
+        <target>Дублікат</target>
+      </segment>
+    </unit>
+    <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
+      <segment>
+        <source>label.new_password</source>
+        <target>Новий пароль</target>
+      </segment>
+    </unit>
+    <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
+      <segment>
+        <source>editfile.updated_successfully</source>
+        <target>Файл оновлено успішно!</target>
+      </segment>
+    </unit>
+    <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
+      <segment>
+        <source>action.add_user</source>
+        <target>Додати користувача</target>
+      </segment>
+    </unit>
+    <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
+      <segment>
+        <source>success</source>
+        <target>Успішно!</target>
+      </segment>
+    </unit>
+    <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
+      <segment>
+        <source>user.updated_profile</source>
+        <target>Профіль користувача оновлено!</target>
+      </segment>
+    </unit>
+    <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>label.roles</source>
+        <target>Ролі</target>
+      </segment>
+    </unit>
+    <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.new_user</source>
+        <target>Новий користувач</target>
+      </segment>
+    </unit>
+    <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
+      <segment>
+        <source>action.view</source>
+        <target>Перелік</target>
+      </segment>
+    </unit>
+    <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>slug.button_locked</source>
+        <target>Заблоковано</target>
+      </segment>
+    </unit>
+    <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>slug.button_edit</source>
+        <target>Редагувати</target>
+      </segment>
+    </unit>
+    <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>slug.generate_from</source>
+        <target>Створити за основою поля:</target>
+      </segment>
+    </unit>
+    <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>image.button_upload</source>
+        <target>Завантажити</target>
+      </segment>
+    </unit>
+    <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>image.button_from_library</source>
+        <target>З бібліотеки</target>
+      </segment>
+    </unit>
+    <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.view_on_site</source>
+        <target>Перегляд на сайті</target>
+      </segment>
+    </unit>
+    <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_publish</source>
+        <target>Замініть статус на "опублікувати"</target>
+      </segment>
+    </unit>
+    <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_held</source>
+        <target>Змінити статус на "не активне"</target>
+      </segment>
+    </unit>
+    <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.status_to_draft</source>
+        <target>Змінити статус на "чернетка"</target>
+      </segment>
+    </unit>
+    <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.duplicate</source>
+        <target>Клонувати</target>
+      </segment>
+    </unit>
+    <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.delete</source>
+        <target>Видалити</target>
+      </segment>
+    </unit>
+    <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.slug</source>
+        <target>Сегмент адреси</target>
+      </segment>
+    </unit>
+    <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.created_on</source>
+        <target>Створено</target>
+      </segment>
+    </unit>
+    <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.published_on</source>
+        <target>Опубліковано</target>
+      </segment>
+    </unit>
+    <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.last_modified_on</source>
+        <target>Змінений</target>
+      </segment>
+    </unit>
+    <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>listing_select_box.card_header.selected</source>
+        <target>Вибрано</target>
+      </segment>
+    </unit>
+    <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>editor_embed.content_url</source>
+        <target>URL-адреса контенту для вбудовування</target>
+      </segment>
+    </unit>
+    <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>editor_embed.placeholder_content_url</source>
+        <target>URL-адреса контенту в Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+      </segment>
+    </unit>
+    <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_height</source>
+        <target>Висота</target>
+      </segment>
+    </unit>
+    <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_pixel</source>
+        <target>піксель</target>
+      </segment>
+    </unit>
+    <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_matched_embed</source>
+        <target>Відповідний вбудований елемент</target>
+      </segment>
+    </unit>
+    <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_preview</source>
+        <target>Попередній перегляд</target>
+      </segment>
+    </unit>
+    <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>editor_embed.label_size</source>
+        <target>Розмір</target>
+      </segment>
+    </unit>
+    <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_filename</source>
+        <target>Імʼя файлу (завантажте новий файл або виберіть наявний)</target>
+      </segment>
+    </unit>
+    <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_alt_text</source>
+        <target>Атрибут Alt</target>
+      </segment>
+    </unit>
+    <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
+      <segment>
+        <source>image.placeholder_title</source>
+        <target>Заголовок</target>
+      </segment>
+    </unit>
+    <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar.toggler</source>
+        <target>Перемкнути ширину бокової панелі</target>
+      </segment>
+    </unit>
+    <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>admin_sidebar_toggler.toggle</source>
+        <target><![CDATA[<span class="sr-only">Вкл./Вимк. </span>меню]]></target>
+      </segment>
+    </unit>
+    <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editor_date.toggle</source>
+        <target>Вкл./Вимк.</target>
+      </segment>
+    </unit>
+    <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>flash_messages.notification</source>
+        <target>Сповіщення</target>
+      </segment>
+    </unit>
+    <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>localeswitcher.button_info</source>
+        <target>Див. Інформацію про локалізацію</target>
+      </segment>
+    </unit>
+    <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
+      <segment>
+        <source>listing.title_sortby</source>
+        <target>Сортувати по</target>
+      </segment>
+    </unit>
+    <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_filter</source>
+        <target>Ключове слово для фільтрації…</target>
+      </segment>
+    </unit>
+    <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
+      <segment>
+        <source>listing.button_filter</source>
+        <target>Відфільтрувати</target>
+      </segment>
+    </unit>
+    <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
+      <segment>
+        <source>listing.button_clear</source>
+        <target>Очистити сортування/фільтр</target>
+      </segment>
+    </unit>
+    <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_default</source>
+        <target>За змовчанням</target>
+      </segment>
+    </unit>
+    <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_ok</source>
+        <target>OK</target>
+      </segment>
+    </unit>
+    <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_missing</source>
+        <target>Відсутній</target>
+      </segment>
+    </unit>
+    <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>files_cards.button_toggle</source>
+        <target>Перемкнути перелік, що розкривається</target>
+      </segment>
+    </unit>
+    <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_image_info</source>
+        <target>Редагувати інфо. про зображення</target>
+      </segment>
+    </unit>
+    <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_edit_file</source>
+        <target>Змінити файл у редакторі</target>
+      </segment>
+    </unit>
+    <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_view_original</source>
+        <target>Перегляд</target>
+      </segment>
+    </unit>
+    <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_duplicate</source>
+        <target>Клонувати</target>
+      </segment>
+    </unit>
+    <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>files_cards.action_delete</source>
+        <target>Видалити</target>
+      </segment>
+    </unit>
+    <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filename</source>
+        <target>Імʼя файлу:</target>
+      </segment>
+    </unit>
+    <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_title</source>
+        <target>Заголовок:</target>
+      </segment>
+    </unit>
+    <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_dimensions</source>
+        <target>Розміри:</target>
+      </segment>
+    </unit>
+    <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_filesize</source>
+        <target>Розмір файла:</target>
+      </segment>
+    </unit>
+    <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
+      <segment>
+        <source>files_cards.label_created_on</source>
+        <target>Створено:</target>
+      </segment>
+    </unit>
+    <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
+      <segment>
+        <source>files_list.remark</source>
+        <target>В цій теці немає файлів. Виберіть теку для переходу.</target>
+      </segment>
+    </unit>
+    <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>quickselect.title_select</source>
+        <target>Вибір файлу:</target>
+      </segment>
+    </unit>
+    <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>finder.button_list</source>
+        <target>Перелік</target>
+      </segment>
+    </unit>
+    <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
+      <segment>
+        <source>finder.button_cards</source>
+        <target>Картки</target>
+      </segment>
+    </unit>
+    <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>extensions.title_desc</source>
+        <target>Опис:</target>
+      </segment>
+    </unit>
+    <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>extensions.title_author</source>
+        <target>Автор:</target>
+      </segment>
+    </unit>
+    <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>extensions.title_package</source>
+        <target>Пакет / імʼя класса:</target>
+      </segment>
+    </unit>
+    <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>extensions.title_version</source>
+        <target>Версія:</target>
+      </segment>
+    </unit>
+    <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>extensions.info_not_installed</source>
+        <target>Це локальный пакет, не встановлений через Composer</target>
+      </segment>
+    </unit>
+    <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>extensions.title_class</source>
+        <target>Імʼя класса:</target>
+      </segment>
+    </unit>
+    <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
+      <segment>
+        <source>extensions.button_configuration</source>
+        <target>Конфігурація</target>
+      </segment>
+    </unit>
+    <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>extensions.button_source</source>
+        <target>Джерело</target>
+      </segment>
+    </unit>
+    <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
+      <segment>
+        <source>extensions.button_remove</source>
+        <target>Видалити розширення</target>
+      </segment>
+    </unit>
+    <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>extensions.button_disable</source>
+        <target>Вимкнути розширення</target>
+      </segment>
+    </unit>
+    <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
+      <segment>
+        <source>login.header_login</source>
+        <target>Bolt » Вхід</target>
+      </segment>
+    </unit>
+    <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>extensions.message_not_implemented</source>
+        <target>Ще не реалізовано.</target>
+      </segment>
+    </unit>
+    <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>listing.title_overview</source>
+        <target>Перелік записів</target>
+      </segment>
+    </unit>
+    <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
+      <segment>
+        <source>files_cards.message_no_files</source>
+        <target>В цій теці немає файлів. Виберіть теку для переходу з правої сторони.</target>
+      </segment>
+    </unit>
+    <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_compact</source>
+        <target>Згорнуто</target>
+      </segment>
+    </unit>
+    <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>listing_filter.button_expanded</source>
+        <target>Розгорнуто</target>
+      </segment>
+    </unit>
+    <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>finder.label_view</source>
+        <target>Перегляд:</target>
+      </segment>
+    </unit>
+    <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.button_edit</source>
+        <target>Редагувати</target>
+      </segment>
+    </unit>
+    <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
+      <segment>
+        <source>controller.user.title</source>
+        <target>Користувачі і права</target>
+      </segment>
+    </unit>
+    <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
+      <segment>
+        <source>controller.user.subtitle</source>
+        <target>Для редагування користувачів і їх прав</target>
+      </segment>
+    </unit>
+    <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_display_name</source>
+        <target>Відображене імʼя</target>
+      </segment>
+    </unit>
+    <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
+      <segment>
+        <source>listing.title_username</source>
+        <target>Імʼя користувача</target>
+      </segment>
+    </unit>
+    <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>listing.title_email</source>
+        <target>Ел. адреса</target>
+      </segment>
+    </unit>
+    <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>listing.title_roles</source>
+        <target>Ролі</target>
+      </segment>
+    </unit>
+    <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_seen</source>
+        <target>Вік сесії</target>
+      </segment>
+    </unit>
+    <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>listing.title_last_ip</source>
+        <target>Останній IP</target>
+      </segment>
+    </unit>
+    <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
+      <segment>
+        <source>listing.title_actions</source>
+        <target>Дії</target>
+      </segment>
+    </unit>
+    <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>user.unknown_user</source>
+        <target>Невідомий користувач</target>
+      </segment>
+    </unit>
+    <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
+      <segment>
+        <source>label.predominant_colors__in_image</source>
+        <target>Переважаючі кольори в зображенні</target>
+      </segment>
+    </unit>
+    <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.overview-for</source>
+        <target>Огляд для '%slug%'</target>
+      </segment>
+    </unit>
+    <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
+      <segment>
+        <source>general.phrase.related-content</source>
+        <target>Пов'язаний контент</target>
+      </segment>
+    </unit>
+    <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
+      <segment>
+        <source>action.search</source>
+        <target>Шукати</target>
+      </segment>
+    </unit>
+    <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
+      <segment>
+        <source>caption.new_contenttype</source>
+        <target>Створити %contenttype%</target>
+      </segment>
+    </unit>
+    <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>caption.untitled_contenttype</source>
+        <target>%contenttype%  без назви</target>
+      </segment>
+    </unit>
+    <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>title.edit_user_profile</source>
+        <target>Редагувати профіль користувача</target>
+      </segment>
+    </unit>
+    <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>caption.redirection_page</source>
+        <target>Сторінка переспрямовування</target>
+      </segment>
+    </unit>
+    <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.edit_image</source>
+        <target>Редагувати зображення</target>
+      </segment>
+    </unit>
+    <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>password.suggested</source>
+        <target><![CDATA[Запропонований безпечний пароль: <code>%password%</code>]]></target>
+      </segment>
+    </unit>
+    <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
+      <segment>
+        <source>field.cropX</source>
+        <target>Обрізати X</target>
+      </segment>
+    </unit>
+    <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
+      <segment>
+        <source>field.cropXPostfix</source>
+        <target>Положення кадрування по осі X, діапазон 0-100.</target>
+      </segment>
+    </unit>
+    <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
+      <segment>
+        <source>field.cropYPostfix</source>
+        <target>Положення кадрування по осі Y, діапазон 0-100. </target>
+      </segment>
+    </unit>
+    <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
+      <segment>
+        <source>field.cropY</source>
+        <target>Обрізати Y</target>
+      </segment>
+    </unit>
+    <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
+      <segment>
+        <source>field.cropZoom</source>
+        <target>Коефіцієнт масштабування кадрування</target>
+      </segment>
+    </unit>
+    <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
+      <segment>
+        <source>field.cropZoomPostfix</source>
+        <target>Масштаб кадрування, діапазон 1-10. </target>
+      </segment>
+    </unit>
+    <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
+      <segment>
+        <source>title.contentType</source>
+        <target>Тип контенту</target>
+      </segment>
+    </unit>
+    <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>listing_table.no_results</source>
+        <target>Нічого не знайдено. Розширте критерії фільтрації або додайте більше контенту.</target>
+      </segment>
+    </unit>
+    <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
+      <segment>
+        <source>listing.option_select_sortby</source>
+        <target>Виберіть поле для сортування …</target>
+      </segment>
+    </unit>
+    <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>title.primary_actions</source>
+        <target>Основні дії</target>
+      </segment>
+    </unit>
+    <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
+      <segment>
+        <source>title.options</source>
+        <target>Опції</target>
+      </segment>
+    </unit>
+    <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
+      <segment>
+        <source>action.delete</source>
+        <target>Видалити</target>
+      </segment>
+    </unit>
+    <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
+      <segment>
+        <source>action.enable</source>
+        <target>Вкл.</target>
+      </segment>
+    </unit>
+    <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>action.disable</source>
+        <target>Вимк.</target>
+      </segment>
+    </unit>
+    <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
+      <segment>
+        <source>listing.title_session_expires</source>
+        <target>Сесія спливає</target>
+      </segment>
+    </unit>
+    <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
+      <segment>
+        <source>listing.title_ip_address</source>
+        <target>IP адреса</target>
+      </segment>
+    </unit>
+    <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
+      <segment>
+        <source>listing.title_browser</source>
+        <target>Браузер / платформа</target>
+      </segment>
+    </unit>
+    <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
+      <segment>
+        <source>image.button_remove</source>
+        <target>Видалити</target>
+      </segment>
+    </unit>
+    <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
+      <segment>
+        <source>image.button_edit_attributes</source>
+        <target>Редагувати атрибути</target>
+      </segment>
+    </unit>
+    <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>image.add_new_image</source>
+        <target>Додати нове зображення</target>
+      </segment>
+    </unit>
+    <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>file.add_new_file</source>
+        <target>Додати новий файл</target>
+      </segment>
+    </unit>
+    <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>collection.remove_item</source>
+        <target>Видалити елемент</target>
+      </segment>
+    </unit>
+    <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>collection.add_item</source>
+        <target>Додати елемент до '%name%'</target>
+      </segment>
+    </unit>
+    <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_up</source>
+        <target>Вгору</target>
+      </segment>
+    </unit>
+    <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>collection.move_item_down</source>
+        <target>Вниз</target>
+      </segment>
+    </unit>
+    <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
+      <segment>
+        <source>extensions.button_detailed_view</source>
+        <target>Переглянути деталі</target>
+      </segment>
+    </unit>
+    <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>extensions.title_configuration</source>
+        <target>Файл конфігурації</target>
+      </segment>
+    </unit>
+    <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>caption.file_upload.upload_text</source>
+        <target>Перетягніть сюди файли для завантаження</target>
+      </segment>
+    </unit>
+    <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
+      <segment>
+        <source>pager.next</source>
+        <target>Далі</target>
+      </segment>
+    </unit>
+    <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>pager.previous</source>
+        <target>Назад</target>
+      </segment>
+    </unit>
+    <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.button_up</source>
+        <target>Вгору</target>
+      </segment>
+    </unit>
+    <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
+      <segment>
+        <source>image.button_down</source>
+        <target>Вниз</target>
+      </segment>
+    </unit>
+    <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
+      <segment>
+        <source>general.phrase.download</source>
+        <target>Завантажити</target>
+      </segment>
+    </unit>
+    <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>caption.logviewer</source>
+        <target>Перегляд логів</target>
+      </segment>
+    </unit>
+    <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>label.request</source>
+        <target>Запит</target>
+      </segment>
+    </unit>
+    <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
+      <segment>
+        <source>label.trace</source>
+        <target>Трасування</target>
+      </segment>
+    </unit>
+    <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
+      <segment>
+        <source>label.context</source>
+        <target>Контекст</target>
+      </segment>
+    </unit>
+    <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
+      <segment>
+        <source>label.id</source>
+        <target>ID</target>
+      </segment>
+    </unit>
+    <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
+      <segment>
+        <source>label.level</source>
+        <target>Рівень</target>
+      </segment>
+    </unit>
+    <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
+      <segment>
+        <source>label.message</source>
+        <target>Повідомлення</target>
+      </segment>
+    </unit>
+    <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>label.timestamp</source>
+        <target>Мітка часу</target>
+      </segment>
+    </unit>
+    <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
+      <segment>
+        <source>label.user</source>
+        <target>Користувач</target>
+      </segment>
+    </unit>
+    <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
+      <segment>
+        <source>listing.disabled</source>
+        <target>Відображення вимкнено</target>
+      </segment>
+    </unit>
+    <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>slug.button_unlocked</source>
+        <target>Розблоковано</target>
+      </segment>
+    </unit>
+    <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
+      <segment>
+        <source>general.phrase.no-content-found</source>
+        <target>Контент не знайдено</target>
+      </segment>
+    </unit>
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>general.phrase.none</source>
+        <target>Немає</target>
+      </segment>
+    </unit>
+    <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
+      <segment>
+        <source>view_locales.badge_empty</source>
+        <target>Пусто</target>
+      </segment>
+    </unit>
+    <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>action.update_all</source>
+        <target>Застосувати до всіх</target>
+      </segment>
+    </unit>
+    <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
+      <segment>
+        <source>about.system_info</source>
+        <target>Системна інформація</target>
+      </segment>
+    </unit>
+    <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
+      <segment>
+        <source>action.confirm_delete</source>
+        <target>Ви впевнені, що хочете видалити цей контент?</target>
+      </segment>
+    </unit>
+    <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
+      <segment>
+        <source>placeholder.username_or_email</source>
+        <target>Ваше імʼя користувача або email</target>
+      </segment>
+    </unit>
+    <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
+      <segment>
+        <source>placeholder.password</source>
+        <target>Ваш пароль</target>
+      </segment>
+    </unit>
+    <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
+      <segment>
+        <source>caption.other_content</source>
+        <target>Інший контент</target>
+      </segment>
+    </unit>
+    <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>editfile.target_not_writable</source>
+        <target>Збереження вимкнено, оскільки цільовий файл недоступний для запису.</target>
+      </segment>
+    </unit>
+    <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
+      <segment>
+        <source>label.translatable</source>
+        <target>Це поле можна перевести</target>
+      </segment>
+    </unit>
+    <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
+      <segment>
+        <source>label.content</source>
+        <target>Контент</target>
+      </segment>
+    </unit>
+    <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
+      <segment>
+        <source>file.delete_success</source>
+        <target>Файл успішно видалено!</target>
+      </segment>
+    </unit>
+    <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
+      <segment>
+        <source>file.delete_confirm</source>
+        <target>Ви впевнені, що хочете видалити цей файл?</target>
+      </segment>
+    </unit>
+    <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby</source>
+        <target>Шукати / фільтрувати по</target>
+      </segment>
+    </unit>
+    <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
+      <segment>
+        <source>content.status_changed_successfully</source>
+        <target>Статус успішно змінено</target>
+      </segment>
+    </unit>
+    <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
+      <segment>
+        <source>content.deleted_successfully</source>
+        <target>Контент успішно видалено</target>
+      </segment>
+    </unit>
+    <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>label.current_status</source>
+        <target>Поточний статус</target>
+      </segment>
+    </unit>
+    <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.published</source>
+        <target>Опубліковано</target>
+      </segment>
+    </unit>
+    <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.draft</source>
+        <target>Чернетка</target>
+      </segment>
+    </unit>
+    <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.timed</source>
+        <target>Відстрочено</target>
+      </segment>
+    </unit>
+    <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>status.held</source>
+        <target>Не активно</target>
+      </segment>
+    </unit>
+    <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
+      <segment>
+        <source>collection.confirm_delete</source>
+        <target>Ви дійсно хочете видалити цей елемент колекції?</target>
+      </segment>
+    </unit>
+    <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>upload.allow_file_types</source>
+        <target>Типи файлів, разрешенные для завантаження</target>
+      </segment>
+    </unit>
+    <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>upload.max_size</source>
+        <target>Максимальний розмір завантажуваного файлу</target>
+      </segment>
+    </unit>
+    <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>listing.placeholder_search</source>
+        <target>Ключове слово…</target>
+      </segment>
+    </unit>
+    <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
+      <segment>
+        <source>title.filtered_by</source>
+        <target><![CDATA[Увесь контент, відфільтрований за <em>'%filter%'</em>.]]></target>
+      </segment>
+    </unit>
+    <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
+      <segment>
+        <source>action.view_site</source>
+        <target>Перейти на сайт</target>
+      </segment>
+    </unit>
+    <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>action.new</source>
+        <target>Створити</target>
+      </segment>
+    </unit>
+    <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
+      <segment>
+        <source>extensions.no_dependencies</source>
+        <target>Немає відомих залежностей</target>
+      </segment>
+    </unit>
+    <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>extensions.title_dependencies</source>
+        <target>Залежності</target>
+      </segment>
+    </unit>
+    <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>collection.expand_all</source>
+        <target>Розгорнути все</target>
+      </segment>
+    </unit>
+    <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
+      <segment>
+        <source>collection.collapse_all</source>
+        <target>Згорнути все</target>
+      </segment>
+    </unit>
+    <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
+      <segment>
+        <source>content.edit_missing_definition</source>
+        <target>Визначення цього Типу контенту відсутнє! Редагування цього запису не працюватиме належним чином. Будь ласка, перевірте свій contenttypes.yaml, щоб впевнитися, що він містить %contenttype%.</target>
+      </segment>
+    </unit>
+    <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
+      <segment>
+        <source>collection.select</source>
+        <target>Вибрати …</target>
+      </segment>
+    </unit>
+    <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
+      <segment>
+        <source>form.empty_username_email</source>
+        <target>Будь ласка, введіть ваше імʼя користувача або адресу електронної пошти</target>
+      </segment>
+    </unit>
+    <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
+      <segment>
+        <source>form.empty_password</source>
+        <target>Будь ласка, введіть ваш пароль</target>
+      </segment>
+    </unit>
+    <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
+      <segment>
+        <source>form.empty_email</source>
+        <target>Будь ласка, введіть свою електронну пошту</target>
+      </segment>
+    </unit>
+    <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
+      <segment>
+        <source>listing.title_filterby_field</source>
+        <target>Фільтр за полем</target>
+      </segment>
+    </unit>
+    <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>image.button_from_url</source>
+        <target>За URL</target>
+      </segment>
+    </unit>
+    <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>files_cards.copy_to_clipboard</source>
+        <target>Копіювати посилання на файл</target>
+      </segment>
+    </unit>
+    <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
+      <segment>
+        <source>warning</source>
+        <target>Попередження</target>
+      </segment>
+    </unit>
+    <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_already_exists</source>
+        <target>Тека вже існує</target>
+      </segment>
+    </unit>
+    <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_error</source>
+        <target>Не вдалося створити теку</target>
+      </segment>
+    </unit>
+    <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
+      <segment>
+        <source>filemanager.create_folder_success</source>
+        <target>Тека успішно створена.</target>
+      </segment>
+    </unit>
+    <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
+      <segment>
+        <source>filemanager.delete_folder_successful</source>
+        <target>Тека успішно видалена</target>
+      </segment>
+    </unit>
+    <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>folder.create_new</source>
+        <target>Нова папка</target>
+      </segment>
+    </unit>
+    <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>label.avatar</source>
+        <target>Аватар</target>
+      </segment>
+    </unit>
+    <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
+      <segment>
+        <source>login.forgotpassword</source>
+        <target>Забули пароль</target>
+      </segment>
+    </unit>
+    <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_header</source>
+        <target>Скинути пароль</target>
+      </segment>
+    </unit>
+    <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_description</source>
+        <target>Введіть свою електронну адресу, і ми надішлемо вам посилання для скидання пароля.</target>
+      </segment>
+    </unit>
+    <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
+      <segment>
+        <source>reset_password.request_send</source>
+        <target>Надіслати</target>
+      </segment>
+    </unit>
+    <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
+      <segment>
+        <source>Email</source>
+        <target>Ел. пошта</target>
+      </segment>
+    </unit>
+    <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
+      <segment>
+        <source>reset_password.back-to-login</source>
+        <target>Назад до входу</target>
+      </segment>
+    </unit>
+    <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_header</source>
+        <target>Скидання пароля</target>
+      </segment>
+    </unit>
+    <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_header</source>
+        <target>Лист для скидання пароля надіслано</target>
+      </segment>
+    </unit>
+    <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_1</source>
+        <target>Ми надіслали лист із посиланням, за яким ви можете скинути свій пароль. Термін дії цього посилання спливає через %hours% год.</target>
+      </segment>
+    </unit>
+    <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
+      <segment>
+        <source>reset_password.check_email_sent_text_2</source>
+        <target>Якщо ви не отримали листа, перевірте теку зі спамом або %tryagain%.</target>
+      </segment>
+    </unit>
+    <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_btn</source>
+        <target>Скинути пароль</target>
+      </segment>
+    </unit>
+    <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_title</source>
+        <target>Вітаємо!</target>
+      </segment>
+    </unit>
+    <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_description</source>
+        <target>Щоб скинути пароль, перейдіть за наступним посиланням</target>
+      </segment>
+    </unit>
+    <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_expire</source>
+        <target>Термін дії цього посилання спливає через %hours% год.</target>
+      </segment>
+    </unit>
+    <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
+      <segment>
+        <source>reset_password.email_thanks</source>
+        <target>Дякуємо!</target>
+      </segment>
+    </unit>
+    <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
+      <segment>
+        <source>reset_password.enter_pwd</source>
+        <target>Будь ласка, введіть пароль</target>
+      </segment>
+    </unit>
+    <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
+      <segment>
+        <source>label.repeat_password</source>
+        <target>Повторіть пароль</target>
+      </segment>
+    </unit>
+    <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
+      <segment>
+        <source>reset_password.not_matching_pwds</source>
+        <target>Паролі мають збігатися.</target>
+      </segment>
+    </unit>
+    <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
+      <segment>
+        <source>reset_password.minimum_length</source>
+        <target>Ваш пароль має містити щонайменше %s символів</target>
+      </segment>
+    </unit>
+    <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
+      <segment>
+        <source>reset_password.no_token</source>
+        <target>У URL-адресі або в сесії не знайдено токен для скидання пароля.</target>
+      </segment>
+    </unit>
+    <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
+      <segment>
+        <source>reset_password.reset_successful</source>
+        <target>Ваш пароль успішно скинуто.</target>
+      </segment>
+    </unit>
+    <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
+      <segment>
+        <source>reset_password.problem_with_request</source>
+        <target>Під час обробки вашого запиту на скидання пароля сталася помилка - %s</target>
+      </segment>
+    </unit>
+    <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
+      <segment>
+        <source>label.filtered_by</source>
+        <target>Відфільтровано за</target>
+      </segment>
+    </unit>
+    <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
+      <segment>
+        <source>action.preview_secure_share</source>
+        <target>Поділитися захищеним посиланням на попередній перегляд</target>
+      </segment>
+    </unit>
+    <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
+      <segment>
+        <source>action.stop_impersonating</source>
+        <target>Припинити видавати себе за іншого</target>
+      </segment>
+    </unit>
+    <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
+      <segment>
+        <source>action.impersonate</source>
+        <target>Видавати себе за іншого</target>
+      </segment>
+    </unit>
+    <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
+      <segment>
+        <source>maintenance.activated_warning</source>
+        <target>Режим технічного обслуговування активовано</target>
+      </segment>
+    </unit>
+    <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>action.refresh</source>
+        <target>Оновити</target>
+      </segment>
+    </unit>
+    <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.showing_records</source>
+        <target>Показано записів %current% з %total%</target>
+      </segment>
+    </unit>
+    <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.name</source>
+        <target>Назва: %name% (однина: %singularName%)</target>
+      </segment>
+    </unit>
+    <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.slug</source>
+        <target>Slug: %slug% (однина: %singularSlug%)</target>
+      </segment>
+    </unit>
+    <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.record_template</source>
+        <target>Шаблон запису: %template%</target>
+      </segment>
+    </unit>
+    <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.listing_template</source>
+        <target>Шаблон списку: %template% (%listingRecords% записів)</target>
+      </segment>
+    </unit>
+    <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
+      <segment>
+        <source>listing_details_box.locales</source>
+        <target>Локалі: %locales%</target>
+      </segment>
+    </unit>
+    <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
+      <segment>
+        <source>action.edit_permissions</source>
+        <target>Редагувати дозволи</target>
+      </segment>
+    </unit>
+    <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
+      <segment>
+        <source>general.label.search</source>
+        <target>Пошук</target>
+      </segment>
+    </unit>
+    <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
+      <segment>
+        <source>image.image_preview</source>
+        <target>Попередній перегляд зображення</target>
+      </segment>
+    </unit>
+    <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
+      <segment>
+        <source>listing_table.actions.select_all</source>
+        <target>Вибрати все</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>Запам'ятати мене? (%duration% днів)</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>Поточні сесії</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>Параметри завантаження</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>Порядок</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>ваша електронна пошта</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>Виберіть файл</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>Виберіть зображення</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>Завантажити з URL</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>Завантаження...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>Зберегти</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>Закрити</target>
+      </segment>
+    </unit>
+  </file>
 </xliff>

--- a/translations/messages.zh_CN.xlf
+++ b/translations/messages.zh_CN.xlf
@@ -1,149 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="zh-CN">
   <file id="messages.zh_CN">
-    <unit id="tbB2gib" name="not_available">
-      <notes>
-        <note>templates/debug/source_code.twig:26</note>
-      </notes>
-      <segment>
-        <source>not_available</source>
-        <target>无法使用</target>
-      </segment>
-    </unit>
-    <unit id="DF34uM2" name="http_error.name">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:15</note>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:15</note>
-      </notes>
-      <segment>
-        <source>http_error.name</source>
-        <target>错误 %status_code%</target>
-      </segment>
-    </unit>
-    <unit id="e3w.2Rf" name="http_error.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error.description</source>
-        <target>未知错误 (HTTP %status_code%) 无法完成请求。</target>
-      </segment>
-    </unit>
-    <unit id="ru5FEGk" name="http_error.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error.suggestion</source>
-        <target><![CDATA[请稍后再次加载此页面或 <a href="%url%">返回主页</a>。]]></target>
-      </segment>
-    </unit>
-    <unit id="Qn5rwdU" name="http_error_403.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_403.description</source>
-        <target>您无权访问此资源。</target>
-      </segment>
-    </unit>
-    <unit id="zDeeh7L" name="http_error_403.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error403.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_403.suggestion</source>
-        <target>请您的系统管理员授予您对该资源的访问权。</target>
-      </segment>
-    </unit>
-    <unit id="_W1eNz2" name="http_error_404.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_404.description</source>
-        <target>找不到页面。</target>
-      </segment>
-    </unit>
-    <unit id="MWNS5dg" name="http_error_404.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error404.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_404.suggestion</source>
-        <target><![CDATA[检查链接中是否有拼写错误或 <a href="%url%">返回主页</a>。]]></target>
-      </segment>
-    </unit>
-    <unit id="ZYXSW95" name="http_error_500.description">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:18</note>
-      </notes>
-      <segment>
-        <source>http_error_500.description</source>
-        <target>服务器错误.</target>
-      </segment>
-    </unit>
-    <unit id="VVs_J1c" name="http_error_500.suggestion">
-      <notes>
-        <note>templates/bundles/TwigBundle/Exception/error500.html.twig:21</note>
-      </notes>
-      <segment>
-        <source>http_error_500.suggestion</source>
-        <target><![CDATA[请稍后再次加载此页面或 <a href="%url%">返回主页</a>。]]></target>
-      </segment>
-    </unit>
-    <unit id="9RwuNlf" name="title.source_code">
-      <notes>
-        <note>templates/debug/source_code.twig:17</note>
-      </notes>
-      <segment>
-        <source>title.source_code</source>
-        <target>用于渲染此页面的源代码</target>
-      </segment>
-    </unit>
-    <unit id="jaB3QjG" name="title.controller_code">
-      <notes>
-        <note>templates/debug/source_code.twig:22</note>
-        <note>templates/debug/source_code.twig:25</note>
-      </notes>
-      <segment>
-        <source>title.controller_code</source>
-        <target>控制器代码</target>
-      </segment>
-    </unit>
-    <unit id="2bH7SjO" name="title.twig_template_code">
-      <notes>
-        <note>templates/debug/source_code.twig:29</note>
-      </notes>
-      <segment>
-        <source>title.twig_template_code</source>
-        <target>Twig 模板</target>
-      </segment>
-    </unit>
     <unit id="1sstKF9" name="title.edit_user">
       <notes>
-        <note>templates/users/edit.twig:4</note>
+        <note>templates/users/edit.html.twig:6</note>
       </notes>
       <segment>
         <source>title.edit_user</source>
         <target>编辑用户</target>
       </segment>
     </unit>
-    <unit id="QbohvW1" name="action.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:7</note>
-      </notes>
-      <segment>
-        <source>action.show_code</source>
-        <target>显示代码</target>
-      </segment>
-    </unit>
     <unit id="HLtdhYw" name="action.save">
       <notes>
-        <note>templates/users/change_password.twig:18</note>
-        <note>templates/users/edit.twig:15</note>
+        <note>templates/content/_buttons.html.twig:12</note>
+        <note>templates/content/edit.html.twig:64</note>
+        <note>templates/finder/editfile.html.twig:38</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/media/edit.html.twig:111</note>
+        <note>templates/users/_form.html.twig:211</note>
+        <note>templates/users/add.html.twig:27</note>
+        <note>templates/users/edit.html.twig:27</note>
+        <note>templates/users/profile.html.twig:94</note>
+        <note>templates/users/profile.html.twig:106</note>
       </notes>
       <segment>
         <source>action.save</source>
@@ -151,21 +29,35 @@
       </segment>
     </unit>
     <unit id="a2vzLi7" name="action.do_something">
-      <segment>
-        <source>action.do_something</source>
-        <target>Do Something</target>
-      </segment>
-    </unit>
-    <unit id="etGJjTo" name="action.edit_user">
       <notes>
-        <note>templates/users/change_password.twig:26</note>
+        <note>templates/pages/kitchensink.html.twig:67</note>
+        <note>templates/pages/kitchensink.html.twig:68</note>
+        <note>templates/pages/kitchensink.html.twig:69</note>
+        <note>templates/pages/kitchensink.html.twig:73</note>
+        <note>templates/pages/kitchensink.html.twig:74</note>
+        <note>templates/pages/kitchensink.html.twig:75</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:83</note>
+        <note>templates/pages/kitchensink.html.twig:84</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>templates/pages/kitchensink.html.twig:90</note>
+        <note>templates/pages/kitchensink.html.twig:91</note>
+        <note>templates/pages/kitchensink.html.twig:97</note>
+        <note>templates/pages/kitchensink.html.twig:98</note>
+        <note>templates/pages/kitchensink.html.twig:102</note>
+        <note>templates/pages/kitchensink.html.twig:103</note>
       </notes>
       <segment>
-        <source>action.edit_user</source>
-        <target>编辑用户</target>
+        <source>action.do_something</source>
+        <target>做点什么</target>
       </segment>
     </unit>
     <unit id="ovKkXwU" name="action.edit">
+      <notes>
+        <note>templates/users/listing.html.twig:64</note>
+      </notes>
       <segment>
         <source>action.edit</source>
         <target>编辑</target>
@@ -173,35 +65,17 @@
     </unit>
     <unit id="LDhDPrF" name="label.username">
       <notes>
-        <note>templates/security/login.twig:66</note>
-        <note>src/Form/UserType.php:31</note>
+        <note>templates/users/_form.html.twig:10</note>
+        <note>templates/users/profile.html.twig:24</note>
       </notes>
       <segment>
         <source>label.username</source>
         <target>用户名</target>
       </segment>
     </unit>
-    <unit id="VgeTgE2" name="help.show_code">
-      <notes>
-        <note>templates/debug/source_code.twig:3</note>
-      </notes>
-      <segment>
-        <source>help.show_code</source>
-        <target><![CDATA[点击按钮可显示此页面 <strong>控制器</strong> 和 <strong>模板</strong> 的源代码.]]></target>
-      </segment>
-    </unit>
-    <unit id="wtG.cxy" name="info.change_password">
-      <notes>
-        <note>templates/users/change_password.twig:12</note>
-      </notes>
-      <segment>
-        <source>info.change_password</source>
-        <target>更改密码后，您将退出应用程序。</target>
-      </segment>
-    </unit>
     <unit id="80JoLd0" name="title.login">
       <notes>
-        <note>templates/security/login.twig:4</note>
+        <note>templates/security/login.html.twig:4</note>
       </notes>
       <segment>
         <source>title.login</source>
@@ -210,8 +84,9 @@
     </unit>
     <unit id="9pvowqn" name="label.password">
       <notes>
-        <note>templates/security/login.twig:70</note>
-        <note>templates/security/login.twig:75</note>
+        <note>src/Form/LoginType.php:43</note>
+        <note>templates/users/_form.html.twig:51</note>
+        <note>templates/users/profile.html.twig:42</note>
       </notes>
       <segment>
         <source>label.password</source>
@@ -220,7 +95,7 @@
     </unit>
     <unit id="gLN0C81" name="action.log_in">
       <notes>
-        <note>templates/security/login.twig:84</note>
+        <note>templates/security/login.html.twig:60</note>
       </notes>
       <segment>
         <source>action.log_in</source>
@@ -229,26 +104,17 @@
     </unit>
     <unit id="vJwSCBO" name="title.contentlisting">
       <notes>
-        <note>templates/content/listing.twig:9</note>
+        <note>templates/content/listing.html.twig:58</note>
       </notes>
       <segment>
         <source>title.contentlisting</source>
         <target>内容列表</target>
       </segment>
     </unit>
-    <unit id="CX_oSFd" name="action.change_password">
-      <notes>
-        <note>templates/users/edit.twig:24</note>
-      </notes>
-      <segment>
-        <source>action.change_password</source>
-        <target>更改密码</target>
-      </segment>
-    </unit>
     <unit id="SNELzJ2" name="field.id">
       <notes>
-        <note>templates/editcontent/edit.twig:118</note>
-        <note>templates/editcontent/media_edit.twig:98</note>
+        <note>templates/content/_fields_aside_summary.html.twig:26</note>
+        <note>templates/media/edit.html.twig:121</note>
       </notes>
       <segment>
         <source>field.id</source>
@@ -257,7 +123,8 @@
     </unit>
     <unit id="FuCyk5C" name="field.status">
       <notes>
-        <note>templates/editcontent/edit.twig:76</note>
+        <note>templates/content/_fields_aside.html.twig:5</note>
+        <note>templates/users/_form.html.twig:153</note>
       </notes>
       <segment>
         <source>field.status</source>
@@ -266,8 +133,8 @@
     </unit>
     <unit id="O9wtVOp" name="field.createdAt">
       <notes>
-        <note>templates/editcontent/edit.twig:86</note>
-        <note>templates/editcontent/media_edit.twig:128</note>
+        <note>templates/content/_fields_aside_summary.html.twig:6</note>
+        <note>templates/media/edit.html.twig:151</note>
       </notes>
       <segment>
         <source>field.createdAt</source>
@@ -276,8 +143,10 @@
     </unit>
     <unit id="eVkSIKu" name="field.modifiedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:94</note>
-        <note>templates/editcontent/media_edit.twig:135</note>
+        <note>src/Controller/Backend/ContentEditController.php:189</note>
+        <note>templates/content/_buttons.html.twig:50</note>
+        <note>templates/content/_fields_aside_summary.html.twig:16</note>
+        <note>templates/media/edit.html.twig:159</note>
       </notes>
       <segment>
         <source>field.modifiedAt</source>
@@ -286,7 +155,7 @@
     </unit>
     <unit id="3gdi1dy" name="field.publishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:102</note>
+        <note>templates/content/_fields_aside.html.twig:15</note>
       </notes>
       <segment>
         <source>field.publishedAt</source>
@@ -295,7 +164,7 @@
     </unit>
     <unit id="eN7IfEL" name="field.depublishedAt">
       <notes>
-        <note>templates/editcontent/edit.twig:110</note>
+        <note>templates/content/_fields_aside.html.twig:24</note>
       </notes>
       <segment>
         <source>field.depublishedAt</source>
@@ -304,7 +173,8 @@
     </unit>
     <unit id="VKhfRZB" name="field.title">
       <notes>
-        <note>templates/editcontent/media_edit.twig:47</note>
+        <note>templates/_partials/fields/embed.html.twig:31</note>
+        <note>templates/media/edit.html.twig:39</note>
       </notes>
       <segment>
         <source>field.title</source>
@@ -313,7 +183,7 @@
     </unit>
     <unit id="7_wwX8J" name="field.description">
       <notes>
-        <note>templates/editcontent/media_edit.twig:53</note>
+        <note>templates/media/edit.html.twig:45</note>
       </notes>
       <segment>
         <source>field.description</source>
@@ -322,7 +192,7 @@
     </unit>
     <unit id="hjDmcPC" name="field.copyright">
       <notes>
-        <note>templates/editcontent/media_edit.twig:59</note>
+        <note>templates/media/edit.html.twig:51</note>
       </notes>
       <segment>
         <source>field.copyright</source>
@@ -331,7 +201,7 @@
     </unit>
     <unit id="v0sitU8" name="field.originalFilename">
       <notes>
-        <note>templates/editcontent/media_edit.twig:66</note>
+        <note>templates/media/edit.html.twig:58</note>
       </notes>
       <segment>
         <source>field.originalFilename</source>
@@ -340,7 +210,8 @@
     </unit>
     <unit id="vlRe8Tx" name="field.width">
       <notes>
-        <note>templates/editcontent/media_edit.twig:105</note>
+        <note>templates/_partials/fields/embed.html.twig:29</note>
+        <note>templates/media/edit.html.twig:128</note>
       </notes>
       <segment>
         <source>field.width</source>
@@ -349,7 +220,8 @@
     </unit>
     <unit id="CZbXbM_" name="field.height">
       <notes>
-        <note>templates/editcontent/media_edit.twig:112</note>
+        <note>templates/_partials/fields/embed.html.twig:30</note>
+        <note>templates/media/edit.html.twig:135</note>
       </notes>
       <segment>
         <source>field.height</source>
@@ -358,7 +230,7 @@
     </unit>
     <unit id="Sz_u.OS" name="field.filesize">
       <notes>
-        <note>templates/editcontent/media_edit.twig:119</note>
+        <note>templates/media/edit.html.twig:142</note>
       </notes>
       <segment>
         <source>field.filesize</source>
@@ -367,7 +239,7 @@
     </unit>
     <unit id="RMPnq6o" name="label.username_or_email">
       <notes>
-        <note>templates/security/login.twig:61</note>
+        <note>src/Form/LoginType.php:31</note>
       </notes>
       <segment>
         <source>label.username_or_email</source>
@@ -376,7 +248,7 @@
     </unit>
     <unit id="IaF1MjB" name="label.rememberme">
       <notes>
-        <note>templates/security/login.twig:80</note>
+        <note>src/Form/LoginType.php:58</note>
       </notes>
       <segment>
         <source>label.rememberme</source>
@@ -385,7 +257,9 @@
     </unit>
     <unit id="k.JymqB" name="about.visit_bolt">
       <notes>
-        <note>templates/pages/about.twig:25</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:76</note>
+        <note>templates/_base/layout.html.twig:43</note>
+        <note>templates/pages/about.html.twig:54</note>
       </notes>
       <segment>
         <source>about.visit_bolt</source>
@@ -394,7 +268,9 @@
     </unit>
     <unit id="UZFanGF" name="about.bolt_documentation">
       <notes>
-        <note>templates/pages/about.twig:28</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:82</note>
+        <note>templates/_base/layout.html.twig:37</note>
+        <note>templates/pages/about.html.twig:57</note>
       </notes>
       <segment>
         <source>about.bolt_documentation</source>
@@ -403,16 +279,16 @@
     </unit>
     <unit id="FO7zDub" name="about.bolt_on_github">
       <notes>
-        <note>templates/pages/about.twig:31</note>
+        <note>templates/pages/about.html.twig:60</note>
       </notes>
       <segment>
         <source>about.bolt_on_github</source>
-        <target>Bolt on Github</target>
+        <target>GitHub 上的 Bolt</target>
       </segment>
     </unit>
     <unit id="_9fS00R" name="about.used_libraries">
       <notes>
-        <note>templates/pages/about.twig:35</note>
+        <note>templates/pages/about.html.twig:64</note>
       </notes>
       <segment>
         <source>about.used_libraries</source>
@@ -421,37 +297,36 @@
     </unit>
     <unit id="tgLgLDQ" name="about.list_of_used_libraries">
       <notes>
-        <note>templates/pages/about.twig:37</note>
+        <note>templates/pages/about.html.twig:66</note>
       </notes>
       <segment>
         <source>about.list_of_used_libraries</source>
         <target>以下是Bolt使用的第三方库。</target>
       </segment>
     </unit>
-    <unit id="aYnbvsn" name="label.fullname">
-      <notes>
-        <note>src/Form/UserType.php:35</note>
-        <note>new</note>
-      </notes>
-      <segment>
-        <source>label.fullname</source>
-        <target>全名</target>
-      </segment>
-    </unit>
     <unit id="D2N6_cP" name="label.email">
       <notes>
-        <note>src/Form/UserType.php:38</note>
-        <note>new</note>
+        <note>src/Form/ResetPasswordRequestFormType.php:25</note>
+        <note>templates/users/_form.html.twig:68</note>
+        <note>templates/users/profile.html.twig:51</note>
       </notes>
       <segment>
         <source>label.email</source>
         <target>Email地址</target>
       </segment>
     </unit>
+    <unit id="D2N7_cP" name="label.about">
+      <notes>
+        <note>templates/users/_form.html.twig:185</note>
+      </notes>
+      <segment>
+        <source>label.about</source>
+        <target>关于</target>
+      </segment>
+    </unit>
     <unit id="OBmPOoB" name="user.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/UserController.php:33</note>
-        <note>new</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
       </notes>
       <segment>
         <source>user.updated_successfully</source>
@@ -460,9 +335,9 @@
     </unit>
     <unit id="3hkt.eH" name="content.updated_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:126</note>
-        <note>src/Controller/Backend/EditRecordController.php:86</note>
-        <note>new</note>
+        <note>src/Controller/Backend/ContentEditController.php:198</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
       </notes>
       <segment>
         <source>content.updated_successfully</source>
@@ -471,8 +346,7 @@
     </unit>
     <unit id="IB0mNQh" name="content.created_successfully">
       <notes>
-        <note>src/Controller/Backend/EditMediaController.php:157</note>
-        <note>new</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
       </notes>
       <segment>
         <source>content.created_successfully</source>
@@ -481,8 +355,7 @@
     </unit>
     <unit id="b1jqjUC" name="editfile.could_not_write">
       <notes>
-        <note>src/Controller/Backend/EditFileController.php:101</note>
-        <note>new</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
       </notes>
       <segment>
         <source>editfile.could_not_write</source>
@@ -490,511 +363,645 @@
       </segment>
     </unit>
     <unit id="mEDsKHk" name="label.locale">
+      <notes>
+        <note>templates/users/_form.html.twig:95</note>
+        <note>templates/users/profile.html.twig:72</note>
+      </notes>
       <segment>
         <source>label.locale</source>
         <target>语言环境</target>
       </segment>
     </unit>
-    <unit id="98Q5SA2" name="label.backend_theme">
-      <segment>
-        <source>label.backend_theme</source>
-        <target>后端主题</target>
-      </segment>
-    </unit>
-    <unit id="Z84BVRW" name="English (en)">
-      <segment>
-        <source>English (en)</source>
-        <target>English (en)</target>
-      </segment>
-    </unit>
-    <unit id="eG9ABZd" name="Nederlands (dutch, nl)">
-      <segment>
-        <source>Nederlands (dutch, nl)</source>
-        <target>Nederlands (dutch, nl)</target>
-      </segment>
-    </unit>
-    <unit id="57LcBXV" name="Español (Spanish, es)">
-      <segment>
-        <source>Español (Spanish, es)</source>
-        <target>Español (Spanish, es)</target>
-      </segment>
-    </unit>
-    <unit id="e7RdvJ0" name="français (French, fr)">
-      <segment>
-        <source>français (French, fr)</source>
-        <target>français (French, fr)</target>
-      </segment>
-    </unit>
-    <unit id="U1vrep2" name="Deutsch (German, de)">
-      <segment>
-        <source>Deutsch (German, de)</source>
-        <target>Deutsch (German, de)</target>
-      </segment>
-    </unit>
-    <unit id="EsWjyMS" name="Język Polski (Polish, pl)">
-      <segment>
-        <source>Język Polski (Polish, pl)</source>
-        <target>Język Polski (Polish, pl)</target>
-      </segment>
-    </unit>
-    <unit id="fbEbOrT" name="Brasilian Portuguese (Brasilian Portuguese, pt_BR)">
-      <segment>
-        <source>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</source>
-        <target>Brasilian Portuguese (Brasilian Portuguese, pt_BR)</target>
-      </segment>
-    </unit>
-    <unit id="pBUPCm9" name="Italiano (Italian, it)">
-      <segment>
-        <source>Italiano (Italian, it)</source>
-        <target>Italiano (Italian, it)</target>
-      </segment>
-    </unit>
     <unit id="Oiwdkpg" name="The Default theme">
+      <notes>
+        <note>templates/users/_form.html.twig:201</note>
+        <note>templates/users/profile.html.twig:85</note>
+      </notes>
       <segment>
         <source>The Default theme</source>
         <target>默认主题</target>
       </segment>
     </unit>
     <unit id="C389Knp" name="The Default Dark theme">
+      <notes>
+        <note>templates/users/_form.html.twig:202</note>
+        <note>templates/users/profile.html.twig:86</note>
+      </notes>
       <segment>
         <source>The Default Dark theme</source>
         <target>默认深色主题 </target>
       </segment>
     </unit>
     <unit id="kouGbMq" name="WoordPers: Kinda looks like that other CMS">
+      <notes>
+        <note>templates/users/_form.html.twig:204</note>
+        <note>templates/users/profile.html.twig:88</note>
+      </notes>
       <segment>
         <source>WoordPers: Kinda looks like that other CMS</source>
-        <target>WoordPers: Kinda looks like that other CMS</target>
+        <target>WoordPers：有点像那个别的 CMS</target>
       </segment>
     </unit>
     <unit id="7aLIA3c" name="caption.dashboard">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:53</note>
+        <note>templates/pages/dashboard.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.dashboard</source>
         <target>仪表盘</target>
       </segment>
     </unit>
-    <unit id="xuNRuUu" name="caption.translations: messages">
-      <segment>
-        <source>caption.translations: messages</source>
-        <target>caption.translations: messages</target>
-      </segment>
-    </unit>
     <unit id="K6TmK4B" name="caption.clear_cache">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:217</note>
+        <note>templates/pages/clearcache.html.twig:6</note>
+        <note>templates/pages/clearcache.html.twig:18</note>
+      </notes>
       <segment>
         <source>caption.clear_cache</source>
         <target>清除缓存</target>
       </segment>
     </unit>
-    <unit id="RRQ1EJ3" name="caption.check_database">
-      <segment>
-        <source>caption.check_database</source>
-        <target>检查数据库</target>
-      </segment>
-    </unit>
-    <unit id="cIiIXu_" name="caption.routing set up">
-      <segment>
-        <source>caption.routing set up</source>
-        <target>caption.routing set up</target>
-      </segment>
-    </unit>
     <unit id="2RUXD4A" name="caption.menu_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:145</note>
+      </notes>
       <segment>
         <source>caption.menu_setup</source>
         <target>菜单设置</target>
       </segment>
     </unit>
     <unit id="drK.0GZ" name="caption.taxonomies">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:134</note>
+      </notes>
       <segment>
         <source>caption.taxonomies</source>
         <target>分类</target>
       </segment>
     </unit>
     <unit id="_w7J5rZ" name="caption.contenttypes">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:123</note>
+      </notes>
       <segment>
         <source>caption.contenttypes</source>
         <target>内容类型</target>
       </segment>
     </unit>
     <unit id="kXNBV9S" name="caption.main_configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:112</note>
+      </notes>
       <segment>
         <source>caption.main_configuration</source>
         <target>主要配置</target>
       </segment>
     </unit>
     <unit id="ipmA6Ah" name="caption.users_permissions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:99</note>
+      </notes>
       <segment>
         <source>caption.users_permissions</source>
-        <target><![CDATA[用户和权限]]></target>
+        <target>用户和权限</target>
       </segment>
     </unit>
     <unit id="zOLL.7E" name="caption.configuration">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:89</note>
+      </notes>
       <segment>
         <source>caption.configuration</source>
         <target>配置</target>
       </segment>
     </unit>
     <unit id="ZO.uqIZ" name="caption.settings">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:77</note>
+      </notes>
       <segment>
         <source>caption.settings</source>
         <target>设置</target>
       </segment>
     </unit>
     <unit id="1xlE8ex" name="caption.content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:61</note>
+      </notes>
       <segment>
         <source>caption.content</source>
         <target>内容</target>
       </segment>
     </unit>
     <unit id="l4yt0BE" name="caption.file_management">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:260</note>
+        <note>templates/finder/finder.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.file_management</source>
         <target>文件管理</target>
       </segment>
     </unit>
     <unit id="mfvtHPQ" name="caption.extensions">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:187</note>
+        <note>templates/pages/extension_details.html.twig:6</note>
+        <note>templates/pages/extensions.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.extensions</source>
         <target>扩展管理</target>
       </segment>
     </unit>
     <unit id="K4D568R" name="caption.view_edit_templates">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:280</note>
+      </notes>
       <segment>
         <source>caption.view_edit_templates</source>
-        <target><![CDATA[查看模板]]></target>
+        <target>查看模板</target>
       </segment>
     </unit>
     <unit id="bq6bSf4" name="caption.uploaded_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:270</note>
+      </notes>
       <segment>
         <source>caption.uploaded_files</source>
         <target>上传文件</target>
       </segment>
     </unit>
     <unit id="wBKDkwl" name="caption.routing_setup">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:157</note>
+      </notes>
       <segment>
         <source>caption.routing_setup</source>
         <target>路由配置</target>
       </segment>
     </unit>
     <unit id="dd5MzCM" name="caption.translations">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:227</note>
+        <note>templates/content/view_locales.html.twig:15</note>
+      </notes>
       <segment>
         <source>caption.translations</source>
         <target>翻译</target>
       </segment>
     </unit>
     <unit id="wLaDaK5" name="caption.about_bolt">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:248</note>
+        <note>templates/pages/about.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.about_bolt</source>
         <target>关于Bolt</target>
       </segment>
     </unit>
     <unit id="xN1kSQQ" name="caption.bolt_payoff">
+      <notes>
+        <note>templates/pages/about.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.bolt_payoff</source>
-        <target><![CDATA[Sophisticated, lightweight & simple CMS]]></target>
+        <target>精致、轻量且简单的 CMS</target>
       </segment>
     </unit>
     <unit id="HK7XTUX" name="caption.edit">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.edit</source>
         <target>编辑</target>
       </segment>
     </unit>
     <unit id="QZYjRy0" name="caption.file_uploader">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:8</note>
+      </notes>
       <segment>
         <source>caption.file_uploader</source>
         <target>上传文件</target>
       </segment>
     </unit>
     <unit id="LaDIuZA" name="caption.meta_information">
+      <notes>
+        <note>templates/finder/finder.html.twig:38</note>
+        <note>templates/media/edit.html.twig:105</note>
+      </notes>
       <segment>
         <source>caption.meta_information</source>
         <target>Meta信息</target>
       </segment>
     </unit>
     <unit id="DodjLNR" name="date">
+      <notes>
+        <note>assets/js/app/editor/Components/Date.vue:76</note>
+        <note>assets/js/filters/date.js:4</note>
+        <note>src/DataFixtures/ContentFixtures.php:357</note>
+        <note>src/Entity/Field/DateField.php:14</note>
+        <note>src/Storage/SelectQuery.php:299</note>
+        <note>src/Storage/SelectQuery.php:449</note>
+        <note>src/Twig/FieldExtension.php:52</note>
+        <note>src/Twig/HtmlExtension.php:106</note>
+        <note>templates/finder/_files_list.html.twig:9</note>
+        <note>templates/helpers/_field_blocks.twig:78</note>
+        <note>templates/helpers/_fields.twig:30</note>
+      </notes>
       <segment>
         <source>date</source>
         <target>日期</target>
       </segment>
     </unit>
     <unit id="zNy_hG8" name="size">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:32</note>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>src/Controller/Backend/Async/UploadController.php:195</note>
+        <note>src/Controller/Backend/Async/UploadController.php:196</note>
+        <note>src/Entity/Field/ImageField.php:88</note>
+        <note>src/Entity/Field/ImageField.php:89</note>
+        <note>templates/finder/_files_list.html.twig:8</note>
+      </notes>
       <segment>
         <source>size</source>
         <target>文件大小</target>
       </segment>
     </unit>
     <unit id="gPYflhh" name="thumbnail">
+      <notes>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/Controller/ImageController.php:113</note>
+        <note>src/Controller/ImageController.php:139</note>
+        <note>src/Entity/Field/ImageField.php:31</note>
+        <note>src/Entity/Field/ImageField.php:96</note>
+        <note>src/Twig/ImageExtension.php:45</note>
+        <note>src/Twig/ImageExtension.php:63</note>
+        <note>templates/_partials/fields/embed.html.twig:14</note>
+        <note>templates/finder/_files_list.html.twig:7</note>
+      </notes>
       <segment>
         <source>thumbnail</source>
         <target>缩略图</target>
       </segment>
     </unit>
     <unit id="_XSgfqS" name="filename">
+      <notes>
+        <note>public/theme/skeleton/custom/test.twig:99</note>
+        <note>src/Controller/Backend/FilemanagerController.php:211</note>
+        <note>src/Controller/Backend/UserEditController.php:84</note>
+        <note>src/Controller/Backend/UserEditController.php:255</note>
+        <note>src/Controller/ImageController.php:41</note>
+        <note>src/DataFixtures/ContentFixtures.php:314</note>
+        <note>src/DataFixtures/ContentFixtures.php:323</note>
+        <note>src/DataFixtures/ContentFixtures.php:382</note>
+        <note>src/DataFixtures/ContentFixtures.php:394</note>
+        <note>src/DataFixtures/ContentFixtures.php:498</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:15</note>
+        <note>src/Entity/Field/FileExtrasTrait.php:21</note>
+        <note>src/Entity/Field/FileField.php:22</note>
+        <note>src/Entity/Field/FileField.php:45</note>
+        <note>src/Entity/Field/FileField.php:63</note>
+        <note>src/Entity/Field/ImageField.php:28</note>
+        <note>src/Entity/Field/ImageField.php:72</note>
+        <note>src/Entity/Field/ImageField.php:87</note>
+        <note>src/Entity/Field/ImageField.php:94</note>
+        <note>src/Entity/Field/ImageField.php:107</note>
+        <note>src/Entity/Field/ImageField.php:108</note>
+        <note>src/Entity/Field/ImageField.php:116</note>
+        <note>src/Entity/Field/ImageField.php:120</note>
+        <note>src/Entity/Field/ImageField.php:144</note>
+        <note>src/Factory/MediaFactory.php:50</note>
+        <note>src/Repository/MediaRepository.php:27</note>
+        <note>src/Twig/ContentExtension.php:189</note>
+        <note>src/Twig/ImageExtension.php:162</note>
+        <note>src/Twig/ImageExtension.php:164</note>
+        <note>templates/_partials/fields/file.html.twig:31</note>
+        <note>templates/_partials/fields/image.html.twig:40</note>
+        <note>templates/finder/_files_list.html.twig:6</note>
+        <note>templates/media/edit.html.twig:31</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:159</note>
+        <note>tests/php/Twig/ContentExtensionTestCase.php:175</note>
+      </notes>
       <segment>
         <source>filename</source>
         <target>文件名</target>
       </segment>
     </unit>
     <unit id="Kw3N1AA" name="actions">
+      <notes>
+        <note>assets/js/app/listing/Components/Table/Row/index.vue:41</note>
+        <note>templates/_partials/_content_listing.html.twig:21</note>
+        <note>templates/finder/_files_list.html.twig:10</note>
+        <note>templates/finder/_folders.html.twig:7</note>
+      </notes>
       <segment>
         <source>actions</source>
-        <target>Actions</target>
+        <target>操作</target>
       </segment>
     </unit>
     <unit id="KHvGNGW" name="directoryname">
+      <notes>
+        <note>templates/finder/_folders.html.twig:6</note>
+      </notes>
       <segment>
         <source>directoryname</source>
         <target>目录名称</target>
       </segment>
     </unit>
-    <unit id="ZV7_x5F" name="action.go">
-      <segment>
-        <source>action.go</source>
-        <target>Go</target>
-      </segment>
-    </unit>
     <unit id="C15MbYY" name="form.quick_select_file">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:9</note>
+      </notes>
       <segment>
         <source>form.quick_select_file</source>
         <target>快速选择要编辑的文件…</target>
       </segment>
     </unit>
-    <unit id="gFcV5nW" name="label.quick_select">
-      <segment>
-        <source>label.quick_select</source>
-        <target>快速选择</target>
-      </segment>
-    </unit>
     <unit id="FSroufa" name="caption.path">
+      <notes>
+        <note>templates/finder/editfile.html.twig:26</note>
+        <note>templates/finder/finder.html.twig:40</note>
+      </notes>
       <segment>
         <source>caption.path</source>
         <target>路径</target>
       </segment>
     </unit>
     <unit id="y5otxEK" name="caption.filename">
+      <notes>
+        <note>templates/media/edit.html.twig:30</note>
+      </notes>
       <segment>
         <source>caption.filename</source>
         <target>文件名</target>
       </segment>
     </unit>
-    <unit id="XNTbZW6" name="action.visit_site">
-      <segment>
-        <source>action.visit_site</source>
-        <target>访问网站</target>
-      </segment>
-    </unit>
     <unit id="KfVJho2" name="action.create_new">
+      <notes>
+        <note>templates/content/listing.html.twig:63</note>
+      </notes>
       <segment>
         <source>action.create_new</source>
         <target>新建</target>
       </segment>
     </unit>
     <unit id="b_RPpcB" name="general.greeting">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:53</note>
+        <note>templates/_base/layout.html.twig:39</note>
+      </notes>
       <segment>
         <source>general.greeting</source>
-        <target>Hey, %name%!</target>
+        <target>嗨，%name%！</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:69</note>
+        <note>templates/_base/layout.html.twig:40</note>
+      </notes>
       <segment>
         <source>action.logout</source>
         <target>注销</target>
       </segment>
     </unit>
     <unit id="zOfpTLD" name="action.edit_profile">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:63</note>
+        <note>templates/_base/layout.html.twig:42</note>
+      </notes>
       <segment>
         <source>action.edit_profile</source>
         <target>编辑资料</target>
       </segment>
     </unit>
     <unit id="N_0yRcH" name="action.close_alert">
+      <notes>
+        <note>templates/_partials/_flash_messages.html.twig:1</note>
+      </notes>
       <segment>
         <source>action.close_alert</source>
         <target>关闭</target>
       </segment>
     </unit>
     <unit id="Dvu2HQx" name="caption.api">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:207</note>
+      </notes>
       <segment>
         <source>caption.api</source>
         <target>API</target>
       </segment>
     </unit>
     <unit id="i4cbdta" name="caption.all_configuration_files">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:165</note>
+      </notes>
       <segment>
         <source>caption.all_configuration_files</source>
         <target>所有配置文件</target>
       </segment>
     </unit>
     <unit id="OpKTKAL" name="caption.maintenance">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:177</note>
+      </notes>
       <segment>
         <source>caption.maintenance</source>
         <target>维护</target>
       </segment>
     </unit>
-    <unit id="hGJoUs5" name="caption.fixtures_dummy_content">
-      <segment>
-        <source>caption.fixtures_dummy_content</source>
-        <target>Fixtures (Dummy Content)</target>
-      </segment>
-    </unit>
     <unit id="P1FHg3Q" name="caption.edit_file">
+      <notes>
+        <note>templates/finder/editfile.html.twig:21</note>
+      </notes>
       <segment>
         <source>caption.edit_file</source>
         <target>编辑文件</target>
       </segment>
     </unit>
-    <unit id="_ef0RBR" name="caption.installation_checks">
-      <segment>
-        <source>caption.installation_checks</source>
-        <target>安装检查</target>
-      </segment>
-    </unit>
-    <unit id="pNPctrH" name="form.select_language">
-      <segment>
-        <source>form.select_language</source>
-        <target>选择语言</target>
-      </segment>
-    </unit>
-    <unit id="9lJhqvA" name="field.locale">
-      <segment>
-        <source>field.locale</source>
-        <target>语言环境</target>
-      </segment>
-    </unit>
     <unit id="8zEzq8N" name="field.current_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:7</note>
+      </notes>
       <segment>
         <source>field.current_locale</source>
         <target>当前语言</target>
       </segment>
     </unit>
     <unit id="ahZvOJz" name="field.switch_to_locale">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:14</note>
+      </notes>
       <segment>
         <source>field.switch_to_locale</source>
         <target>切换语言</target>
       </segment>
     </unit>
     <unit id="aQX4Emy" name="field.author">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:32</note>
+        <note>templates/content/_fields_aside.html.twig:33</note>
+      </notes>
       <segment>
         <source>field.author</source>
         <target>作者</target>
       </segment>
     </unit>
     <unit id="UNBaDz." name="general.phrase.edit">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:26</note>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:4</note>
+        <note>templates/content/view_locales.html.twig:60</note>
+      </notes>
       <segment>
         <source>general.phrase.edit</source>
         <target>编辑</target>
       </segment>
     </unit>
     <unit id="t2TNwOq" name="Unknown">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:7</note>
+      </notes>
       <segment>
         <source>Unknown</source>
         <target>未知</target>
       </segment>
     </unit>
     <unit id="A_d5KPt" name="general.phrase.written-by-on">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:6</note>
+      </notes>
       <segment>
         <source>general.phrase.written-by-on</source>
         <target>由%name%于%date%所写。</target>
       </segment>
     </unit>
     <unit id="TVU.FCV" name="general.phrase.missing-about-page">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:33</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page</source>
         <target>"About" 页面丢失</target>
       </segment>
     </unit>
     <unit id="7iq8jIG" name="general.phrase.missing-about-page-block">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:35</note>
+      </notes>
       <segment>
         <source>general.phrase.missing-about-page-block</source>
         <target>"About" 页面的 block 丢失</target>
       </segment>
     </unit>
     <unit id="AGegYAN" name="contenttypes.generic.recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:53</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
         <target>最近的 %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:12</note>
+        <note>public/theme/skeleton/search.twig:23</note>
+      </notes>
       <segment>
         <source>general.phrase.search-ellipsis</source>
         <target>…</target>
       </segment>
     </unit>
     <unit id="wGlnx8X" name="general.phrase.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:9</note>
+        <note>public/theme/skeleton/search.twig:11</note>
+        <note>public/theme/skeleton/search.twig:24</note>
+        <note>templates/_base/layout.html.twig:44</note>
+      </notes>
       <segment>
         <source>general.phrase.search</source>
         <target>搜索</target>
       </segment>
     </unit>
-    <unit id="z0k8hRg" name="9fb3e6e">
-      <segment>
-        <source>9fb3e6e</source>
-        <target><![CDATA[This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
-      </segment>
-    </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:60</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
         <target>%contenttypes% 概述</target>
       </segment>
     </unit>
     <unit id="skuzBpI" name="contenttypes.generic.no-recent">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:62</note>
+      </notes>
       <segment>
         <source>contenttypes.generic.no-recent</source>
         <target>未找到最近的 %contenttype%</target>
       </segment>
     </unit>
     <unit id="ma9mBv_" name="Menu">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:4</note>
+      </notes>
       <segment>
         <source>Menu</source>
         <target>菜单</target>
       </segment>
     </unit>
     <unit id="ScJmuqq" name="Search">
+      <notes>
+        <note>src/DataFixtures/ContentFixtures.php:443</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:14</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:26</note>
+        <note>tests/cypress/integration/dashboard_globalsearch.spec.js:37</note>
+      </notes>
       <segment>
         <source>Search</source>
         <target>搜索</target>
       </segment>
     </unit>
     <unit id="k.xuYv2" name="general.phrase.permalink">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.permalink</source>
         <target>永久链接</target>
       </segment>
     </unit>
-    <unit id="zsyp43M" name="label.displayname">
-      <segment>
-        <source>label.displayname</source>
-        <target>显示名称</target>
-      </segment>
-    </unit>
     <unit id="2MMvCKK" name="label.cache_cleared">
+      <notes>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+      </notes>
       <segment>
         <source>label.cache_cleared</source>
         <target>缓存清除成功！</target>
       </segment>
     </unit>
     <unit id="Wou02nK" name="caption.kitchensink">
-      <segment>
-        <source>caption.kitchensink</source>
-        <target>The Kitchensink</target>
-      </segment>
-    </unit>
-    <unit id="wrUiAsV" name="general.phrase.search-results-for-variable">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': consequatur</note>
+        <note>src/Menu/BackendMenuBuilder.php:238</note>
       </notes>
       <segment>
-        <source>general.phrase.search-results-for-variable</source>
-        <target>'%search%'的搜索结果。</target>
+        <source>caption.kitchensink</source>
+        <target>综合示例页</target>
       </segment>
     </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%search%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:11</note>
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
@@ -1003,8 +1010,7 @@
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
       <notes>
-        <note>parameters:</note>
-        <note> '%SEARCHTERM%': ymnrubeyrvwearsytevsf</note>
+        <note>public/theme/skeleton/search.twig:51</note>
       </notes>
       <segment>
         <source>general.phrase.no-search-results-for</source>
@@ -1012,1665 +1018,2420 @@
       </segment>
     </unit>
     <unit id="_KyvT9o" name="general.phrase.no-search-term-provided">
+      <notes>
+        <note>public/theme/skeleton/search.twig:53</note>
+      </notes>
       <segment>
         <source>general.phrase.no-search-term-provided</source>
         <target>请提供关键词，以显示相关结果。</target>
       </segment>
     </unit>
     <unit id="Pily_qo" name="general.phrase.read-more">
+      <notes>
+        <note>public/theme/skeleton/partials/_aside.twig:23</note>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:10</note>
+      </notes>
       <segment>
         <source>general.phrase.read-more</source>
         <target>阅读更多</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:17</note>
+      </notes>
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[This website is <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
+        <target><![CDATA[本网站<a href='https://boltcms.io' target='_blank' title='精致、轻量且简单的 CMS'>由 Bolt 构建</a>。]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
+      <notes>
+        <note>vendor/bolt/newswidget/templates/news.html.twig:3</note>
+      </notes>
       <segment>
         <source>general.latest_bolt_news</source>
-        <target>Latest Bolt News</target>
+        <target>Bolt 最新动态</target>
       </segment>
     </unit>
     <unit id="dQIY7_J" name="action.preview">
+      <notes>
+        <note>templates/content/_buttons.html.twig:19</note>
+      </notes>
       <segment>
         <source>action.preview</source>
         <target>预览</target>
       </segment>
     </unit>
     <unit id="ok6YulQ" name="action.view_saved">
+      <notes>
+        <note>templates/content/_buttons.html.twig:58</note>
+      </notes>
       <segment>
         <source>action.view_saved</source>
         <target>查看已保存版本</target>
       </segment>
     </unit>
     <unit id="SeTqePC" name="label.display_name">
+      <notes>
+        <note>templates/users/_form.html.twig:26</note>
+        <note>templates/users/profile.html.twig:33</note>
+      </notes>
       <segment>
         <source>label.display_name</source>
         <target>显示名称</target>
       </segment>
     </unit>
     <unit id="EvAqL__" name="caption.duplicate">
+      <notes>
+        <note>templates/content/edit.html.twig:22</note>
+      </notes>
       <segment>
         <source>caption.duplicate</source>
-        <target>Duplicate</target>
-      </segment>
-    </unit>
-    <unit id="pGkejkU" name="label.current_password">
-      <segment>
-        <source>label.current_password</source>
-        <target>当前密码</target>
+        <target>复制</target>
       </segment>
     </unit>
     <unit id="iiWFLaI" name="label.new_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:40</note>
+      </notes>
       <segment>
         <source>label.new_password</source>
         <target>新密码</target>
       </segment>
     </unit>
-    <unit id="Ucl9Jfc" name="label.new_password_confirm">
-      <segment>
-        <source>label.new_password_confirm</source>
-        <target>新密码（确认）</target>
-      </segment>
-    </unit>
     <unit id="Iyry5.g" name="editfile.updated_successfully">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+      </notes>
       <segment>
         <source>editfile.updated_successfully</source>
         <target>文件更新成功！</target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">
+      <notes>
+        <note>templates/users/add.html.twig:6</note>
+        <note>templates/users/listing.html.twig:109</note>
+        <note>templates/users/listing.html.twig:176</note>
+      </notes>
       <segment>
         <source>action.add_user</source>
         <target>添加用户</target>
       </segment>
     </unit>
     <unit id="ruQIhH0" name="success">
+      <notes>
+        <note>assets/js/app/ajax-save.js:93</note>
+        <note>assets/js/app/ajax-save.js:97</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ClearCacheController.php:24</note>
+        <note>src/Controller/Backend/ContentEditController.php:196</note>
+        <note>src/Controller/Backend/ContentEditController.php:197</note>
+        <note>src/Controller/Backend/ContentEditController.php:208</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+        <note>src/Controller/Backend/FileEditController.php:104</note>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+        <note>src/Controller/Backend/FileEditController.php:188</note>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+        <note>src/Controller/Backend/GeneralController.php:48</note>
+        <note>src/Controller/Backend/MediaEditController.php:64</note>
+        <note>src/Controller/Backend/MediaEditController.php:88</note>
+        <note>src/Controller/Backend/UserEditController.php:129</note>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+        <note>src/Twig/Notifications.php:21</note>
+        <note>templates/media/edit.html.twig:95</note>
+        <note>templates/pages/kitchensink.html.twig:81</note>
+        <note>templates/pages/kitchensink.html.twig:88</note>
+      </notes>
       <segment>
         <source>success</source>
         <target>成功！</target>
       </segment>
     </unit>
     <unit id="YDH.7uR" name="user.updated_profile">
+      <notes>
+        <note>src/Controller/Backend/UserEditController.php:161</note>
+        <note>src/Controller/Backend/UserEditController.php:193</note>
+      </notes>
       <segment>
         <source>user.updated_profile</source>
         <target>用户资料已更新！</target>
       </segment>
     </unit>
     <unit id="iD6CNOO" name="label.roles">
+      <notes>
+        <note>templates/users/_form.html.twig:124</note>
+      </notes>
       <segment>
         <source>label.roles</source>
         <target>角色</target>
       </segment>
     </unit>
     <unit id="7whLbH8" name="user.new_user">
+      <notes>
+        <note>templates/users/add.html.twig:11</note>
+        <note>templates/users/edit.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.new_user</source>
         <target>新用户</target>
       </segment>
     </unit>
     <unit id="TtmWqX3" name="action.view">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:9</note>
+        <note>templates/_base/layout.html.twig:93</note>
+      </notes>
       <segment>
         <source>action.view</source>
         <target>查看</target>
       </segment>
     </unit>
-    <unit id="I2ykiIZ" name="caption.folders">
-      <segment>
-        <source>caption.folders</source>
-        <target>文件夹</target>
-      </segment>
-    </unit>
     <unit id="kaK5Wdr" name="slug.button_locked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:18</note>
+      </notes>
       <segment>
         <source>slug.button_locked</source>
         <target>锁定</target>
       </segment>
     </unit>
     <unit id="qcDEz5O" name="slug.button_edit">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:19</note>
+      </notes>
       <segment>
         <source>slug.button_edit</source>
         <target>编辑</target>
       </segment>
     </unit>
     <unit id="raO5QSf" name="slug.generate_from">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:20</note>
+      </notes>
       <segment>
         <source>slug.generate_from</source>
         <target>来源:</target>
       </segment>
     </unit>
     <unit id="vptPhch" name="image.button_upload">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:16</note>
+        <note>templates/_partials/fields/filelist.html.twig:16</note>
+        <note>templates/_partials/fields/image.html.twig:17</note>
+        <note>templates/_partials/fields/imagelist.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:13</note>
+        <note>templates/_partials/fields/simple_image.html.twig:58</note>
+      </notes>
       <segment>
         <source>image.button_upload</source>
         <target>上传</target>
       </segment>
     </unit>
     <unit id="vIVO1lU" name="image.button_from_library">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:18</note>
+        <note>templates/_partials/fields/filelist.html.twig:18</note>
+        <note>templates/_partials/fields/image.html.twig:19</note>
+        <note>templates/_partials/fields/imagelist.html.twig:18</note>
+        <note>templates/_partials/fields/simple_image.html.twig:14</note>
+        <note>templates/_partials/fields/simple_image.html.twig:59</note>
+      </notes>
       <segment>
         <source>image.button_from_library</source>
-        <target>From library</target>
+        <target>从媒体库选择</target>
       </segment>
     </unit>
     <unit id="L0TE0M9" name="listing_table.actions.view_on_site">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing_table.actions.view_on_site</source>
         <target>查看网站</target>
       </segment>
     </unit>
     <unit id="PoauAuK" name="listing_table.actions.status_to_publish">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:24</note>
+        <note>templates/_partials/_content_listing.html.twig:27</note>
+        <note>templates/content/listing.html.twig:43</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_publish</source>
         <target>将状态更改为“发布”</target>
       </segment>
     </unit>
     <unit id="ZJxfdD6" name="listing_table.actions.status_to_held">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:25</note>
+        <note>templates/content/listing.html.twig:42</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_held</source>
         <target>将状态更改为“保留”</target>
       </segment>
     </unit>
     <unit id="apyOs0o" name="listing_table.actions.status_to_draft">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:26</note>
+        <note>templates/content/listing.html.twig:41</note>
+      </notes>
       <segment>
         <source>listing_table.actions.status_to_draft</source>
         <target>将状态更改为“草稿”</target>
       </segment>
     </unit>
     <unit id="5H60Xq6" name="listing_table.actions.duplicate">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:28</note>
+      </notes>
       <segment>
         <source>listing_table.actions.duplicate</source>
-        <target>Duplicate</target>
+        <target>复制</target>
       </segment>
     </unit>
     <unit id="hR8ri.m" name="listing_table.actions.delete">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:29</note>
+      </notes>
       <segment>
         <source>listing_table.actions.delete</source>
         <target>删除</target>
       </segment>
     </unit>
     <unit id="5zbX1vo" name="listing_table.actions.slug">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:30</note>
+      </notes>
       <segment>
         <source>listing_table.actions.slug</source>
         <target>Slug</target>
       </segment>
     </unit>
     <unit id="wKDOBOC" name="listing_table.actions.created_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:31</note>
+      </notes>
       <segment>
         <source>listing_table.actions.created_on</source>
         <target>创建于</target>
       </segment>
     </unit>
     <unit id="tVX01Xl" name="listing_table.actions.published_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:32</note>
+      </notes>
       <segment>
         <source>listing_table.actions.published_on</source>
         <target>发布于</target>
       </segment>
     </unit>
     <unit id="kHkjS5U" name="listing_table.actions.last_modified_on">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing_table.actions.last_modified_on</source>
         <target>最后修改</target>
       </segment>
     </unit>
     <unit id="BdhsE_X" name="listing_select_box.card_header.selected">
+      <notes>
+        <note>templates/content/listing.html.twig:40</note>
+      </notes>
       <segment>
         <source>listing_select_box.card_header.selected</source>
         <target>最后修改于</target>
       </segment>
     </unit>
-    <unit id="jBpmj90" name="listing_select_box.card_body.records_passed">
-      <segment>
-        <source>listing_select_box.card_body.records_passed</source>
-        <target>selected record ids passed</target>
-      </segment>
-    </unit>
-    <unit id="D8vDkhK" name="listing_select_box.card_body.remark">
-      <segment>
-        <source>listing_select_box.card_body.remark</source>
-        <target>(these can be used with something like axios to bulk modify/delete)</target>
-      </segment>
-    </unit>
     <unit id="kHeY93_" name="editor_embed.content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:20</note>
+      </notes>
       <segment>
         <source>editor_embed.content_url</source>
         <target>要嵌入内容的URL</target>
       </segment>
     </unit>
     <unit id="VoIdmBa" name="editor_embed.placeholder_content_url">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:21</note>
+      </notes>
       <segment>
         <source>editor_embed.placeholder_content_url</source>
-        <target>URL of content on Facebook, Twitter, Soundcloud, Youtube, Vimeo…</target>
+        <target>Facebook、Twitter、Soundcloud、Youtube、Vimeo 等平台上的内容 URL…</target>
       </segment>
     </unit>
     <unit id="1.Eb1GS" name="editor_embed.label_height">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:22</note>
+      </notes>
       <segment>
         <source>editor_embed.label_height</source>
         <target>高度</target>
       </segment>
     </unit>
     <unit id="eWLSFJs" name="editor_embed.label_pixel">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:23</note>
+      </notes>
       <segment>
         <source>editor_embed.label_pixel</source>
         <target>像素</target>
       </segment>
     </unit>
     <unit id="EAtXrAm" name="editor_embed.label_matched_embed">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:24</note>
+      </notes>
       <segment>
         <source>editor_embed.label_matched_embed</source>
         <target>匹配嵌入</target>
       </segment>
     </unit>
     <unit id="zATju4V" name="editor_embed.label_preview">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:25</note>
+      </notes>
       <segment>
         <source>editor_embed.label_preview</source>
         <target>预览</target>
       </segment>
     </unit>
     <unit id="9SQ0oaR" name="editor_embed.label_size">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:26</note>
+      </notes>
       <segment>
         <source>editor_embed.label_size</source>
         <target>尺寸</target>
       </segment>
     </unit>
     <unit id="oOuVKRv" name="image.placeholder_filename">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:20</note>
+        <note>templates/_partials/fields/filelist.html.twig:19</note>
+        <note>templates/_partials/fields/image.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:16</note>
+        <note>templates/_partials/fields/simple_image.html.twig:61</note>
+      </notes>
       <segment>
         <source>image.placeholder_filename</source>
         <target>文件名（上传新文件，或选择现有文件）</target>
       </segment>
     </unit>
     <unit id="BWubOnS" name="image.placeholder_alt_text">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:21</note>
+        <note>templates/_partials/fields/filelist.html.twig:20</note>
+        <note>templates/_partials/fields/image.html.twig:22</note>
+        <note>templates/_partials/fields/imagelist.html.twig:20</note>
+        <note>templates/_partials/fields/simple_image.html.twig:17</note>
+        <note>templates/_partials/fields/simple_image.html.twig:62</note>
+      </notes>
       <segment>
         <source>image.placeholder_alt_text</source>
         <target>Alt属性</target>
       </segment>
     </unit>
     <unit id="VPV0lFM" name="image.placeholder_title">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:22</note>
+        <note>templates/_partials/fields/filelist.html.twig:21</note>
+        <note>templates/_partials/fields/imagelist.html.twig:21</note>
+        <note>templates/_partials/fields/simple_image.html.twig:18</note>
+      </notes>
       <segment>
         <source>image.placeholder_title</source>
         <target>标题属性</target>
       </segment>
     </unit>
     <unit id="Gabafxx" name="admin_sidebar.toggler">
+      <notes>
+        <note>templates/_base/layout.html.twig:91</note>
+      </notes>
       <segment>
         <source>admin_sidebar.toggler</source>
         <target>侧边栏宽度</target>
       </segment>
     </unit>
     <unit id="jXAelLe" name="admin_sidebar_toggler.toggle">
+      <notes>
+        <note>templates/_base/layout.html.twig:82</note>
+      </notes>
       <segment>
         <source>admin_sidebar_toggler.toggle</source>
         <target><![CDATA[<span class="sr-only">切换 </span>menu]]></target>
       </segment>
     </unit>
     <unit id="BINgtmK" name="editor_date.toggle">
+      <notes>
+        <note>templates/_partials/fields/date.html.twig:39</note>
+      </notes>
       <segment>
         <source>editor_date.toggle</source>
         <target>切换</target>
       </segment>
     </unit>
-    <unit id="VQ2t655" name="file.label_filename">
-      <segment>
-        <source>file.label_filename</source>
-        <target>文件名</target>
-      </segment>
-    </unit>
-    <unit id="tvpSmD7" name="file.label_title">
-      <segment>
-        <source>file.label_title</source>
-        <target>标题</target>
-      </segment>
-    </unit>
-    <unit id="hXT_hI." name="file.button_view">
-      <segment>
-        <source>file.button_view</source>
-        <target>查看图片</target>
-      </segment>
-    </unit>
-    <unit id="QKIqqOw" name="file.button_upload">
-      <segment>
-        <source>file.button_upload</source>
-        <target>上传图片</target>
-      </segment>
-    </unit>
-    <unit id="4_JdYp1" name="file.remark">
-      <segment>
-        <source>file.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>image</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="TJDc9vQ" name="file.label_alt">
-      <segment>
-        <source>file.label_alt</source>
-        <target>Alt</target>
-      </segment>
-    </unit>
-    <unit id="M.3olSc" name="filelist.remark">
-      <segment>
-        <source>filelist.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>imagelist</code>-field.]]></target>
-      </segment>
-    </unit>
-    <unit id="zg5Dum5" name="geolocation.label_geolocation">
-      <segment>
-        <source>geolocation.label_geolocation</source>
-        <target>地理位置:</target>
-      </segment>
-    </unit>
-    <unit id="Com0pbc" name="geolocation.label_address">
-      <segment>
-        <source>geolocation.label_address</source>
-        <target>地址搜索</target>
-      </segment>
-    </unit>
-    <unit id="3o0LPHj" name="geolocation.placeholder_address">
-      <segment>
-        <source>geolocation.placeholder_address</source>
-        <target>街道、邮政编码、城市或其他位置…</target>
-      </segment>
-    </unit>
-    <unit id="CC5QTmy" name="geolocation.label_lat">
-      <segment>
-        <source>geolocation.label_lat</source>
-        <target>纬度</target>
-      </segment>
-    </unit>
-    <unit id="MJ5WYEM" name="geolocation.label_address_matched">
-      <segment>
-        <source>geolocation.label_address_matched</source>
-        <target>地址匹配</target>
-      </segment>
-    </unit>
-    <unit id="WJGjWG8" name="geolocation.label_marker">
-      <segment>
-        <source>geolocation.label_marker</source>
-        <target>标记位置</target>
-      </segment>
-    </unit>
-    <unit id="SaP3OOf" name="geolocation.label_control">
-      <segment>
-        <source>geolocation.label_control</source>
-        <target>最近的地址</target>
-      </segment>
-    </unit>
-    <unit id="AHaenW3" name="geolocation.label_long">
-      <segment>
-        <source>geolocation.label_long</source>
-        <target>经度</target>
-      </segment>
-    </unit>
-    <unit id="TkryUve" name="imagelist.remark">
-      <segment>
-        <source>imagelist.remark</source>
-        <target><![CDATA[Note: This field is practically the same as the <code>filelist</code>-field.]]></target>
-      </segment>
-    </unit>
     <unit id="z2AgHGp" name="flash_messages.notification">
+      <notes>
+        <note>src/Controller/Backend/ContentEditController.php:199</note>
+        <note>templates/_partials/_flash_messages.html.twig:8</note>
+      </notes>
       <segment>
         <source>flash_messages.notification</source>
         <target>通知</target>
       </segment>
     </unit>
-    <unit id="qQKx1lR" name="buttons.button_toggle">
-      <segment>
-        <source>buttons.button_toggle</source>
-        <target>Toggle Dropdown</target>
-      </segment>
-    </unit>
     <unit id="ypPzS03" name="localeswitcher.button_info">
+      <notes>
+        <note>templates/content/_localeswitcher.html.twig:19</note>
+      </notes>
       <segment>
         <source>localeswitcher.button_info</source>
         <target>查看本地化信息</target>
       </segment>
     </unit>
     <unit id="wQ0WYAT" name="listing.title_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:69</note>
+        <note>templates/content/listing.html.twig:70</note>
+        <note>templates/users/listing.html.twig:190</note>
+        <note>templates/users/listing.html.twig:191</note>
+      </notes>
       <segment>
         <source>listing.title_sortby</source>
         <target>排序方式</target>
       </segment>
     </unit>
-    <unit id="ZGv90X8" name="listing.option_select_item">
-      <segment>
-        <source>listing.option_select_item</source>
-        <target>选择项目</target>
-      </segment>
-    </unit>
-    <unit id="TIyjgb6" name="listing.title_title">
-      <segment>
-        <source>listing.title_title</source>
-        <target>标题</target>
-      </segment>
-    </unit>
     <unit id="pn22p7q" name="listing.placeholder_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:106</note>
+        <note>templates/users/listing.html.twig:214</note>
+        <note>templates/users/listing.html.twig:215</note>
+      </notes>
       <segment>
         <source>listing.placeholder_filter</source>
         <target>筛选关键字…</target>
       </segment>
     </unit>
     <unit id="ni4zApC" name="listing.button_filter">
+      <notes>
+        <note>templates/content/listing.html.twig:123</note>
+        <note>templates/users/listing.html.twig:220</note>
+      </notes>
       <segment>
         <source>listing.button_filter</source>
         <target>筛选</target>
       </segment>
     </unit>
     <unit id="doNsgm0" name="listing.button_clear">
+      <notes>
+        <note>templates/content/listing.html.twig:126</note>
+        <note>templates/users/listing.html.twig:223</note>
+      </notes>
       <segment>
         <source>listing.button_clear</source>
         <target>清除排序/筛选</target>
       </segment>
     </unit>
     <unit id="37kJiIe" name="view_locales.badge_default">
+      <notes>
+        <note>templates/content/view_locales.html.twig:99</note>
+      </notes>
       <segment>
         <source>view_locales.badge_default</source>
         <target>默认</target>
       </segment>
     </unit>
     <unit id="JTRCo_U" name="view_locales.badge_ok">
+      <notes>
+        <note>templates/content/view_locales.html.twig:105</note>
+      </notes>
       <segment>
         <source>view_locales.badge_ok</source>
         <target>OK</target>
       </segment>
     </unit>
     <unit id="ufFUPp7" name="view_locales.badge_missing">
+      <notes>
+        <note>templates/content/view_locales.html.twig:101</note>
+      </notes>
       <segment>
         <source>view_locales.badge_missing</source>
-        <target>Missing</target>
+        <target>缺失</target>
       </segment>
     </unit>
     <unit id="QQvRJe." name="files_cards.button_toggle">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:10</note>
+      </notes>
       <segment>
         <source>files_cards.button_toggle</source>
-        <target>Toggle Dropdown</target>
+        <target>切换下拉菜单</target>
       </segment>
     </unit>
     <unit id="gtC_ujD" name="files_cards.action_edit_image_info">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:17</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_image_info</source>
         <target>编辑图片信息</target>
       </segment>
     </unit>
     <unit id="5LXvJfE" name="files_cards.action_edit_file">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:19</note>
+      </notes>
       <segment>
         <source>files_cards.action_edit_file</source>
         <target>在编辑器中编辑文件</target>
       </segment>
     </unit>
     <unit id="H1pgP94" name="files_cards.action_view_original">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:25</note>
+      </notes>
       <segment>
         <source>files_cards.action_view_original</source>
         <target>查看原件</target>
       </segment>
     </unit>
     <unit id="ZoY6ADX" name="files_cards.action_duplicate">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:36</note>
+      </notes>
       <segment>
         <source>files_cards.action_duplicate</source>
-        <target>Duplicate</target>
+        <target>复制</target>
       </segment>
     </unit>
     <unit id="JjU6ZQP" name="files_cards.action_delete">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:49</note>
+      </notes>
       <segment>
         <source>files_cards.action_delete</source>
         <target>删除</target>
       </segment>
     </unit>
     <unit id="3jdNwuk" name="files_cards.label_filename">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:56</note>
+      </notes>
       <segment>
         <source>files_cards.label_filename</source>
         <target>文件名:</target>
       </segment>
     </unit>
     <unit id="Y90_Pn1" name="files_cards.label_title">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:63</note>
+      </notes>
       <segment>
         <source>files_cards.label_title</source>
         <target>标题:</target>
       </segment>
     </unit>
     <unit id="EdCfIKX" name="files_cards.label_dimensions">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:70</note>
+      </notes>
       <segment>
         <source>files_cards.label_dimensions</source>
         <target>尺寸:</target>
       </segment>
     </unit>
     <unit id="eQBhceV" name="files_cards.label_filesize">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:76</note>
+      </notes>
       <segment>
         <source>files_cards.label_filesize</source>
         <target>文件大小:</target>
       </segment>
     </unit>
     <unit id="uiCjlwk" name="files_cards.label_created_on">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:81</note>
+      </notes>
       <segment>
         <source>files_cards.label_created_on</source>
         <target>创建于:</target>
       </segment>
     </unit>
     <unit id=".fL0AbE" name="files_list.remark">
+      <notes>
+        <note>templates/finder/_files_list.html.twig:75</note>
+      </notes>
       <segment>
         <source>files_list.remark</source>
         <target>此文件夹中没有文件。选择要导航到的文件夹。</target>
       </segment>
     </unit>
     <unit id="v6cfPyt" name="quickselect.title_select">
+      <notes>
+        <note>templates/finder/_quickselect.html.twig:5</note>
+      </notes>
       <segment>
         <source>quickselect.title_select</source>
         <target>选择文件:</target>
       </segment>
     </unit>
     <unit id="m3tNvJb" name="finder.button_list">
+      <notes>
+        <note>templates/finder/finder.html.twig:45</note>
+      </notes>
       <segment>
         <source>finder.button_list</source>
         <target>列表</target>
       </segment>
     </unit>
     <unit id="tRLgeoX" name="finder.button_cards">
+      <notes>
+        <note>templates/finder/finder.html.twig:49</note>
+      </notes>
       <segment>
         <source>finder.button_cards</source>
         <target>卡片</target>
       </segment>
     </unit>
     <unit id="nrWBJNm" name="extensions.title_desc">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:24</note>
+        <note>templates/pages/extension_details.html.twig:51</note>
+        <note>templates/pages/extensions.html.twig:27</note>
+        <note>templates/pages/extensions.html.twig:44</note>
+      </notes>
       <segment>
         <source>extensions.title_desc</source>
         <target>描述:</target>
       </segment>
     </unit>
     <unit id="7raDJAR" name="extensions.title_author">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:26</note>
+        <note>templates/pages/extensions.html.twig:29</note>
+      </notes>
       <segment>
         <source>extensions.title_author</source>
         <target>作者:</target>
       </segment>
     </unit>
     <unit id="UP8pNGy" name="extensions.title_package">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:28</note>
+        <note>templates/pages/extensions.html.twig:31</note>
+      </notes>
       <segment>
         <source>extensions.title_package</source>
-        <target>Package / Class name:</target>
+        <target>包 / 类名：</target>
       </segment>
     </unit>
     <unit id="QFQ1uTC" name="extensions.title_version">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:34</note>
+        <note>templates/pages/extensions.html.twig:37</note>
+      </notes>
       <segment>
         <source>extensions.title_version</source>
         <target>版本:</target>
       </segment>
     </unit>
     <unit id="piuatxC" name="extensions.info_not_installed">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:52</note>
+        <note>templates/pages/extensions.html.twig:45</note>
+      </notes>
       <segment>
         <source>extensions.info_not_installed</source>
         <target>这是一个本地包，不是通过 Composer 安装的</target>
       </segment>
     </unit>
     <unit id="3j1gEmk" name="extensions.title_class">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:53</note>
+        <note>templates/pages/extensions.html.twig:46</note>
+      </notes>
       <segment>
         <source>extensions.title_class</source>
-        <target>Class name:</target>
+        <target>类名：</target>
       </segment>
     </unit>
     <unit id="mjhFljb" name="extensions.button_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:62</note>
+        <note>templates/pages/extensions.html.twig:58</note>
+      </notes>
       <segment>
         <source>extensions.button_configuration</source>
         <target>配置</target>
       </segment>
     </unit>
     <unit id="r3ryNTG" name="extensions.button_source">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:67</note>
+        <note>templates/pages/extensions.html.twig:63</note>
+      </notes>
       <segment>
         <source>extensions.button_source</source>
-        <target>Source</target>
+        <target>源码</target>
       </segment>
     </unit>
     <unit id="qc3rFkZ" name="extensions.button_remove">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:74</note>
+      </notes>
       <segment>
         <source>extensions.button_remove</source>
         <target>删除扩展</target>
       </segment>
     </unit>
     <unit id="SLZyVzU" name="extensions.button_disable">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:91</note>
+        <note>templates/pages/extensions.html.twig:86</note>
+      </notes>
       <segment>
         <source>extensions.button_disable</source>
         <target>禁用扩展</target>
       </segment>
     </unit>
     <unit id="beqzCkE" name="login.header_login">
+      <notes>
+        <note>templates/security/login.html.twig:40</note>
+      </notes>
       <segment>
         <source>login.header_login</source>
         <target>Bolt » 登录</target>
       </segment>
     </unit>
     <unit id="7JK6jNv" name="extensions.message_not_implemented">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:72</note>
+        <note>templates/pages/extension_details.html.twig:73</note>
+        <note>templates/pages/extension_details.html.twig:84</note>
+        <note>templates/pages/extension_details.html.twig:85</note>
+        <note>templates/pages/extensions.html.twig:68</note>
+        <note>templates/pages/extensions.html.twig:69</note>
+        <note>templates/pages/extensions.html.twig:79</note>
+        <note>templates/pages/extensions.html.twig:80</note>
+      </notes>
       <segment>
         <source>extensions.message_not_implemented</source>
         <target>尚未实现，对不起！</target>
       </segment>
     </unit>
     <unit id="Hlf9c1s" name="listing.title_overview">
+      <notes>
+        <note>templates/content/listing.html.twig:6</note>
+      </notes>
       <segment>
         <source>listing.title_overview</source>
         <target>概述</target>
       </segment>
     </unit>
     <unit id="8JeahIj" name="files_cards.message_no_files">
+      <notes>
+        <note>templates/finder/_files_cards.html.twig:48</note>
+      </notes>
       <segment>
         <source>files_cards.message_no_files</source>
         <target>此文件夹中没有文件，请在右侧选择要导航到的文件夹</target>
       </segment>
     </unit>
     <unit id="pcq1NGk" name="listing_filter.button_compact">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>listing_filter.button_compact</source>
         <target>紧凑</target>
       </segment>
     </unit>
     <unit id="xIztVmp" name="listing_filter.button_expanded">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:14</note>
+      </notes>
       <segment>
         <source>listing_filter.button_expanded</source>
         <target>展开</target>
       </segment>
     </unit>
     <unit id="73A2bWM" name="finder.label_view">
+      <notes>
+        <note>templates/finder/finder.html.twig:41</note>
+      </notes>
       <segment>
         <source>finder.label_view</source>
         <target>查看:</target>
       </segment>
     </unit>
     <unit id="Em.C0bV" name="listing_table.actions.button_edit">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:34</note>
+      </notes>
       <segment>
         <source>listing_table.actions.button_edit</source>
         <target>编辑</target>
       </segment>
     </unit>
     <unit id="Iy4HXCU" name="controller.user.title">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:50</note>
+      </notes>
       <segment>
         <source>controller.user.title</source>
-        <target><![CDATA[用户和权限]]></target>
+        <target>用户和权限</target>
       </segment>
     </unit>
     <unit id="HBwIQ9b" name="controller.user.subtitle">
+      <notes>
+        <note>src/Controller/Backend/UserController.php:51</note>
+      </notes>
       <segment>
         <source>controller.user.subtitle</source>
         <target>编辑用户及其权限</target>
       </segment>
     </unit>
-    <unit id="0Gyf5xr" name="controller.database.check_title">
-      <segment>
-        <source>controller.database.check_title</source>
-        <target>数据库检查</target>
-      </segment>
-    </unit>
-    <unit id="SeDwjX6" name="controller.database.check_subtitle">
-      <segment>
-        <source>controller.database.check_subtitle</source>
-        <target>检查数据库</target>
-      </segment>
-    </unit>
-    <unit id="nJnALPG" name="controller.database.update_title">
-      <segment>
-        <source>controller.database.update_title</source>
-        <target>数据库更新</target>
-      </segment>
-    </unit>
-    <unit id="nRE74_i" name="controller.database.update_subtitle">
-      <segment>
-        <source>controller.database.update_subtitle</source>
-        <target>更新数据库</target>
-      </segment>
-    </unit>
-    <unit id="a3UNsKw" name="controller.omnisearch.title">
-      <segment>
-        <source>controller.omnisearch.title</source>
-        <target>Omnisearch</target>
-      </segment>
-    </unit>
-    <unit id="4N41oTU" name="controller.omnisearch.subtitle">
-      <segment>
-        <source>controller.omnisearch.subtitle</source>
-        <target>To search, in an omni-like fashion</target>
-      </segment>
-    </unit>
     <unit id="7cXqH5s" name="listing.title_display_name">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_display_name</source>
         <target>显示名称</target>
       </segment>
     </unit>
     <unit id="Ay7xZ2h" name="listing.title_username">
+      <notes>
+        <note>templates/users/listing.html.twig:19</note>
+        <note>templates/users/listing.html.twig:122</note>
+      </notes>
       <segment>
         <source>listing.title_username</source>
         <target>用户名</target>
       </segment>
     </unit>
     <unit id="RN1tdtJ" name="listing.title_email">
+      <notes>
+        <note>templates/users/listing.html.twig:20</note>
+      </notes>
       <segment>
         <source>listing.title_email</source>
-        <target>Email</target>
+        <target>电子邮箱</target>
       </segment>
     </unit>
     <unit id="0pjZ.GV" name="listing.title_roles">
+      <notes>
+        <note>templates/users/listing.html.twig:21</note>
+      </notes>
       <segment>
         <source>listing.title_roles</source>
         <target>角色</target>
       </segment>
     </unit>
     <unit id="hXEFV1n" name="listing.title_last_seen">
+      <notes>
+        <note>templates/users/listing.html.twig:22</note>
+        <note>templates/users/listing.html.twig:123</note>
+      </notes>
       <segment>
         <source>listing.title_last_seen</source>
-        <target>Session age</target>
+        <target>会话时长</target>
       </segment>
     </unit>
     <unit id="pn7kE17" name="listing.title_last_ip">
+      <notes>
+        <note>templates/users/listing.html.twig:23</note>
+      </notes>
       <segment>
         <source>listing.title_last_ip</source>
-        <target>Last IP</target>
+        <target>最后 IP</target>
       </segment>
     </unit>
     <unit id="GZ65uOC" name="listing.title_actions">
+      <notes>
+        <note>templates/users/listing.html.twig:24</note>
+      </notes>
       <segment>
         <source>listing.title_actions</source>
-        <target>Actions</target>
-      </segment>
-    </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>无效的电子邮件</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>无效的密码，密码应至少包含6个字符。</target>
+        <target>操作</target>
       </segment>
     </unit>
     <unit id="TpGxDI3" name="user.unknown_user">
+      <notes>
+        <note>templates/users/profile.html.twig:11</note>
+      </notes>
       <segment>
         <source>user.unknown_user</source>
         <target>未知的用户</target>
       </segment>
     </unit>
     <unit id="EaqUUfe" name="label.predominant_colors__in_image">
+      <notes>
+        <note>templates/media/edit.html.twig:114</note>
+      </notes>
       <segment>
         <source>label.predominant_colors__in_image</source>
         <target>图像中的主色</target>
       </segment>
     </unit>
     <unit id="8RPjZ5w" name="general.phrase.overview-for">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:14</note>
+      </notes>
       <segment>
         <source>general.phrase.overview-for</source>
         <target>'%slug%' 概述</target>
       </segment>
     </unit>
     <unit id="6mze9DI" name="general.phrase.related-content">
+      <notes>
+        <note>public/theme/skeleton/partials/_recordfooter.twig:40</note>
+      </notes>
       <segment>
         <source>general.phrase.related-content</source>
         <target>相关内容</target>
       </segment>
     </unit>
     <unit id="odDw0du" name="action.search">
+      <notes>
+        <note>public/theme/skeleton/partials/_footer.twig:13</note>
+      </notes>
       <segment>
         <source>action.search</source>
         <target>搜索</target>
       </segment>
     </unit>
     <unit id="QoeqyPT" name="caption.new_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:17</note>
+        <note>templates/content/view_locales.html.twig:11</note>
+      </notes>
       <segment>
         <source>caption.new_contenttype</source>
         <target>新 %contenttype%</target>
       </segment>
     </unit>
     <unit id="n.jOrkg" name="caption.untitled_contenttype">
+      <notes>
+        <note>templates/content/edit.html.twig:13</note>
+        <note>templates/content/view_locales.html.twig:10</note>
+      </notes>
       <segment>
         <source>caption.untitled_contenttype</source>
         <target>未命名的 %contenttype%</target>
       </segment>
     </unit>
     <unit id="Dgtkgju" name="title.edit_user_profile">
+      <notes>
+        <note>templates/users/profile.html.twig:6</note>
+      </notes>
       <segment>
         <source>title.edit_user_profile</source>
         <target>编辑用户资料</target>
       </segment>
     </unit>
     <unit id="rCKtTo5" name="caption.redirection_page">
+      <notes>
+        <note>templates/pages/menupage.html.twig:13</note>
+      </notes>
       <segment>
         <source>caption.redirection_page</source>
         <target>页面重定向</target>
       </segment>
     </unit>
     <unit id="TtIlBDd" name="caption.edit_image">
+      <notes>
+        <note>templates/media/edit.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.edit_image</source>
         <target>编辑图片</target>
       </segment>
     </unit>
-    <unit id="MClSUET" name="general.phrase.select_language">
-      <segment>
-        <source>general.phrase.select_language</source>
-        <target>选择语言</target>
-      </segment>
-    </unit>
     <unit id="hiE9jap" name="password.suggested">
+      <notes>
+        <note>templates/users/_form.html.twig:44</note>
+      </notes>
       <segment>
         <source>password.suggested</source>
         <target><![CDATA[建议安全密码: <code>%password%</code>]]></target>
       </segment>
     </unit>
     <unit id="fLOd6Zd" name="field.cropX">
+      <notes>
+        <note>templates/media/edit.html.twig:70</note>
+      </notes>
       <segment>
         <source>field.cropX</source>
         <target>裁剪 X</target>
       </segment>
     </unit>
     <unit id="Sd_AbmV" name="field.cropXPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:73</note>
+      </notes>
       <segment>
         <source>field.cropXPostfix</source>
         <target>X轴裁剪范围：0-100</target>
       </segment>
     </unit>
     <unit id="BQBmQHT" name="field.cropYPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:80</note>
+      </notes>
       <segment>
         <source>field.cropYPostfix</source>
         <target>Y轴裁剪范围：0-100</target>
       </segment>
     </unit>
     <unit id="hi98HIj" name="field.cropY">
+      <notes>
+        <note>templates/media/edit.html.twig:77</note>
+      </notes>
       <segment>
         <source>field.cropY</source>
         <target>裁剪 Y</target>
       </segment>
     </unit>
     <unit id="PHOpD5y" name="field.cropZoom">
+      <notes>
+        <note>templates/media/edit.html.twig:84</note>
+      </notes>
       <segment>
         <source>field.cropZoom</source>
         <target>缩放</target>
       </segment>
     </unit>
     <unit id="tn6Z8wY" name="field.cropZoomPostfix">
+      <notes>
+        <note>templates/media/edit.html.twig:87</note>
+      </notes>
       <segment>
         <source>field.cropZoomPostfix</source>
         <target>缩放范围：1-10</target>
       </segment>
     </unit>
     <unit id="n.3JZvX" name="title.contentType">
+      <notes>
+        <note>templates/content/listing.html.twig:136</note>
+      </notes>
       <segment>
         <source>title.contentType</source>
         <target>内容类型</target>
       </segment>
     </unit>
-    <unit id="TSkqRw3" name="listing.title_taxonomy">
-      <segment>
-        <source>listing.title_taxonomy</source>
-        <target>分类</target>
-      </segment>
-    </unit>
     <unit id="Hr2E9Oa" name="listing_table.no_results">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:44</note>
+      </notes>
       <segment>
         <source>listing_table.no_results</source>
         <target>未找到结果，扩大过滤条件，或添加更多内容。</target>
       </segment>
     </unit>
     <unit id="hp554Ds" name="listing.option_select_sortby">
+      <notes>
+        <note>templates/content/listing.html.twig:72</note>
+        <note>templates/users/listing.html.twig:193</note>
+      </notes>
       <segment>
         <source>listing.option_select_sortby</source>
         <target>选择要排序的字段…</target>
       </segment>
     </unit>
     <unit id="JEnqOi." name="title.primary_actions">
+      <notes>
+        <note>templates/content/edit.html.twig:103</note>
+      </notes>
       <segment>
         <source>title.primary_actions</source>
         <target>主要操作</target>
       </segment>
     </unit>
     <unit id="7616Os4" name="title.options">
+      <notes>
+        <note>templates/content/edit.html.twig:115</note>
+        <note>templates/users/listing.html.twig:59</note>
+      </notes>
       <segment>
         <source>title.options</source>
         <target>选项</target>
       </segment>
     </unit>
     <unit id="hTKWQ6g" name="action.delete">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:27</note>
+        <note>templates/content/_buttons.html.twig:69</note>
+        <note>templates/content/listing.html.twig:44</note>
+        <note>templates/finder/_folders.html.twig:39</note>
+        <note>templates/users/listing.html.twig:96</note>
+      </notes>
       <segment>
         <source>action.delete</source>
         <target>删除</target>
       </segment>
     </unit>
     <unit id="ezqx.4H" name="action.enable">
+      <notes>
+        <note>templates/users/listing.html.twig:76</note>
+      </notes>
       <segment>
         <source>action.enable</source>
         <target>启用</target>
       </segment>
     </unit>
     <unit id="ryXZRAu" name="action.disable">
+      <notes>
+        <note>templates/users/listing.html.twig:71</note>
+      </notes>
       <segment>
         <source>action.disable</source>
         <target>禁用</target>
       </segment>
     </unit>
-    <unit id="29MN3Ip" name="user.enabled_successfully">
-      <segment>
-        <source>user.enabled_successfully</source>
-        <target>用户已启用！</target>
-      </segment>
-    </unit>
-    <unit id="nj8qBZ5" name="user.disabled_successfully">
-      <segment>
-        <source>user.disabled_successfully</source>
-        <target>用户已禁用！</target>
-      </segment>
-    </unit>
     <unit id="Npkio79" name="listing.title_session_expires">
+      <notes>
+        <note>templates/users/listing.html.twig:124</note>
+      </notes>
       <segment>
         <source>listing.title_session_expires</source>
         <target>Session过期</target>
       </segment>
     </unit>
     <unit id="mmUDcto" name="listing.title_ip_address">
+      <notes>
+        <note>templates/users/listing.html.twig:125</note>
+      </notes>
       <segment>
         <source>listing.title_ip_address</source>
         <target>IP地址</target>
       </segment>
     </unit>
     <unit id="x9qAwrz" name="listing.title_browser">
+      <notes>
+        <note>templates/users/listing.html.twig:126</note>
+      </notes>
       <segment>
         <source>listing.title_browser</source>
         <target>浏览器/平台</target>
       </segment>
     </unit>
     <unit id="FqVh1Hv" name="image.button_remove">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:19</note>
+        <note>templates/_partials/fields/filelist.html.twig:22</note>
+        <note>templates/_partials/fields/image.html.twig:20</note>
+        <note>templates/_partials/fields/imagelist.html.twig:22</note>
+        <note>templates/_partials/fields/simple_image.html.twig:15</note>
+        <note>templates/_partials/fields/simple_image.html.twig:60</note>
+      </notes>
       <segment>
         <source>image.button_remove</source>
         <target>移除</target>
       </segment>
     </unit>
     <unit id="eHV6ZJB" name="image.button_edit_attributes">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:23</note>
+        <note>templates/_partials/fields/filelist.html.twig:26</note>
+        <note>templates/_partials/fields/image.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:23</note>
+        <note>templates/_partials/fields/simple_image.html.twig:19</note>
+        <note>templates/_partials/fields/simple_image.html.twig:63</note>
+      </notes>
       <segment>
         <source>image.button_edit_attributes</source>
         <target>编辑属性</target>
       </segment>
     </unit>
-    <unit id="s14vS9S" name="image.button_move_up">
-      <segment>
-        <source>image.button_move_up</source>
-        <target>上移</target>
-      </segment>
-    </unit>
-    <unit id="xoOPAPl" name="image.button_move_down">
-      <segment>
-        <source>image.button_move_down</source>
-        <target>下移</target>
-      </segment>
-    </unit>
     <unit id="Oj2UZ5J" name="image.add_new_image">
+      <notes>
+        <note>templates/_partials/fields/imagelist.html.twig:27</note>
+      </notes>
       <segment>
         <source>image.add_new_image</source>
         <target>添加新图片</target>
       </segment>
     </unit>
     <unit id="8Q4FxVw" name="file.add_new_file">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>file.add_new_file</source>
         <target>添加新文件</target>
       </segment>
     </unit>
     <unit id=".t1ICS7" name="collection.remove_item">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:20</note>
+      </notes>
       <segment>
         <source>collection.remove_item</source>
         <target>删除项目</target>
       </segment>
     </unit>
     <unit id="0C9.Vmh" name="collection.add_item">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:6</note>
+      </notes>
       <segment>
         <source>collection.add_item</source>
         <target>向“%name%”添加新项目</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:5</note>
+      </notes>
       <segment>
         <source>collection.move_item_up</source>
         <target>上移</target>
       </segment>
     </unit>
     <unit id="KzBtfHi" name="collection.move_item_down">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:9</note>
+      </notes>
       <segment>
         <source>collection.move_item_down</source>
         <target>下移</target>
       </segment>
     </unit>
     <unit id="BFARQEU" name="extensions.button_detailed_view">
+      <notes>
+        <note>templates/pages/extensions.html.twig:54</note>
+      </notes>
       <segment>
         <source>extensions.button_detailed_view</source>
         <target>查看详情</target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:31</note>
+        <note>templates/pages/extensions.html.twig:34</note>
+      </notes>
       <segment>
         <source>extensions.title_configuration</source>
         <target>配置文件</target>
       </segment>
     </unit>
     <unit id="283aB_E" name="caption.file_upload.upload_text">
+      <notes>
+        <note>templates/finder/_uploader.html.twig:17</note>
+      </notes>
       <segment>
         <source>caption.file_upload.upload_text</source>
         <target>将文件拖放到此处进行上传</target>
       </segment>
     </unit>
     <unit id="L_YQKUn" name="pager.next">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:66</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:74</note>
+        <note>templates/helpers/_pager_bulma.html.twig:34</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:69</note>
+      </notes>
       <segment>
         <source>pager.next</source>
         <target>下一页</target>
       </segment>
     </unit>
     <unit id="AMxTho9" name="pager.previous">
+      <notes>
+        <note>templates/helpers/_pager_basic.html.twig:30</note>
+        <note>templates/helpers/_pager_bootstrap.html.twig:33</note>
+        <note>templates/helpers/_pager_bulma.html.twig:28</note>
+        <note>templates/helpers/_pager_tailwind.html.twig:29</note>
+      </notes>
       <segment>
         <source>pager.previous</source>
         <target>上一页</target>
       </segment>
     </unit>
     <unit id="7aSD0Qr" name="image.button_up">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:23</note>
+        <note>templates/_partials/fields/imagelist.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.button_up</source>
-        <target>Up</target>
+        <target>上移</target>
       </segment>
     </unit>
     <unit id="WihD8Y5" name="image.button_down">
+      <notes>
+        <note>templates/_partials/fields/filelist.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:26</note>
+      </notes>
       <segment>
         <source>image.button_down</source>
-        <target>Down</target>
+        <target>下移</target>
       </segment>
     </unit>
     <unit id="fon6eNN" name="general.phrase.download">
+      <notes>
+        <note>templates/helpers/_field_blocks.twig:28</note>
+      </notes>
       <segment>
         <source>general.phrase.download</source>
         <target>下载</target>
       </segment>
     </unit>
     <unit id="2MtT_h0" name="caption.logviewer">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:197</note>
+        <note>templates/pages/logviewer.html.twig:6</note>
+      </notes>
       <segment>
         <source>caption.logviewer</source>
         <target>日志查看</target>
       </segment>
     </unit>
     <unit id="FlGE3qB" name="label.request">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:39</note>
+      </notes>
       <segment>
         <source>label.request</source>
-        <target>Request</target>
+        <target>请求</target>
       </segment>
     </unit>
     <unit id="l71Tprl" name="label.trace">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:53</note>
+      </notes>
       <segment>
         <source>label.trace</source>
-        <target>Trace</target>
+        <target>堆栈跟踪</target>
       </segment>
     </unit>
     <unit id="29ZEo1r" name="label.context">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:71</note>
+      </notes>
       <segment>
         <source>label.context</source>
-        <target>Context</target>
+        <target>上下文</target>
       </segment>
     </unit>
     <unit id="txRonia" name="label.id">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:19</note>
+      </notes>
       <segment>
         <source>label.id</source>
         <target>ID</target>
       </segment>
     </unit>
     <unit id="IwLLxxx" name="label.level">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:20</note>
+      </notes>
       <segment>
         <source>label.level</source>
         <target>等级</target>
       </segment>
     </unit>
     <unit id="51OQi14" name="label.message">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:23</note>
+      </notes>
       <segment>
         <source>label.message</source>
         <target>信息</target>
       </segment>
     </unit>
     <unit id="S0f6iTL" name="label.timestamp">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:25</note>
+      </notes>
       <segment>
         <source>label.timestamp</source>
         <target>时间戳</target>
       </segment>
     </unit>
     <unit id="O2X4xZH" name="label.user">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:86</note>
+      </notes>
       <segment>
         <source>label.user</source>
         <target>用户</target>
       </segment>
     </unit>
     <unit id="3MuwWwe" name="listing.disabled">
+      <notes>
+        <note>templates/users/listing.html.twig:33</note>
+      </notes>
       <segment>
         <source>listing.disabled</source>
         <target>已禁用</target>
       </segment>
     </unit>
     <unit id="XQ2U6fN" name="slug.button_unlocked">
+      <notes>
+        <note>templates/_partials/fields/slug.html.twig:17</note>
+      </notes>
       <segment>
         <source>slug.button_unlocked</source>
         <target>解锁</target>
       </segment>
     </unit>
     <unit id="jz2qkbb" name="general.phrase.no-content-found">
+      <notes>
+        <note>public/theme/skeleton/listing.twig:42</note>
+      </notes>
       <segment>
         <source>general.phrase.no-content-found</source>
         <target>未找到内容</target>
       </segment>
     </unit>
-    <unit id="FM8B.gO" name="general.phrase.empty-database">
+    <unit id="OPxagAY" name="general.phrase.none">
+      <notes>
+        <note>public/theme/skeleton/partials/_sub_taxonomylinks.twig:12</note>
+        <note>templates/helpers/_taxonomylinks.html.twig:14</note>
+      </notes>
       <segment>
-        <source>general.phrase.empty-database</source>
-        <target>It looks like the database is empty. Write some content in the Bolt backend, or run the command to add some fixtures (dummy content). </target>
+        <source>general.phrase.none</source>
+        <target>无</target>
       </segment>
     </unit>
     <unit id="SGlj7K2" name="view_locales.badge_empty">
+      <notes>
+        <note>templates/content/view_locales.html.twig:103</note>
+      </notes>
       <segment>
         <source>view_locales.badge_empty</source>
-        <target>Empty</target>
+        <target>空</target>
       </segment>
     </unit>
     <unit id="WeJxw6Z" name="action.update_all">
+      <notes>
+        <note>templates/content/listing.html.twig:45</note>
+      </notes>
       <segment>
         <source>action.update_all</source>
         <target>全部应用</target>
       </segment>
     </unit>
     <unit id="QVRwwK4" name="about.system_info">
+      <notes>
+        <note>templates/pages/about.html.twig:21</note>
+      </notes>
       <segment>
         <source>about.system_info</source>
         <target>系统信息</target>
       </segment>
     </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>无效的显示名称</target>
-      </segment>
-    </unit>
     <unit id="6Gw1lsE" name="action.confirm_delete">
+      <notes>
+        <note>templates/content/_buttons.html.twig:63</note>
+        <note>templates/finder/_folders.html.twig:40</note>
+        <note>templates/finder/_folders.html.twig:41</note>
+        <note>templates/users/listing.html.twig:89</note>
+        <note>templates/users/listing.html.twig:90</note>
+      </notes>
       <segment>
         <source>action.confirm_delete</source>
         <target>您确定要删除此内容吗？</target>
       </segment>
     </unit>
     <unit id="z_tOHwq" name="placeholder.username_or_email">
+      <notes>
+        <note>src/Form/LoginType.php:38</note>
+      </notes>
       <segment>
         <source>placeholder.username_or_email</source>
         <target>您的用户名或电子邮件</target>
       </segment>
     </unit>
     <unit id="xgYhRkc" name="placeholder.password">
+      <notes>
+        <note>src/Form/LoginType.php:52</note>
+      </notes>
       <segment>
         <source>placeholder.password</source>
         <target>你的密码</target>
       </segment>
     </unit>
     <unit id="KshyLfh" name="caption.other_content">
+      <notes>
+        <note>src/Menu/BackendMenuBuilder.php:336</note>
+      </notes>
       <segment>
         <source>caption.other_content</source>
         <target>其他内容</target>
       </segment>
     </unit>
     <unit id="wHOF8eG" name="editfile.target_not_writable">
+      <notes>
+        <note>templates/finder/editfile.html.twig:39</note>
+      </notes>
       <segment>
         <source>editfile.target_not_writable</source>
         <target>保存被禁用，因为目标文件不可写。</target>
       </segment>
     </unit>
     <unit id="hAysbHB" name="label.translatable">
+      <notes>
+        <note>templates/_partials/fields/_label.html.twig:6</note>
+      </notes>
       <segment>
         <source>label.translatable</source>
         <target>此字段可翻译</target>
       </segment>
     </unit>
     <unit id="qqpGLJl" name="label.content">
+      <notes>
+        <note>templates/pages/logviewer.html.twig:92</note>
+      </notes>
       <segment>
         <source>label.content</source>
         <target>内容</target>
       </segment>
     </unit>
     <unit id="v7ZTnja" name="file.delete_success">
+      <notes>
+        <note>src/Controller/Backend/FileEditController.php:148</note>
+      </notes>
       <segment>
         <source>file.delete_success</source>
         <target>文件删除成功！</target>
       </segment>
     </unit>
     <unit id="wHPoBzP" name="file.delete_confirm">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:42</note>
+        <note>templates/finder/_files_actions.html.twig:43</note>
+      </notes>
       <segment>
         <source>file.delete_confirm</source>
         <target>您确定要删除此文件吗？</target>
       </segment>
     </unit>
     <unit id="IWbf2by" name="listing.title_filterby">
+      <notes>
+        <note>templates/content/listing.html.twig:104</note>
+        <note>templates/users/listing.html.twig:207</note>
+      </notes>
       <segment>
         <source>listing.title_filterby</source>
         <target>搜索/过滤依据</target>
       </segment>
     </unit>
     <unit id="Zssh7In" name="content.status_changed_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:55</note>
+        <note>src/Controller/Backend/ContentEditController.php:264</note>
+      </notes>
       <segment>
         <source>content.status_changed_successfully</source>
         <target>状态更改成功</target>
       </segment>
     </unit>
     <unit id="GOhQBY9" name="content.deleted_successfully">
+      <notes>
+        <note>src/Controller/Backend/BulkOperationsController.php:82</note>
+        <note>src/Controller/Backend/ContentEditController.php:288</note>
+      </notes>
       <segment>
         <source>content.deleted_successfully</source>
         <target>内容删除成功</target>
       </segment>
     </unit>
     <unit id=".I3mIHo" name="label.current_status">
+      <notes>
+        <note>templates/content/_buttons.html.twig:46</note>
+      </notes>
       <segment>
         <source>label.current_status</source>
         <target>当前状态</target>
       </segment>
     </unit>
     <unit id="utGAKaQ" name="status.published">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.published</source>
         <target>已发布</target>
       </segment>
     </unit>
     <unit id="HJbHjee" name="status.draft">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.draft</source>
         <target>草稿</target>
       </segment>
     </unit>
     <unit id="h7dP3WY" name="status.timed">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.timed</source>
         <target>定时</target>
       </segment>
     </unit>
     <unit id="oxqDDuK" name="status.held">
+      <notes>
+        <note>src/Twig/ContentExtension.php:601</note>
+        <note>templates/content/_buttons.html.twig:47</note>
+      </notes>
       <segment>
         <source>status.held</source>
         <target>保留</target>
       </segment>
     </unit>
     <unit id="JpJFIFq" name="collection.confirm_delete">
+      <notes>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:13</note>
+        <note>templates/_partials/fields/_collection_buttons.html.twig:14</note>
+      </notes>
       <segment>
         <source>collection.confirm_delete</source>
         <target>您确定要删除吗？</target>
       </segment>
     </unit>
     <unit id="YZJO3Ul" name="upload.allow_file_types">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:5</note>
+        <note>templates/_partials/fields/filelist.html.twig:5</note>
+        <note>templates/_partials/fields/image.html.twig:5</note>
+        <note>templates/_partials/fields/imagelist.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:5</note>
+        <note>templates/_partials/fields/simple_image.html.twig:49</note>
+        <note>templates/finder/_uploader.html.twig:3</note>
+      </notes>
       <segment>
         <source>upload.allow_file_types</source>
         <target>允许上传的文件类型</target>
       </segment>
     </unit>
     <unit id="noOf4ML" name="upload.max_size">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:6</note>
+        <note>templates/_partials/fields/filelist.html.twig:6</note>
+        <note>templates/_partials/fields/image.html.twig:6</note>
+        <note>templates/_partials/fields/imagelist.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:6</note>
+        <note>templates/_partials/fields/simple_image.html.twig:50</note>
+        <note>templates/finder/_uploader.html.twig:4</note>
+      </notes>
       <segment>
         <source>upload.max_size</source>
         <target>最大上传</target>
       </segment>
     </unit>
     <unit id="O_m7mx1" name="listing.placeholder_search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:26</note>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:27</note>
+        <note>templates/_base/layout.html.twig:45</note>
+      </notes>
       <segment>
         <source>listing.placeholder_search</source>
         <target>搜索关键字 …</target>
       </segment>
     </unit>
     <unit id="munFS0n" name="title.filtered_by">
+      <notes>
+        <note>templates/pages/dashboard.html.twig:12</note>
+      </notes>
       <segment>
         <source>title.filtered_by</source>
         <target><![CDATA[所有内容，由<em>'%filter%'</em>过滤。]]></target>
       </segment>
     </unit>
     <unit id="GPd6Hap" name="action.view_site">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:16</note>
+        <note>templates/_base/layout.html.twig:38</note>
+      </notes>
       <segment>
         <source>action.view_site</source>
         <target>查看网站</target>
       </segment>
     </unit>
     <unit id="f.rvF6y" name="action.new">
+      <notes>
+        <note>assets/js/app/sidebar/Components/Menu/_SubMenu.vue:5</note>
+        <note>templates/_base/layout.html.twig:92</note>
+        <note>templates/finder/_createfolder.html.twig:9</note>
+      </notes>
       <segment>
         <source>action.new</source>
         <target>添加</target>
       </segment>
     </unit>
     <unit id="60xy4WG" name="extensions.no_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:39</note>
+      </notes>
       <segment>
         <source>extensions.no_dependencies</source>
         <target>没有依赖关系</target>
       </segment>
     </unit>
     <unit id="LfwezhR" name="extensions.title_dependencies">
+      <notes>
+        <note>templates/pages/extension_details.html.twig:36</note>
+      </notes>
       <segment>
         <source>extensions.title_dependencies</source>
         <target>依赖关系</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:7</note>
+      </notes>
       <segment>
         <source>collection.expand_all</source>
         <target>展开全部</target>
       </segment>
     </unit>
     <unit id="JjvI6hp" name="collection.collapse_all">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:8</note>
+      </notes>
       <segment>
         <source>collection.collapse_all</source>
         <target>全部收缩</target>
       </segment>
     </unit>
     <unit id="pXtciRI" name="content.edit_missing_definition">
+      <notes>
+        <note>templates/content/edit.html.twig:45</note>
+      </notes>
       <segment>
         <source>content.edit_missing_definition</source>
-        <target>The definition for this ContentType is missing! Editing this record will not work as expected. Please check your contenttypes.yaml to make sure that it contains %contenttype%.</target>
+        <target>此内容类型（ContentType）的定义缺失！编辑此记录将无法正常工作。请检查您的 contenttypes.yaml 文件，确保其中包含 %contenttype%。</target>
       </segment>
     </unit>
     <unit id="RBJ0NMl" name="collection.select">
+      <notes>
+        <note>templates/_partials/fields/collection.html.twig:10</note>
+      </notes>
       <segment>
         <source>collection.select</source>
         <target>选择 …</target>
       </segment>
     </unit>
     <unit id="2SSLP1K" name="form.empty_username_email">
+      <notes>
+        <note>src/Form/LoginType.php:34</note>
+      </notes>
       <segment>
         <source>form.empty_username_email</source>
         <target>请输入您的用户名或电子邮件</target>
       </segment>
     </unit>
     <unit id="5Qf_RiO" name="form.empty_password">
+      <notes>
+        <note>src/Form/LoginType.php:46</note>
+      </notes>
       <segment>
         <source>form.empty_password</source>
         <target>请输入您的密码</target>
       </segment>
     </unit>
     <unit id="f8zXapF" name="form.empty_email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:28</note>
+      </notes>
       <segment>
         <source>form.empty_email</source>
         <target>请输入您的电子邮件</target>
       </segment>
     </unit>
     <unit id="fAmcKUQ" name="listing.title_filterby_field">
+      <notes>
+        <note>templates/content/listing.html.twig:112</note>
+      </notes>
       <segment>
         <source>listing.title_filterby_field</source>
         <target>按字段过滤</target>
       </segment>
     </unit>
     <unit id="kciiidS" name="image.button_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:24</note>
+        <note>templates/_partials/fields/imagelist.html.twig:24</note>
+        <note>templates/_partials/fields/simple_image.html.twig:64</note>
+      </notes>
       <segment>
         <source>image.button_from_url</source>
         <target>来源URL</target>
       </segment>
     </unit>
     <unit id="QcN1pi8" name="files_cards.copy_to_clipboard">
+      <notes>
+        <note>templates/finder/_files_actions.html.twig:29</note>
+      </notes>
       <segment>
         <source>files_cards.copy_to_clipboard</source>
         <target>复制文件链接</target>
       </segment>
     </unit>
     <unit id="S9k1S7Z" name="warning">
+      <notes>
+        <note>assets/js/app/ajax-save.js:39</note>
+        <note>src/Controller/Backend/FileEditController.php:82</note>
+        <note>src/Controller/Backend/FileEditController.php:106</note>
+        <note>src/Controller/Backend/FilemanagerController.php:111</note>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+        <note>src/Controller/Backend/GeneralController.php:50</note>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+        <note>src/Twig/Notifications.php:42</note>
+        <note>templates/helpers/page_404.html.twig:36</note>
+        <note>templates/pages/kitchensink.html.twig:82</note>
+        <note>templates/pages/kitchensink.html.twig:89</note>
+        <note>vendor/bolt/configuration-notices-widget/src/Checks.php:55</note>
+      </notes>
       <segment>
         <source>warning</source>
         <target>警告</target>
       </segment>
     </unit>
     <unit id="4fyuUU." name="filemanager.create_folder_already_exists">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:150</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_already_exists</source>
         <target>文件夹已存在</target>
       </segment>
     </unit>
     <unit id="aSxePCB" name="filemanager.create_folder_error">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:151</note>
+        <note>src/Controller/Backend/FilemanagerController.php:157</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_error</source>
         <target>无法创建文件夹</target>
       </segment>
     </unit>
     <unit id="wbFKypA" name="filemanager.create_folder_success">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:155</note>
+      </notes>
       <segment>
         <source>filemanager.create_folder_success</source>
         <target>文件夹创建成功。</target>
       </segment>
     </unit>
     <unit id="lZxOEzh" name="filemanager.delete_folder_successful">
+      <notes>
+        <note>src/Controller/Backend/FilemanagerController.php:115</note>
+      </notes>
       <segment>
         <source>filemanager.delete_folder_successful</source>
         <target>文件夹删除成功</target>
       </segment>
     </unit>
     <unit id="a6Xhtq0" name="folder.create_new">
+      <notes>
+        <note>templates/finder/_createfolder.html.twig:13</note>
+      </notes>
       <segment>
         <source>folder.create_new</source>
         <target>新建文件夹</target>
       </segment>
     </unit>
-    <unit id="FcXvWL8" name="title.add_user">
-      <segment>
-        <source>title.add_user</source>
-        <target>添加用户</target>
-      </segment>
-    </unit>
     <unit id="nWMH_Nr" name="label.avatar">
+      <notes>
+        <note>templates/users/_form.html.twig:172</note>
+      </notes>
       <segment>
         <source>label.avatar</source>
         <target>头像</target>
       </segment>
     </unit>
     <unit id="i37ZNqN" name="login.forgotpassword">
+      <notes>
+        <note>templates/security/login.html.twig:64</note>
+      </notes>
       <segment>
         <source>login.forgotpassword</source>
         <target>忘记密码</target>
       </segment>
     </unit>
     <unit id="y.dIywE" name="reset_password.request_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:32</note>
+        <note>templates/reset_password/request.html.twig:4</note>
+        <note>templates/reset_password/request.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.request_header</source>
         <target>重置密码</target>
       </segment>
     </unit>
     <unit id="SwOgM7K" name="reset_password.request_description">
+      <notes>
+        <note>templates/reset_password/request.html.twig:42</note>
+      </notes>
       <segment>
         <source>reset_password.request_description</source>
         <target>输入您的电子邮件地址，我们将向您发送一个链接以重置您的密码。</target>
       </segment>
     </unit>
     <unit id="RX0Iuzi" name="reset_password.request_send">
+      <notes>
+        <note>templates/reset_password/request.html.twig:44</note>
+      </notes>
       <segment>
         <source>reset_password.request_send</source>
         <target>提交</target>
       </segment>
     </unit>
     <unit id="lpzL089" name="Email">
+      <notes>
+        <note>src/Command/AddUserCommand.php:158</note>
+        <note>src/Command/ListUsersCommand.php:101</note>
+        <note>tests/cypress/integration-temporary-disabled/edit_record_1_field.spec.js:56</note>
+      </notes>
       <segment>
         <source>Email</source>
-        <target>Email</target>
+        <target>电子邮箱</target>
       </segment>
     </unit>
     <unit id="k9hekeu" name="reset_password.back-to-login">
+      <notes>
+        <note>templates/reset_password/request.html.twig:47</note>
+      </notes>
       <segment>
         <source>reset_password.back-to-login</source>
         <target>返回登录</target>
       </segment>
     </unit>
     <unit id="gVc0Uf4" name="reset_password.reset_header">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:4</note>
+        <note>templates/reset_password/reset.html.twig:32</note>
+      </notes>
       <segment>
         <source>reset_password.reset_header</source>
         <target>重置您的密码</target>
       </segment>
     </unit>
     <unit id="U6qdalg" name="reset_password.check_email_sent_header">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:4</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_header</source>
         <target>密码重置邮件已发送</target>
       </segment>
     </unit>
     <unit id="SxW1D3L" name="reset_password.check_email_sent_text_1">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:35</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_1</source>
         <target>已发送电子邮件，其中包含您重置密码的链接。此链接将在%hours%小时后过期。</target>
       </segment>
     </unit>
     <unit id="z25k4DS" name="reset_password.check_email_sent_text_2">
+      <notes>
+        <note>templates/reset_password/check_email.html.twig:36</note>
+      </notes>
       <segment>
         <source>reset_password.check_email_sent_text_2</source>
         <target>如果您没有收到电子邮件，请检查您的垃圾邮件文件夹或%tryagain%。</target>
       </segment>
     </unit>
     <unit id="QpUMHfK" name="reset_password.reset_btn">
+      <notes>
+        <note>templates/reset_password/reset.html.twig:37</note>
+      </notes>
       <segment>
         <source>reset_password.reset_btn</source>
         <target>重置密码</target>
       </segment>
     </unit>
     <unit id="dp42qbF" name="reset_password.email_title">
+      <notes>
+        <note>templates/reset_password/email.html.twig:1</note>
+      </notes>
       <segment>
         <source>reset_password.email_title</source>
-        <target>Hi!</target>
+        <target>您好！</target>
       </segment>
     </unit>
     <unit id="xS2vvXw" name="reset_password.email_description">
+      <notes>
+        <note>templates/reset_password/email.html.twig:3</note>
+      </notes>
       <segment>
         <source>reset_password.email_description</source>
         <target>要重置您的密码，请访问以下链接</target>
       </segment>
     </unit>
     <unit id="apkSD11" name="reset_password.email_expire">
+      <notes>
+        <note>templates/reset_password/email.html.twig:7</note>
+      </notes>
       <segment>
         <source>reset_password.email_expire</source>
         <target>此链接将在%hours%小时后过期</target>
       </segment>
     </unit>
     <unit id="_gg3hPE" name="reset_password.email_thanks">
+      <notes>
+        <note>templates/reset_password/email.html.twig:9</note>
+      </notes>
       <segment>
         <source>reset_password.email_thanks</source>
-        <target>Cheers!</target>
+        <target>谢谢！</target>
       </segment>
     </unit>
     <unit id="harDiJR" name="reset_password.enter_pwd">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:31</note>
+      </notes>
       <segment>
         <source>reset_password.enter_pwd</source>
         <target>请输入密码</target>
       </segment>
     </unit>
     <unit id="rU9cSfq" name="label.repeat_password">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:43</note>
+      </notes>
       <segment>
         <source>label.repeat_password</source>
         <target>重复密码</target>
       </segment>
     </unit>
     <unit id="Tg5zdeo" name="reset_password.not_matching_pwds">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:45</note>
+      </notes>
       <segment>
         <source>reset_password.not_matching_pwds</source>
-        <target>The password fields must match.</target>
+        <target>两次输入的密码必须一致。</target>
       </segment>
     </unit>
     <unit id="1JZeWxG" name="reset_password.minimum_length">
+      <notes>
+        <note>src/Form/ChangePasswordFormType.php:35</note>
+      </notes>
       <segment>
         <source>reset_password.minimum_length</source>
         <target>您的密码应至少为 %s 个字符</target>
       </segment>
     </unit>
     <unit id="GUQYLn2" name="reset_password.no_token">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:99</note>
+      </notes>
       <segment>
         <source>reset_password.no_token</source>
-        <target>No reset password token found in the URL or in the session.</target>
+        <target>在 URL 或会话中未找到重置密码令牌。</target>
       </segment>
     </unit>
     <unit id="SjuOnue" name="reset_password.reset_successful">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:134</note>
+      </notes>
       <segment>
         <source>reset_password.reset_successful</source>
         <target>您的密码已成功重置。</target>
       </segment>
     </unit>
     <unit id="5Xr92sQ" name="reset_password.problem_with_request">
+      <notes>
+        <note>src/Controller/Backend/ResetPasswordController.php:106</note>
+        <note>src/Controller/Backend/ResetPasswordController.php:169</note>
+      </notes>
       <segment>
         <source>reset_password.problem_with_request</source>
         <target>在处理您的密码重置请求时出现问题 - %s</target>
       </segment>
     </unit>
     <unit id="u3DMmBH" name="label.filtered_by">
+      <notes>
+        <note>templates/content/listing.html.twig:12</note>
+        <note>templates/content/listing.html.twig:13</note>
+      </notes>
       <segment>
         <source>label.filtered_by</source>
-        <target>filtered by</target>
+        <target>筛选依据</target>
       </segment>
     </unit>
     <unit id="qoZwSEY" name="action.preview_secure_share">
+      <notes>
+        <note>templates/content/_buttons.html.twig:34</note>
+      </notes>
       <segment>
         <source>action.preview_secure_share</source>
         <target>分享安全预览链接</target>
       </segment>
     </unit>
     <unit id="zYeSeNJ" name="action.stop_impersonating">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:10</note>
+        <note>templates/_base/layout.html.twig:41</note>
+      </notes>
       <segment>
         <source>action.stop_impersonating</source>
-        <target>stop impersonating</target>
+        <target>停止模拟身份</target>
       </segment>
     </unit>
     <unit id="W7z__Yi" name="action.impersonate">
+      <notes>
+        <note>templates/users/listing.html.twig:82</note>
+      </notes>
       <segment>
         <source>action.impersonate</source>
-        <target>impersonate</target>
+        <target>模拟身份</target>
       </segment>
     </unit>
     <unit id="qlucRr7" name="maintenance.activated_warning">
+      <notes>
+        <note>templates/widget/maintenance_mode.twig:25</note>
+      </notes>
       <segment>
         <source>maintenance.activated_warning</source>
         <target>维护模式已激活</target>
       </segment>
     </unit>
     <unit id="CvNi3GD" name="action.refresh">
+      <notes>
+        <note>templates/_partials/fields/embed.html.twig:28</note>
+      </notes>
       <segment>
         <source>action.refresh</source>
         <target>刷新</target>
       </segment>
     </unit>
     <unit id="9UKAP.V" name="listing_details_box.showing_records">
+      <notes>
+        <note>templates/content/listing.html.twig:148</note>
+      </notes>
       <segment>
         <source>listing_details_box.showing_records</source>
-        <target>Showing records %current% of %total%</target>
+        <target>显示第 %current% 条，共 %total% 条记录</target>
       </segment>
     </unit>
     <unit id="UrywY0R" name="listing_details_box.name">
+      <notes>
+        <note>templates/content/listing.html.twig:154</note>
+      </notes>
       <segment>
         <source>listing_details_box.name</source>
-        <target>Name: %name% (singular: %singularName%)</target>
+        <target>名称：%name%（单数：%singularName%）</target>
       </segment>
     </unit>
     <unit id=".l3zbrq" name="listing_details_box.slug">
+      <notes>
+        <note>templates/content/listing.html.twig:160</note>
+      </notes>
       <segment>
         <source>listing_details_box.slug</source>
-        <target>Slug: %slug% (singular: %singularSlug%)</target>
+        <target>Slug：%slug%（单数：%singularSlug%）</target>
       </segment>
     </unit>
     <unit id="eJ9YbdG" name="listing_details_box.record_template">
+      <notes>
+        <note>templates/content/listing.html.twig:166</note>
+      </notes>
       <segment>
         <source>listing_details_box.record_template</source>
-        <target>Record template: %template%</target>
+        <target>记录模板：%template%</target>
       </segment>
     </unit>
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
+      <notes>
+        <note>templates/content/listing.html.twig:172</note>
+      </notes>
       <segment>
         <source>listing_details_box.listing_template</source>
-        <target>Listing template: %template% (%listingRecords% records)</target>
+        <target>列表模板：%template%（%listingRecords% 条记录）</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">
+      <notes>
+        <note>templates/content/listing.html.twig:186</note>
+      </notes>
       <segment>
         <source>listing_details_box.locales</source>
         <target>语言环境: %locales%</target>
       </segment>
     </unit>
     <unit id="z8r0TY6" name="action.edit_permissions">
+      <notes>
+        <note>templates/users/listing.html.twig:112</note>
+        <note>templates/users/listing.html.twig:183</note>
+      </notes>
       <segment>
         <source>action.edit_permissions</source>
         <target>编辑权限</target>
       </segment>
     </unit>
     <unit id="OYUVA5." name="general.label.search">
+      <notes>
+        <note>assets/js/app/toolbar/Components/Toolbar.vue:21</note>
+        <note>templates/_base/layout.html.twig:46</note>
+      </notes>
       <segment>
         <source>general.label.search</source>
         <target>搜索</target>
       </segment>
     </unit>
     <unit id="wG04eAa" name="image.image_preview">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:25</note>
+      </notes>
       <segment>
         <source>image.image_preview</source>
         <target>预览图片</target>
       </segment>
     </unit>
     <unit id="OEqzPDO" name="listing_table.actions.select_all">
+      <notes>
+        <note>templates/_partials/_content_listing.html.twig:15</note>
+      </notes>
       <segment>
         <source>listing_table.actions.select_all</source>
         <target>全选</target>
+      </segment>
+    </unit>
+    <unit id="2hoKa1k" name="label.remembermeduration">
+      <notes>
+        <note>src/Form/LoginType.php:58</note>
+      </notes>
+      <segment>
+        <source>label.remembermeduration</source>
+        <target>记住我？（%duration% 天）</target>
+      </segment>
+    </unit>
+    <unit id="eJG2.4P" name="listing.current_sessions_header">
+      <notes>
+        <note>templates/users/listing.html.twig:117</note>
+      </notes>
+      <segment>
+        <source>listing.current_sessions_header</source>
+        <target>当前会话</target>
+      </segment>
+    </unit>
+    <unit id="a_COwtV" name="image.button_upload_options">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:17</note>
+        <note>templates/_partials/fields/filelist.html.twig:17</note>
+        <note>templates/_partials/fields/image.html.twig:18</note>
+        <note>templates/_partials/fields/imagelist.html.twig:17</note>
+      </notes>
+      <segment>
+        <source>image.button_upload_options</source>
+        <target>上传选项</target>
+      </segment>
+    </unit>
+    <unit id="a_CQgly" name="Order">
+      <notes>
+        <note>templates/content/_taxonomies.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>Order</source>
+        <target>排序</target>
+      </segment>
+    </unit>
+    <unit id="Y7ajNNN" name="placeholder.email">
+      <notes>
+        <note>src/Form/ResetPasswordRequestFormType.php:32</note>
+      </notes>
+      <segment>
+        <source>placeholder.email</source>
+        <target>您的电子邮箱</target>
+      </segment>
+    </unit>
+    <unit id="MjY7.cg" name="modal.title.file_field">
+      <notes>
+        <note>templates/_partials/fields/file.html.twig:24</note>
+        <note>templates/_partials/fields/filelist.html.twig:27</note>
+      </notes>
+      <segment>
+        <source>modal.title.file_field</source>
+        <target>选择文件</target>
+      </segment>
+    </unit>
+    <unit id="0yPnNMd" name="modal.title.image_field">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:26</note>
+        <note>templates/_partials/fields/imagelist.html.twig:28</note>
+      </notes>
+      <segment>
+        <source>modal.title.image_field</source>
+        <target>选择图片</target>
+      </segment>
+    </unit>
+    <unit id="KIN.Ehy" name="modal.title.upload_from_url">
+      <notes>
+        <note>templates/_partials/fields/image.html.twig:27</note>
+        <note>templates/_partials/fields/imagelist.html.twig:29</note>
+      </notes>
+      <segment>
+        <source>modal.title.upload_from_url</source>
+        <target>从 URL 上传</target>
+      </segment>
+    </unit>
+    <unit id="ODb3pJA" name="modal.text.loading">
+      <notes>
+        <note>templates/_base/layout.html.twig:142</note>
+        <note>templates/_base/layout.html.twig:149</note>
+      </notes>
+      <segment>
+        <source>modal.text.loading</source>
+        <target>加载中...</target>
+      </segment>
+    </unit>
+    <unit id="VlfWDQr" name="modal.button_save">
+      <notes>
+        <note>templates/_base/layout.html.twig:154</note>
+        <note>templates/_partials/fields/file.html.twig:25</note>
+        <note>templates/_partials/fields/filelist.html.twig:28</note>
+        <note>templates/_partials/fields/image.html.twig:28</note>
+        <note>templates/_partials/fields/imagelist.html.twig:30</note>
+      </notes>
+      <segment>
+        <source>modal.button_save</source>
+        <target>保存</target>
+      </segment>
+    </unit>
+    <unit id="ct_I4w3" name="modal.button_deny">
+      <notes>
+        <note>templates/_base/layout.html.twig:153</note>
+        <note>templates/_partials/fields/file.html.twig:26</note>
+        <note>templates/_partials/fields/filelist.html.twig:29</note>
+        <note>templates/_partials/fields/image.html.twig:29</note>
+        <note>templates/_partials/fields/imagelist.html.twig:31</note>
+      </notes>
+      <segment>
+        <source>modal.button_deny</source>
+        <target>关闭</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.cs.xlf
+++ b/translations/security.cs.xlf
@@ -2,105 +2,185 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="cs">
   <file id="security.cs">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
-      <segment state="translated">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
+      <segment>
         <source>An authentication exception occurred.</source>
         <target>Došlo k chybě při autentizaci.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Ověřovací údaje se nepodařilo najít.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Požadavek na ověření nebylo možné zpracovat z důvodu systémového problému.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Nesprávné přístupové údaje.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Cookie již použil někdo jiný.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Nemáte oprávnění k požadavku na tento zdroj.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Neplatný CSRF token.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Nebyl nalezen žádný zprostředkovatel ověřování, který by podporoval ověřovací token.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Relace není k dispozici, buď vypršela, nebo nejsou aktivovány soubory cookie.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Nebyl nalezen žádný token.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Uživatelské jméno nebylo nalezeno.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Platnost účtu vypršela.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Platnost přístupových údajů vypršela.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Účet je deaktivován.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Účet je zablokován.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
-      <segment state="translated">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
         <source>User is disabled.</source>
-        <target>Uživatel je zakázán.</target>
+        <target>Uživatel je deaktivován.</target>
       </segment>
     </unit>
     <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
       <segment>
         <source>You have to login in order to access this page.</source>
         <target>Pro přístup k této stránce se musíte přihlásit.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Příliš mnoho nepovedených pokusů přihlášení. Zkuste to prosím později.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minutu.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minutu.|Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minuty.|Příliš mnoho neúspěšných pokusů o přihlášení, zkuste to prosím znovu za %minutes% minut.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.de.xlf
+++ b/translations/security.de.xlf
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
   <file id="security.de">
-    <unit id="NF.vvAN" name="You have to login in order to access this page.">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Security/AuthenticationEntryPointRedirector.php:27</note>
-      </notes>
-      <segment>
-        <source>You have to login in order to access this page.</source>
-        <target>Sie müssen sich anmelden, um auf diese Seite zugreifen zu können.</target>
-      </segment>
-    </unit>
     <unit id="baI_ZxO" name="An authentication exception occurred.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
       </notes>
       <segment>
         <source>An authentication exception occurred.</source>
@@ -21,7 +12,7 @@
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
       </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
@@ -30,7 +21,7 @@
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
       </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
@@ -39,7 +30,7 @@
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>tests/cypress/integration/login.spec.js:7</note>
       </notes>
       <segment>
         <source>Invalid credentials.</source>
@@ -48,7 +39,7 @@
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
       </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
@@ -57,7 +48,7 @@
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
       </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
@@ -66,7 +57,9 @@
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
       </notes>
       <segment>
         <source>Invalid CSRF token.</source>
@@ -75,7 +68,7 @@
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
       </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
@@ -84,7 +77,7 @@
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
       </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
@@ -93,7 +86,7 @@
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
       </notes>
       <segment>
         <source>No token could be found.</source>
@@ -102,7 +95,7 @@
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
       </notes>
       <segment>
         <source>Username could not be found.</source>
@@ -111,7 +104,7 @@
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
       </notes>
       <segment>
         <source>Account has expired.</source>
@@ -120,7 +113,7 @@
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
       </notes>
       <segment>
         <source>Credentials have expired.</source>
@@ -129,7 +122,7 @@
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
       </notes>
       <segment>
         <source>Account is disabled.</source>
@@ -138,43 +131,52 @@
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
       </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Der Account ist gesperrt.</target>
       </segment>
     </unit>
+    <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
+        <source>User is disabled.</source>
+        <target>Benutzer ist deaktiviert.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Sie müssen sich anmelden, um auf diese Seite zugreifen zu können.</target>
+      </segment>
+    </unit>
     <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
       </notes>
       <segment>
         <source>Too many failed login attempts, please try again later.</source>
         <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es später noch einmal.</target>
       </segment>
     </unit>
-    <unit id="l9VYRj0" name="Invalid or expired login link.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Invalid or expired login link.</source>
-        <target>Ungültiger oder abgelaufener Anmelde-Link.</target>
-      </segment>
-    </unit>
     <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
       </notes>
       <segment>
         <source>Too many failed login attempts, please try again in %minutes% minute.</source>
-        <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in einer Minute noch einmal.</target>
+        <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es in %minutes% Minute noch einmal.</target>
       </segment>
     </unit>
     <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
       </notes>
       <segment>
         <source>Too many failed login attempts, please try again in %minutes% minutes.</source>

--- a/translations/security.el.xlf
+++ b/translations/security.el.xlf
@@ -1,100 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="security.en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="el">
+  <file id="security.el">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Παρουσιάστηκε σφάλμα ελέγχου ταυτότητας.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Δεν ήταν δυνατή η εύρεση διαπιστευτηρίων ελέγχου ταυτότητας.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Δεν ήταν δυνατή η επεξεργασία του αιτήματος ελέγχου ταυτότητας λόγω προβλήματος συστήματος.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Ακυρα διαπιστευτήρια.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Το cookie έχει ήδη χρησιμοποιηθεί από κάποιον άλλο.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Δεν έχεις δικαίωμα να ζητήσεις τον πόρο.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Άκυρο CSRF token.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Δεν βρέθηκε πάροχος ελέγχου ταυτότητας που να υποστηρίζει το διακριτικό ελέγχου ταυτότητας.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Δεν υπάρχει διαθέσιμο session, έχει λήξει ή δεν ενεργοποιούνται τα cookie.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Δεν βρέθηκε token.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Δεν ήταν δυνατή η εύρεση του ονόματος χρήστη.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Ο λογαριασμός έχει λήξει.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Τα διαπιστευτήρια έχουν λήξει.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Ο λογαριασμός είναι απενεργοποιημένος.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Ο λογαριασμός είναι κλειδωμένος.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
       <segment>
         <source>User is disabled.</source>
         <target>Ο χρήστης είναι απενεργοποιημένος.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Πρέπει να συνδεθείτε για να αποκτήσετε πρόσβαση σε αυτή τη σελίδα.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Πολλαπλές αποτυχημένες απόπειρες σύνδεσης, παρακαλούμε ξαναδοκιμάστε αργότερα.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Πολλαπλές αποτυχημένες απόπειρες σύνδεσης, παρακαλούμε ξαναδοκιμάστε σε %minutes% λεπτό.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Πολλές αποτυχημένες προσπάθειες σύνδεσης, δοκιμάστε ξανά σε %minutes% λεπτά.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.en.xlf
+++ b/translations/security.en.xlf
@@ -2,105 +2,185 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="security.en">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>An authentication exception occurred.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Authentication credentials could not be found.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Authentication request could not be processed due to a system problem.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Invalid credentials.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Cookie has already been used by someone else.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Not privileged to request the resource.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Invalid CSRF token.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>No authentication provider found to support the authentication token.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>No session available, it either timed out or cookies are not enabled.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>No token could be found.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Username could not be found.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Account has expired.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Credentials have expired.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Account is disabled.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Account is locked.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
       <segment>
         <source>User is disabled.</source>
         <target>User is disabled.</target>
       </segment>
     </unit>
     <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
       <segment>
         <source>You have to login in order to access this page.</source>
         <target>You have to login in order to access this page.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Too many failed login attempts, please try again later.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Too many failed login attempts, please try again in %minutes% minute.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Too many failed login attempts, please try again in %minutes% minutes.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.es.xlf
+++ b/translations/security.es.xlf
@@ -2,93 +2,185 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="es">
   <file id="security.es">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Ocurrió un error de autenticación.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>No se encontraron las credenciales de autenticación.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>La solicitud de autenticación no se pudo procesar debido a un problema del sistema.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Credenciales no válidas.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>La cookie ya ha sido usada por otra persona.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>No tiene privilegios para solicitar el recurso.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Token CSRF no válido.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>No se encontró un proveedor de autenticación que soporte el token de autenticación.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>No hay ninguna sesión disponible, ha expirado o las cookies no están habilitados.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>No se encontró ningún token.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>No se encontró el nombre de usuario.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>La cuenta ha expirado.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Las credenciales han expirado.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>La cuenta está deshabilitada.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>La cuenta está bloqueada.</target>
+      </segment>
+    </unit>
+    <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
+        <source>User is disabled.</source>
+        <target>El usuario está deshabilitado.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Debe iniciar sesión para acceder a esta página.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo más tarde.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo en %minutes% minuto.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo en %minutes% minutos.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.fr.xlf
+++ b/translations/security.fr.xlf
@@ -2,99 +2,185 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
   <file id="security.fr">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Une exception dans l'authentification s'est produite.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Les informations d'authentification n'ont pas été trouvé</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>La demande d'authentification n'a pas pu être traitée en raison d'un problème système.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Identifiants invalides</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Le cookie a déjà été utilisé par quelqu'un d'autre.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Vous n'avez pas les privilèges nécessaires pour demander cette ressource.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Jeton CSRF non valide.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Aucun fournisseur d'authentification trouvé pour prendre en charge le jeton d'authentification.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Aucune session disponible, elle a expiré ou les cookies ne sont pas activés.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Aucun jeton n'a pu être trouvé.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Le nom d'utilisateur est introuvable.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Le compte a expiré.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Les informations d'identification ont expiré.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Le compte est désactivé.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Le compte est verrouillé.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
       <segment>
         <source>User is disabled.</source>
         <target>L'utilisateur est désactivé.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Vous devez vous connecter pour accéder à cette page.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Plusieurs tentatives de connexion ont échoué, veuillez réessayer plus tard.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Plusieurs tentatives de connexion ont échoué, veuillez réessayer dans %minutes% minute.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Trop de tentatives de connexion échouées, veuillez réessayer dans %minutes% minutes.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.hu.xlf
+++ b/translations/security.hu.xlf
@@ -1,70 +1,187 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="hu" target-language="hu" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="baI_ZxO" resname="An authentication exception occurred.">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="hu">
+  <file id="security.hu">
+    <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
+      <segment>
         <source>An authentication exception occurred.</source>
         <target>Hitelesítési hiba lépett fel.</target>
-      </trans-unit>
-      <trans-unit id="OETylMq" resname="Authentication credentials could not be found.">
+      </segment>
+    </unit>
+    <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
+      <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Nem találhatók hitelesítési információk.</target>
-      </trans-unit>
-      <trans-unit id="3RJINQ0" resname="Authentication request could not be processed due to a system problem.">
+      </segment>
+    </unit>
+    <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
+      <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>A hitelesítési kérést rendszerhiba miatt nem lehet feldolgozni.</target>
-      </trans-unit>
-      <trans-unit id="qr0aiUo" resname="Invalid credentials.">
+      </segment>
+    </unit>
+    <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
+      <segment>
         <source>Invalid credentials.</source>
         <target>Érvénytelen hitelesítési információk.</target>
-      </trans-unit>
-      <trans-unit id="zrJWK0F" resname="Cookie has already been used by someone else.">
+      </segment>
+    </unit>
+    <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
+      <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Ezt a sütit valaki más már felhasználta.</target>
-      </trans-unit>
-      <trans-unit id="blC0fXX" resname="Not privileged to request the resource.">
+      </segment>
+    </unit>
+    <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
+      <segment>
         <source>Not privileged to request the resource.</source>
         <target>Nem rendelkezik az erőforrás eléréséhez szükséges jogosultsággal.</target>
-      </trans-unit>
-      <trans-unit id="dLzMRPR" resname="Invalid CSRF token.">
+      </segment>
+    </unit>
+    <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
+      <segment>
         <source>Invalid CSRF token.</source>
         <target>Érvénytelen CSRF token.</target>
-      </trans-unit>
-      <trans-unit id="PhhlLem" resname="No authentication provider found to support the authentication token.">
+      </segment>
+    </unit>
+    <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
+      <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Nem található a hitelesítési tokent támogató hitelesítési szolgáltatás.</target>
-      </trans-unit>
-      <trans-unit id="v_RS21A" resname="No session available, it either timed out or cookies are not enabled.">
+      </segment>
+    </unit>
+    <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
+      <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Munkamenet nem áll rendelkezésre, túllépte az időkeretet vagy a sütik le vannak tiltva.</target>
-      </trans-unit>
-      <trans-unit id="EYCKpDH" resname="No token could be found.">
+      </segment>
+    </unit>
+    <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
+      <segment>
         <source>No token could be found.</source>
         <target>Nem található token.</target>
-      </trans-unit>
-      <trans-unit id="z3cOUZo" resname="Username could not be found.">
+      </segment>
+    </unit>
+    <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
+      <segment>
         <source>Username could not be found.</source>
         <target>A felhasználónév nem található.</target>
-      </trans-unit>
-      <trans-unit id="By5eLYM" resname="Account has expired.">
+      </segment>
+    </unit>
+    <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
+      <segment>
         <source>Account has expired.</source>
         <target>A fiók lejárt.</target>
-      </trans-unit>
-      <trans-unit id="YfZhiuA" resname="Credentials have expired.">
+      </segment>
+    </unit>
+    <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
+      <segment>
         <source>Credentials have expired.</source>
         <target>A hitelesítési információk lejártak.</target>
-      </trans-unit>
-      <trans-unit id="NrSSfLs" resname="Account is disabled.">
+      </segment>
+    </unit>
+    <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
+      <segment>
         <source>Account is disabled.</source>
         <target>Felfüggesztett fiók.</target>
-      </trans-unit>
-      <trans-unit id="O5ZyxHr" resname="Account is locked.">
+      </segment>
+    </unit>
+    <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
+      <segment>
         <source>Account is locked.</source>
         <target>Zárolt fiók.</target>
-      </trans-unit>
-    </body>
+      </segment>
+    </unit>
+    <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
+        <source>User is disabled.</source>
+        <target>A felhasználó le van tiltva.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Az oldal megtekintéséhez be kell jelentkeznie.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Túl sok sikertelen bejelentkezési kísérlet, kérjük próbálja újra később.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Túl sok sikertelen bejelentkezési kísérlet, kérjük próbálja újra %minutes% perc múlva.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Túl sok sikertelen bejelentkezési kísérlet, kérjük, próbálja újra %minutes% perc múlva.</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/security.nl.xlf
+++ b/translations/security.nl.xlf
@@ -1,94 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl" trgLang="nl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="security.nl">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Er heeft zich een authenticatieprobleem voorgedaan.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Authenticatiegegevens konden niet worden gevonden.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Authenticatieaanvraag kon niet worden verwerkt door een technisch probleem.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Ongeldige inloggegevens.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Cookie is al door een ander persoon gebruikt.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Onvoldoende rechten om de aanvraag te verwerken.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>CSRF-code is ongeldig.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Geen authenticatieprovider gevonden die de authenticatietoken ondersteunt.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Geen sessie beschikbaar, mogelijk is deze verlopen of cookies zijn uitgeschakeld.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Er kon geen authenticatietoken worden gevonden.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Gebruikersnaam kon niet worden gevonden.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Account is verlopen.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Authenticatiegegevens zijn verlopen.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Account is gedeactiveerd.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Account is geblokkeerd.</target>
+      </segment>
+    </unit>
+    <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
+        <source>User is disabled.</source>
+        <target>Gebruiker is uitgeschakeld.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>U moet inloggen om deze pagina te openen.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Te veel onjuiste inlogpogingen, probeer het later nogmaals.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Te veel onjuiste inlogpogingen, probeer het opnieuw over %minutes% minuut.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Te veel onjuiste inlogpogingen, probeer het opnieuw over %minutes% minuten.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.ru.xlf
+++ b/translations/security.ru.xlf
@@ -1,107 +1,187 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="ru" trgLang="ru">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="ru">
   <file id="security.ru">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Произошла ошибка аутентификации.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Не удалось найти учётные данные для аутентификации.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Запрос аутентификации не может быть обработан из-за системной проблемы.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Неверные учётные данные.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Cookie уже использовался кем-то другим.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Нет прав для запроса ресурса.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Недействительный CSRF токен.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Не найден провайдер аутентификации, поддерживающий токен аутентификации.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Сеанс недоступен: либо время ожидания истекло, либо файлы cookie не включены.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Не удалось найти токен.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Имя пользователя не найдено.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Срок действия учётной записи истёк.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Срок действия учётных данных истёк.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Аккаунт отключен.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Аккаунт заблокирован.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
       <segment>
         <source>User is disabled.</source>
         <target>Пользователь отключён.</target>
       </segment>
     </unit>
-	<unit id="NF.vvAN" name="You have to login in order to access this page.">
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
       <segment>
         <source>You have to login in order to access this page.</source>
         <target>Для доступа к этой странице вам необходимо войти в систему.</target>
       </segment>
     </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Слишком много неудачных попыток входа, пожалуйста, попробуйте позже.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Слишком много неудачных попыток входа, повторите попытку через %minutes% минуту.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Слишком много неудачных попыток входа, повторите попытку через %minutes% минуту.|Слишком много неудачных попыток входа, повторите попытку через %minutes% минуты.|Слишком много неудачных попыток входа, повторите попытку через %minutes% минут.</target>
+      </segment>
+    </unit>
   </file>
-</xliff> 
+</xliff>

--- a/translations/security.tr.xlf
+++ b/translations/security.tr.xlf
@@ -1,100 +1,186 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="security.en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="tr">
+  <file id="security.tr">
     <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
       <segment>
         <source>An authentication exception occurred.</source>
         <target>Bir kimlik doğrulama istisnası oluştu.</target>
       </segment>
     </unit>
     <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>Authentication credentials could not be found.</source>
         <target>Kimlik doğrulama kimlik bilgileri bulunamadı.</target>
       </segment>
     </unit>
     <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
       <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>Bir sistem sorunu nedeniyle kimlik doğrulama isteği işlenemedi.</target>
       </segment>
     </unit>
     <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
       <segment>
         <source>Invalid credentials.</source>
         <target>Geçersiz kimlik bilgileri.</target>
       </segment>
     </unit>
     <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
       <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Çerez zaten başkası tarafından kullanıldı.</target>
       </segment>
     </unit>
     <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
       <segment>
         <source>Not privileged to request the resource.</source>
         <target>Kaynağı talep etme ayrıcalığına sahip değil.</target>
       </segment>
     </unit>
     <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
       <segment>
         <source>Invalid CSRF token.</source>
         <target>Geçersiz CSRF jetonu.</target>
       </segment>
     </unit>
     <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
       <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>Kimlik doğrulama jetonunu destekleyen hiçbir kimlik doğrulama sağlayıcısı bulunamadı.</target>
       </segment>
     </unit>
     <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
       <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Kullanılabilir oturum yok, ya zaman aşımına uğradı ya da tanımlama bilgileri etkinleştirilmedi.</target>
       </segment>
     </unit>
     <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
       <segment>
         <source>No token could be found.</source>
         <target>Belirteç bulunamadı.</target>
       </segment>
     </unit>
     <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
       <segment>
         <source>Username could not be found.</source>
         <target>Kullanıcı adı bulunamadı.</target>
       </segment>
     </unit>
     <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Account has expired.</source>
         <target>Hesabın süresi doldu.</target>
       </segment>
     </unit>
     <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
       <segment>
         <source>Credentials have expired.</source>
         <target>Kimlik bilgilerinin süresi doldu.</target>
       </segment>
     </unit>
     <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
       <segment>
         <source>Account is disabled.</source>
         <target>Hesap devredışı.</target>
       </segment>
     </unit>
     <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
       <segment>
         <source>Account is locked.</source>
         <target>Hesap kilitlendi.</target>
       </segment>
     </unit>
     <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
       <segment>
         <source>User is disabled.</source>
         <target>Kullanıcı devre dışı bırakıldı.</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>Bu sayfaya erişmek için giriş yapmalısınız.</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>Çok fazla başarısız giriş denemesi, lütfen daha sonra tekrar deneyin.</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
       </segment>
     </unit>
   </file>

--- a/translations/security.zh_CN.xlf
+++ b/translations/security.zh_CN.xlf
@@ -1,70 +1,187 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="zh-CN" target-language="zh-CN" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="baI_ZxO" resname="An authentication exception occurred.">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="zh-CN">
+  <file id="security.zh_CN">
+    <unit id="baI_ZxO" name="An authentication exception occurred.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationException.php:95</note>
+      </notes>
+      <segment>
         <source>An authentication exception occurred.</source>
         <target>身份验证发生异常。</target>
-      </trans-unit>
-      <trans-unit id="OETylMq" resname="Authentication credentials could not be found.">
+      </segment>
+    </unit>
+    <unit id="OETylMq" name="Authentication credentials could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationCredentialsNotFoundException.php:25</note>
+      </notes>
+      <segment>
         <source>Authentication credentials could not be found.</source>
         <target>没有找到身份验证的凭证。</target>
-      </trans-unit>
-      <trans-unit id="3RJINQ0" resname="Authentication request could not be processed due to a system problem.">
+      </segment>
+    </unit>
+    <unit id="3RJINQ0" name="Authentication request could not be processed due to a system problem.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AuthenticationServiceException.php:24</note>
+      </notes>
+      <segment>
         <source>Authentication request could not be processed due to a system problem.</source>
         <target>由于系统故障，身份验证的请求无法被处理。</target>
-      </trans-unit>
-      <trans-unit id="qr0aiUo" resname="Invalid credentials.">
+      </segment>
+    </unit>
+    <unit id="qr0aiUo" name="Invalid credentials.">
+      <notes>
+        <note>tests/cypress/integration/login.spec.js:7</note>
+      </notes>
+      <segment>
         <source>Invalid credentials.</source>
         <target>无效的凭证。</target>
-      </trans-unit>
-      <trans-unit id="zrJWK0F" resname="Cookie has already been used by someone else.">
+      </segment>
+    </unit>
+    <unit id="zrJWK0F" name="Cookie has already been used by someone else.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CookieTheftException.php:25</note>
+      </notes>
+      <segment>
         <source>Cookie has already been used by someone else.</source>
         <target>Cookie 已经被其他人使用。</target>
-      </trans-unit>
-      <trans-unit id="blC0fXX" resname="Not privileged to request the resource.">
+      </segment>
+    </unit>
+    <unit id="blC0fXX" name="Not privileged to request the resource.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InsufficientAuthenticationException.php:26</note>
+      </notes>
+      <segment>
         <source>Not privileged to request the resource.</source>
         <target>没有权限请求此资源。</target>
-      </trans-unit>
-      <trans-unit id="dLzMRPR" resname="Invalid CSRF token.">
+      </segment>
+    </unit>
+    <unit id="dLzMRPR" name="Invalid CSRF token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/InvalidCsrfTokenException.php:24</note>
+        <note>vendor/symfony/security-http/EventListener/CsrfProtectionListener.php:51</note>
+        <note>vendor/symfony/security-http/Firewall/LogoutListener.php:79</note>
+      </notes>
+      <segment>
         <source>Invalid CSRF token.</source>
         <target>无效的 CSRF token 。</target>
-      </trans-unit>
-      <trans-unit id="PhhlLem" resname="No authentication provider found to support the authentication token.">
+      </segment>
+    </unit>
+    <unit id="PhhlLem" name="No authentication provider found to support the authentication token.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/ProviderNotFoundException.php:25</note>
+      </notes>
+      <segment>
         <source>No authentication provider found to support the authentication token.</source>
         <target>没有找到支持此 token 的身份验证服务提供方。</target>
-      </trans-unit>
-      <trans-unit id="v_RS21A" resname="No session available, it either timed out or cookies are not enabled.">
+      </segment>
+    </unit>
+    <unit id="v_RS21A" name="No session available, it either timed out or cookies are not enabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/SessionUnavailableException.php:30</note>
+      </notes>
+      <segment>
         <source>No session available, it either timed out or cookies are not enabled.</source>
         <target>Session 不可用。会话超时或没有启用 cookies 。</target>
-      </trans-unit>
-      <trans-unit id="EYCKpDH" resname="No token could be found.">
+      </segment>
+    </unit>
+    <unit id="EYCKpDH" name="No token could be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/TokenNotFoundException.php:24</note>
+      </notes>
+      <segment>
         <source>No token could be found.</source>
         <target>找不到 token 。</target>
-      </trans-unit>
-      <trans-unit id="z3cOUZo" resname="Username could not be found.">
+      </segment>
+    </unit>
+    <unit id="z3cOUZo" name="Username could not be found.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/UserNotFoundException.php:26</note>
+      </notes>
+      <segment>
         <source>Username could not be found.</source>
         <target>找不到用户名。</target>
-      </trans-unit>
-      <trans-unit id="By5eLYM" resname="Account has expired.">
+      </segment>
+    </unit>
+    <unit id="By5eLYM" name="Account has expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/AccountExpiredException.php:24</note>
+      </notes>
+      <segment>
         <source>Account has expired.</source>
         <target>帐号已过期。</target>
-      </trans-unit>
-      <trans-unit id="YfZhiuA" resname="Credentials have expired.">
+      </segment>
+    </unit>
+    <unit id="YfZhiuA" name="Credentials have expired.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/CredentialsExpiredException.php:24</note>
+      </notes>
+      <segment>
         <source>Credentials have expired.</source>
         <target>凭证已过期。</target>
-      </trans-unit>
-      <trans-unit id="NrSSfLs" resname="Account is disabled.">
+      </segment>
+    </unit>
+    <unit id="NrSSfLs" name="Account is disabled.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/DisabledException.php:24</note>
+      </notes>
+      <segment>
         <source>Account is disabled.</source>
         <target>帐号已被禁用。</target>
-      </trans-unit>
-      <trans-unit id="O5ZyxHr" resname="Account is locked.">
+      </segment>
+    </unit>
+    <unit id="O5ZyxHr" name="Account is locked.">
+      <notes>
+        <note>vendor/symfony/security-core/Exception/LockedException.php:24</note>
+      </notes>
+      <segment>
         <source>Account is locked.</source>
         <target>帐号已被锁定。</target>
-      </trans-unit>
-    </body>
+      </segment>
+    </unit>
+    <unit id="w7KhJ8F" name="User is disabled.">
+      <notes>
+        <note>src/Exception/DisabledUserLoginAttemptException.php:16</note>
+      </notes>
+      <segment>
+        <source>User is disabled.</source>
+        <target>用户已被禁用。</target>
+      </segment>
+    </unit>
+    <unit id="NF.vvAN" name="You have to login in order to access this page.">
+      <notes>
+        <note>src/Security/AuthenticationEntryPointRedirector.php:26</note>
+      </notes>
+      <segment>
+        <source>You have to login in order to access this page.</source>
+        <target>您必须登录才能访问此页面。</target>
+      </segment>
+    </unit>
+    <unit id="gd.MOnZ" name="Too many failed login attempts, please try again later.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again later.</source>
+        <target>登入失败的次数过多，请稍后再试。</target>
+      </segment>
+    </unit>
+    <unit id="9qGC3hG" name="Too many failed login attempts, please try again in %minutes% minute.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+        <target>登入失败的次数过多，请在%minutes%分钟后再试。</target>
+      </segment>
+    </unit>
+    <unit id="AJR3lMs" name="Too many failed login attempts, please try again in %minutes% minutes.">
+      <notes>
+        <note>~vendor/symfony/security-core/Exception/TooManyLoginAttemptsAuthenticationException.php:39</note>
+      </notes>
+      <segment>
+        <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+        <target>登录尝试失败次数过多，请在 %minutes% 分钟后重试。</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/validators.cs.xlf
+++ b/translations/validators.cs.xlf
@@ -2,162 +2,194 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="cs">
   <file id="validators.cs">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Tato hodnota by měla být false.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Tato hodnota by měla být true.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Tato hodnota by měla být typu {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Tato hodnota by měla být prázdná.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Vámi vybraná hodnota není platnou volbou.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Musíte vybrat alespoň {{ limit }} možnost.|Musíte vybrat alespoň {{ limit }} možností.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Musíte vybrat nejvýše {{ limit }} možnost.|Musíte vybrat nejvýše {{ limit }} možností.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Jedna nebo více zadaných hodnot je neplatná.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Toto pole se neočekávalo.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Toto pole chybí.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Tato hodnota neodpovídá platnému datu.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Tato hodnota neodpovídá platnému datu a času.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Tato hodnota není platnou e-mailovou adresou.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Soubor se nepodařilo najít.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Soubor není čitelný.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Soubor je příliš velký ({{ size }} {{ suffix }}). Maximální povolená velikost je {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Typ mime souboru je neplatný ({{ type }}). Povolené typy mime jsou {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Tato hodnota by měla být {{ limit }} nebo nižší.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Tato hodnota je příliš dlouhá. Měla by mít maximálně {{ limit }} znak nebo méně.|Tato hodnota je příliš dlouhá. Měla by mít maximálně {{ limit }} znaků nebo méně.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Tato hodnota by měla být {{ limit }} nebo vyšší.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Tato hodnota je příliš krátká. Měla by mít minimálně {{ limit }} znak nebo více.|Tato hodnota je příliš krátká. Měla by mít minimálně {{ limit }} znaků nebo více.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Tato hodnota by neměla být prázdná.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Tato hodnota by neměla být null.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Tato hodnota by měla být null.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Tato hodnota není platná.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Tato hodnota neodpovídá platné časové specifikaci.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Tato hodnota není platnou adresou URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>Soubor je příliš velký. Maximální povolená velikost je {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Soubor je příliš velký.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Soubor se nepodařilo nahrát.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Tato hodnota by měla být platné číslo.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Tento soubor není platným obrázkem.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Toto není platná IP adresa.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Tato hodnota není platným jazykem.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Tato hodnota neodpovídá platnému národnímu prostředí.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Tato hodnota není platnou zemí.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Tato hodnota je již použita.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Velikost obrázku se nepodařilo zjistit.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>Šířka obrázku je příliš velká ({{ width }}px). Povolená maximální šířka je {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>Šířka obrázku je příliš malá ({{ width }}px). Minimální očekávaná šířka je {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>Výška obrázku je příliš velká ({{ height }}px). Povolená maximální výška je {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>Výška obrázku je příliš malá ({{ height }}px). Minimální očekávaná výška je {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Tato hodnota by měla odpovídat aktuálnímu uživatelskému heslu.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Tato hodnota by měla mít přesně {{ limit }} znak.|Tato hodnota by měla mít přesně {{ limit }} znaků.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Soubor byl nahrán pouze částečně.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Nebyl nahrán žádný soubor.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>V souboru php.ini nebyla nakonfigurována žádná dočasná složka nebo nakonfigurovaná složka neexistuje.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Nelze zapsat dočasný soubor na disk.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Nahrávání se nezdařilo kvůli PHP rozšíření.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Tato kolekce by měla obsahovat alespoň {{ limit }} prvek nebo více.|Tato kolekce by měla obsahovat alespoň {{ limit }} prvků nebo více.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Tato kolekce by měla obsahovat maximálně {{ limit }} prvek.|Tato kolekce by měla obsahovat maximálně {{ limit }} prvků nebo méně.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Tato kolekce by měla obsahovat právě {{ limit }} prvek.|Tato kolekce by měla obsahovat právě {{ limit }} prvků.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Neplatné číslo karty.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Nepodporovaný typ karty nebo neplatné číslo karty.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Toto není platné mezinárodní číslo bankovního účtu (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Tato hodnota není platným ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Tato hodnota není platným ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Tato hodnota není platným číslem ISBN-10 ani platným číslem ISBN-13.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Tato hodnota není platným ISSN.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Tato hodnota není platnou měnou.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Tato hodnota by se měla rovnat {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Tato hodnota by měla být větší než {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Tato hodnota by měla být větší nebo rovna {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Tato hodnota by měla být shodná s {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Tato hodnota by měla být menší než {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Tato hodnota by měla být menší nebo rovna {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Tato hodnota by neměla být rovna {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Tato hodnota by neměla být totožná s {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Poměr obrázku je příliš velký ({{ ratio }}). Maximálně povolený poměr je {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Poměr obrázku je příliš malý ({{ ratio }}). Minimální očekávaný poměr je {{ min_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>Obrázek je čtvercový ({{ width }}x{{ height }}px). Čtvercové obrázky nejsou povoleny.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>Obrázek je orientován na šířku ({{ width }}x{{ height }}px). Obrázky orientované na šířku nejsou povoleny.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>Obrázek je orientován na výšku ({{ width }}x{{ height }}px). Obrázky orientované na výšku nejsou povoleny.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Prázdný soubor není povolen.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Tato hodnota neodpovídá očekávané {{ charset }} znakové sadě.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Toto není platný identifikační kód podniku (BIC).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Chyba</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Toto není platný identifikátor UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Tato hodnota by měla být násobkem hodnoty{{ compared_value }}.</target>
+        <target>Tato hodnota by měla být násobkem hodnoty {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Tento obchodní identifikační kód (BIC) není spojen s IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Tato hodnota by měla být platný JSON.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
-        <target>Tato kolekce by měla obsahovat pouze unikátní prvky</target>
+        <target>Tato kolekce by měla obsahovat pouze unikátní prvky.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Tato hodnota by měla být kladná.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Tato hodnota by měla být buď kladná, nebo nula.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Tato hodnota by měla být záporná.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Tato hodnota by měla být buď záporná, nebo nula.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Tato hodnota není platným časovým pásmem.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Toto heslo uniklo při úniku dat a nesmí být použito. Použijte prosím jiné heslo.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Tato hodnota by měla být mezi {{ min }} a {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Tento formulář by neměl obsahovat žádná další pole.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Nahraný soubor je příliš velký. Zkuste prosím nahrát menší soubor.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Token CSRF je neplatný. Zkuste prosím formulář odeslat znovu.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Uveďte prosím shrnutí svého příspěvku!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Váš příspěvek by měl mít nějaký obsah!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Obsah příspěvku je příliš krátký (minimálně {{ limit }} znaků)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Příliš mnoho značek (přidejte {{ limit }} značek nebo méně)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Nenechávejte prosím svůj komentář prázdný!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Komentář je příliš krátký (minimálně {{ limit }} znaků)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Komentář je příliš dlouhý ({{ limit }} maximálně znaků)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Obsah tohoto komentáře je považován za spam.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
-        <target>Uživatel s {{ value }} e-mailem již existuje.</target>
+        <target>Uživatel s e-mailem {{ value }} již existuje.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
         <target>Uživatel s uživatelským jménem {{ value }} již existuje.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Neplatné heslo. Heslo by mělo obsahovat alespoň 6 znaků.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Neplatný e-mail</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Uživatelské jméno musí obsahovat pouze malá písmena latinky, čísla a podtržítka.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Nesprávné zobrazované jméno</target>

--- a/translations/validators.de.xlf
+++ b/translations/validators.de.xlf
@@ -1,70 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="de">
   <file id="validators.de">
-    <unit id="LDy5h0B" name="user.duplicate_email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.duplicate_email</source>
-        <target>Ein Benutzer mit der E-Mail {{ value }} existiert bereits</target>
-      </segment>
-    </unit>
-    <unit id="D4OMpCY" name="user.duplicate_username">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.duplicate_username</source>
-        <target>Ein Benutzer mit Benutzername {{ value }} existiert bereits</target>
-      </segment>
-    </unit>
-    <unit id="4oq.CNw" name="user.not_valid_display_name">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.not_valid_display_name</source>
-        <target>Ungültiger Anzeigename</target>
-      </segment>
-    </unit>
-    <unit id="4eH4IFY" name="user.username_invalid_characters">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.username_invalid_characters</source>
-        <target>Der Benutzername darf nur lateinische Kleinbuchstaben, Zahlen und Unterstriche enthalten.</target>
-      </segment>
-    </unit>
-    <unit id="fkXL.k6" name="user.not_valid_email">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.not_valid_email</source>
-        <target>Ungültige E-Mail</target>
-      </segment>
-    </unit>
-    <unit id="HjWW.NS" name="user.not_valid_password">
-      <notes>
-        <note category="file-source" priority="1">bolt-core/src/Entity/User.php:0</note>
-        <note category="state" priority="1">new</note>
-      </notes>
-      <segment>
-        <source>user.not_valid_password</source>
-        <target>Ungültiges Passwort. Das Passwort sollte mindestens 6 Zeichen enthalten.</target>
-      </segment>
-    </unit>
     <unit id="zh5oKD9" name="This value should be false.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
       </notes>
       <segment>
         <source>This value should be false.</source>
@@ -73,7 +12,7 @@
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
       </notes>
       <segment>
         <source>This value should be true.</source>
@@ -82,7 +21,8 @@
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
       </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
@@ -91,7 +31,7 @@
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
       </notes>
       <segment>
         <source>This value should be blank.</source>
@@ -100,34 +40,16 @@
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
       </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Sie haben einen ungültigen Wert ausgewählt.</target>
       </segment>
     </unit>
-    <unit id="u81CkP8">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-        <target>Sie müssen mindestens {{ limit }} Möglichkeit wählen.|Sie müssen mindestens {{ limit }} Möglichkeiten wählen.</target>
-      </segment>
-    </unit>
-    <unit id="nIvOQ_o">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-        <target>Sie dürfen höchstens {{ limit }} Möglichkeit wählen.|Sie dürfen höchstens {{ limit }} Möglichkeiten wählen.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
       </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
@@ -136,7 +58,7 @@
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
       </notes>
       <segment>
         <source>This field was not expected.</source>
@@ -145,7 +67,7 @@
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
       </notes>
       <segment>
         <source>This field is missing.</source>
@@ -154,7 +76,7 @@
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
       </notes>
       <segment>
         <source>This value is not a valid date.</source>
@@ -163,7 +85,8 @@
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
       </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
@@ -172,7 +95,7 @@
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
       </notes>
       <segment>
         <source>This value is not a valid email address.</source>
@@ -181,7 +104,7 @@
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
       </notes>
       <segment>
         <source>The file could not be found.</source>
@@ -190,70 +113,34 @@
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
       </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Die Datei ist nicht lesbar.</target>
       </segment>
     </unit>
-    <unit id="JocOVM2">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>Die Datei ist zu groß ({{ size }} {{ suffix }}). Die maximal zulässige Größe beträgt {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="YW21SPH">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-        <target>Der Dateityp ist ungültig ({{ type }}). Erlaubte Dateitypen sind {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
       </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Dieser Wert sollte kleiner oder gleich {{ limit }} sein.</target>
       </segment>
     </unit>
-    <unit id="HX7TOFm">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-        <target>Diese Zeichenkette ist zu lang. Sie sollte höchstens {{ limit }} Zeichen haben.|Diese Zeichenkette ist zu lang. Sie sollte höchstens {{ limit }} Zeichen haben.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
       </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Dieser Wert sollte größer oder gleich {{ limit }} sein.</target>
       </segment>
     </unit>
-    <unit id="ekfrU.c">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-        <target>Diese Zeichenkette ist zu kurz. Sie sollte mindestens {{ limit }} Zeichen haben.|Diese Zeichenkette ist zu kurz. Sie sollte mindestens {{ limit }} Zeichen haben.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
       </notes>
       <segment>
         <source>This value should not be blank.</source>
@@ -262,7 +149,7 @@
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
       </notes>
       <segment>
         <source>This value should not be null.</source>
@@ -271,7 +158,7 @@
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
       </notes>
       <segment>
         <source>This value should be null.</source>
@@ -280,7 +167,10 @@
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
       </notes>
       <segment>
         <source>This value is not valid.</source>
@@ -289,7 +179,7 @@
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
       </notes>
       <segment>
         <source>This value is not a valid time.</source>
@@ -298,7 +188,7 @@
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
       </notes>
       <segment>
         <source>This value is not a valid URL.</source>
@@ -306,9 +196,6 @@
       </segment>
     </unit>
     <unit id="jpaLsb2" name="The two values should be equal.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
       <segment>
         <source>The two values should be equal.</source>
         <target>Die beiden Werte sollten identisch sein.</target>
@@ -316,7 +203,8 @@
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
       </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
@@ -325,7 +213,8 @@
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
       </notes>
       <segment>
         <source>The file is too large.</source>
@@ -334,7 +223,8 @@
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
       </notes>
       <segment>
         <source>The file could not be uploaded.</source>
@@ -343,7 +233,7 @@
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
       </notes>
       <segment>
         <source>This value should be a valid number.</source>
@@ -352,7 +242,7 @@
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
       </notes>
       <segment>
         <source>This file is not a valid image.</source>
@@ -361,7 +251,7 @@
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
       </notes>
       <segment>
         <source>This is not a valid IP address.</source>
@@ -370,7 +260,7 @@
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
       </notes>
       <segment>
         <source>This value is not a valid language.</source>
@@ -379,7 +269,7 @@
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
       </notes>
       <segment>
         <source>This value is not a valid locale.</source>
@@ -388,7 +278,7 @@
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
       </notes>
       <segment>
         <source>This value is not a valid country.</source>
@@ -397,7 +287,7 @@
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
       </notes>
       <segment>
         <source>This value is already used.</source>
@@ -406,70 +296,25 @@
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
       </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Die Größe des Bildes konnte nicht ermittelt werden.</target>
       </segment>
     </unit>
-    <unit id="zVtJJEa">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-        <target>Die Bildbreite ist zu groß ({{ width }}px). Die maximal zulässige Breite beträgt {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="s8LFQGC">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-        <target>Die Bildbreite ist zu gering ({{ width }}px). Die erwartete Mindestbreite beträgt {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="Z.NgqFj">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-        <target>Die Bildhöhe ist zu groß ({{ height }}px). Die maximal zulässige Höhe beträgt {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="AW1lWVM">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-        <target>Die Bildhöhe ist zu gering ({{ height }}px). Die erwartete Mindesthöhe beträgt {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
       </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Dieser Wert sollte dem aktuellen Benutzerpasswort entsprechen.</target>
       </segment>
     </unit>
-    <unit id="gYImVyV">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-        <target>Dieser Wert sollte genau {{ limit }} Zeichen lang sein.|Dieser Wert sollte genau {{ limit }} Zeichen lang sein.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
       </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
@@ -478,7 +323,7 @@
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
       </notes>
       <segment>
         <source>No file was uploaded.</source>
@@ -487,7 +332,7 @@
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
       </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
@@ -496,7 +341,7 @@
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
       </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
@@ -505,43 +350,16 @@
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
       </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Eine PHP-Erweiterung verhinderte den Upload.</target>
       </segment>
     </unit>
-    <unit id="gTJYRl6">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-        <target>Diese Sammlung sollte {{ limit }} oder mehr Elemente beinhalten.|Diese Sammlung sollte {{ limit }} oder mehr Elemente beinhalten.</target>
-      </segment>
-    </unit>
-    <unit id="FFn3lVn">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-        <target>Diese Sammlung sollte {{ limit }} oder weniger Elemente beinhalten.|Diese Sammlung sollte {{ limit }} oder weniger Elemente beinhalten.</target>
-      </segment>
-    </unit>
-    <unit id="bSdilZv">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-        <target>Diese Sammlung sollte genau {{ limit }} Element beinhalten.|Diese Sammlung sollte genau {{ limit }} Elemente beinhalten.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
       </notes>
       <segment>
         <source>Invalid card number.</source>
@@ -550,7 +368,7 @@
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
       </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
@@ -559,7 +377,7 @@
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
       </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
@@ -568,7 +386,7 @@
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
       </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
@@ -577,7 +395,7 @@
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
       </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
@@ -586,7 +404,7 @@
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
       </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
@@ -595,7 +413,7 @@
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
       </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
@@ -604,7 +422,7 @@
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
       </notes>
       <segment>
         <source>This value is not a valid currency.</source>
@@ -613,7 +431,7 @@
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
       </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
@@ -622,7 +440,7 @@
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
       </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
@@ -631,25 +449,16 @@
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
       </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Dieser Wert sollte größer oder gleich {{ compared_value }} sein.</target>
       </segment>
     </unit>
-    <unit id="bOF1fpm">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Dieser Wert sollte identisch sein mit {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
       </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
@@ -658,7 +467,7 @@
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
       </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
@@ -667,70 +476,25 @@
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
       </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Dieser Wert sollte nicht {{ compared_value }} sein.</target>
       </segment>
     </unit>
-    <unit id="Bi22JLt">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Dieser Wert sollte nicht identisch sein mit {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="VczCWzQ">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-        <target>Das Seitenverhältnis des Bildes ist zu groß ({{ ratio }}). Der erlaubte Maximalwert ist {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="v57PXhq">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-        <target>Das Seitenverhältnis des Bildes ist zu klein ({{ ratio }}). Der erwartete Minimalwert ist {{ min_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
       </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>Das Bild ist quadratisch ({{ width }}x{{ height }}px). Quadratische Bilder sind nicht erlaubt.</target>
       </segment>
     </unit>
-    <unit id="G_lu2qW">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-        <target>Das Bild ist im Querformat ({{ width }}x{{ height }}px). Bilder im Querformat sind nicht erlaubt.</target>
-      </segment>
-    </unit>
-    <unit id="sFyGx4B">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-        <target>Das Bild ist im Hochformat ({{ width }}x{{ height }}px). Bilder im Hochformat sind nicht erlaubt.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
       </notes>
       <segment>
         <source>An empty file is not allowed.</source>
@@ -738,9 +502,6 @@
       </segment>
     </unit>
     <unit id="bcfVezI" name="The host could not be resolved.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
       <segment>
         <source>The host could not be resolved.</source>
         <target>Der Hostname konnte nicht aufgelöst werden.</target>
@@ -748,7 +509,7 @@
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
       </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
@@ -757,7 +518,7 @@
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
       </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
@@ -766,7 +527,7 @@
     </unit>
     <unit id="VKDowX6" name="Error">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>assets/js/app/ajax-save.js:37</note>
       </notes>
       <segment>
         <source>Error</source>
@@ -775,7 +536,7 @@
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
       </notes>
       <segment>
         <source>This is not a valid UUID.</source>
@@ -784,7 +545,7 @@
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
       </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -793,7 +554,7 @@
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
       </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
@@ -802,7 +563,7 @@
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
       </notes>
       <segment>
         <source>This value should be valid JSON.</source>
@@ -811,7 +572,7 @@
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
       </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
@@ -820,7 +581,7 @@
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
       </notes>
       <segment>
         <source>This value should be positive.</source>
@@ -829,7 +590,7 @@
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
       </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
@@ -838,7 +599,7 @@
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
       </notes>
       <segment>
         <source>This value should be negative.</source>
@@ -847,7 +608,7 @@
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
       </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
@@ -856,115 +617,25 @@
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
       </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Dieser Wert ist keine gültige Zeitzone.</target>
       </segment>
     </unit>
-    <unit id="40dnsod">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-        <target>Dieses Passwort ist Teil eines Datenlecks, es darf nicht verwendet werden.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
       </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Dieser Wert sollte zwischen {{ min }} und {{ max }} sein.</target>
       </segment>
     </unit>
-    <unit id="7g313cV" name="This value is not a valid hostname.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is not a valid hostname.</source>
-        <target>Dieser Wert ist kein gültiger Hostname.</target>
-      </segment>
-    </unit>
-    <unit id="xwtBimR">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-        <target>Die Anzahl an Elementen in dieser Sammlung sollte ein Vielfaches von {{ compared_value }} sein.</target>
-      </segment>
-    </unit>
-    <unit id="FDRZr.s" name="This value should satisfy at least one of the following constraints:">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value should satisfy at least one of the following constraints:</source>
-        <target>Dieser Wert sollte eine der folgenden Bedingungen erfüllen:</target>
-      </segment>
-    </unit>
-    <unit id="WwY0IGI" name="Each element of this collection should satisfy its own set of constraints.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Each element of this collection should satisfy its own set of constraints.</source>
-        <target>Jedes Element dieser Sammlung sollte seine eigene Menge an Bedingungen erfüllen.</target>
-      </segment>
-    </unit>
-    <unit id="lrbaa8g" name="This value is not a valid International Securities Identification Number (ISIN).">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-        <target>Dieser Wert ist keine gültige Internationale Wertpapierkennnummer (ISIN).</target>
-      </segment>
-    </unit>
-    <unit id="6akW5mb" name="This value should be a valid expression.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value should be a valid expression.</source>
-        <target>Dieser Wert sollte eine gültige Expression sein.</target>
-      </segment>
-    </unit>
-    <unit id="CQ0wfFa" name="This value is not a valid CSS color.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is not a valid CSS color.</source>
-        <target>Dieser Wert ist keine gültige CSS-Farbe.</target>
-      </segment>
-    </unit>
-    <unit id="GAaG0KN" name="This value is not a valid CIDR notation.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>This value is not a valid CIDR notation.</source>
-        <target>Dieser Wert entspricht nicht der CIDR-Notation.</target>
-      </segment>
-    </unit>
-    <unit id="ddJy.XP" name="The value of the netmask should be between {{ min }} and {{ max }}.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
-        <target>Der Wert der Subnetzmaske sollte zwischen {{ min }} und {{ max }} liegen.</target>
-      </segment>
-    </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
       </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
@@ -973,7 +644,7 @@
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
       </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
@@ -982,361 +653,66 @@
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
       </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Der CSRF-Token ist ungültig. Versuchen Sie bitte das Formular erneut zu senden.</target>
       </segment>
     </unit>
-    <unit id="eo1zeih" name="This value is not a valid HTML5 color.">
+    <unit id="LDy5h0B" name="user.duplicate_email">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:24</note>
       </notes>
       <segment>
-        <source>This value is not a valid HTML5 color.</source>
-        <target>Dieser Wert ist keine gültige HTML5 Farbe.</target>
+        <source>user.duplicate_email</source>
+        <target>Ein Benutzer mit der E-Mail {{ value }} existiert bereits</target>
       </segment>
     </unit>
-    <unit id="dN.ZVc0" name="Please enter a valid birthdate.">
+    <unit id="D4OMpCY" name="user.duplicate_username">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:25</note>
       </notes>
       <segment>
-        <source>Please enter a valid birthdate.</source>
-        <target>Bitte geben Sie ein gültiges Geburtsdatum ein.</target>
+        <source>user.duplicate_username</source>
+        <target>Ein Benutzer mit Benutzername {{ value }} existiert bereits</target>
       </segment>
     </unit>
-    <unit id="OPymPfZ" name="The selected choice is invalid.">
+    <unit id="HjWW.NS" name="user.not_valid_password">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:57</note>
       </notes>
       <segment>
-        <source>The selected choice is invalid.</source>
-        <target>Die Auswahl ist ungültig.</target>
+        <source>user.not_valid_password</source>
+        <target>Ungültiges Passwort. Das Passwort sollte mindestens 6 Zeichen enthalten.</target>
       </segment>
     </unit>
-    <unit id="GUH6TYE" name="The collection is invalid.">
+    <unit id="fkXL.k6" name="user.not_valid_email">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:49</note>
       </notes>
       <segment>
-        <source>The collection is invalid.</source>
-        <target>Diese Gruppe von Feldern ist ungültig.</target>
+        <source>user.not_valid_email</source>
+        <target>Ungültige E-Mail</target>
       </segment>
     </unit>
-    <unit id="14il0ha" name="Please select a valid color.">
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:43</note>
       </notes>
       <segment>
-        <source>Please select a valid color.</source>
-        <target>Bitte geben Sie eine gültige Farbe ein.</target>
+        <source>user.username_invalid_characters</source>
+        <target>Der Benutzername darf nur lateinische Kleinbuchstaben, Zahlen und Unterstriche enthalten.</target>
       </segment>
     </unit>
-    <unit id="4AJRUCC" name="Please select a valid country.">
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
       <notes>
-        <note category="state" priority="1">obsolete</note>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
       </notes>
       <segment>
-        <source>Please select a valid country.</source>
-        <target>Bitte wählen Sie ein gültiges Land aus.</target>
-      </segment>
-    </unit>
-    <unit id="xAI5mrh" name="Please select a valid currency.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid currency.</source>
-        <target>Bitte wählen Sie eine gültige Währung aus.</target>
-      </segment>
-    </unit>
-    <unit id="c6v9ASZ" name="Please choose a valid date interval.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please choose a valid date interval.</source>
-        <target>Bitte wählen Sie ein gültiges Datumsintervall.</target>
-      </segment>
-    </unit>
-    <unit id="2BR60Jg" name="Please enter a valid date and time.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid date and time.</source>
-        <target>Bitte geben Sie ein gültiges Datum samt Uhrzeit ein.</target>
-      </segment>
-    </unit>
-    <unit id="ofLBhv0" name="Please enter a valid date.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid date.</source>
-        <target>Bitte geben Sie ein gültiges Datum ein.</target>
-      </segment>
-    </unit>
-    <unit id="Xsmm6Mc" name="Please select a valid file.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid file.</source>
-        <target>Bitte wählen Sie eine gültige Datei.</target>
-      </segment>
-    </unit>
-    <unit id="Fka0cZD" name="The hidden field is invalid.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The hidden field is invalid.</source>
-        <target>Das versteckte Feld ist ungültig.</target>
-      </segment>
-    </unit>
-    <unit id="69ux5Ml" name="Please enter an integer.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter an integer.</source>
-        <target>Bitte geben Sie eine ganze Zahl ein.</target>
-      </segment>
-    </unit>
-    <unit id="TQbat_9" name="Please select a valid language.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid language.</source>
-        <target>Bitte wählen Sie eine gültige Sprache.</target>
-      </segment>
-    </unit>
-    <unit id="vpa7l8w" name="Please select a valid locale.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid locale.</source>
-        <target>Bitte wählen Sie eine gültige Locale-Einstellung aus.</target>
-      </segment>
-    </unit>
-    <unit id="Gz8pWER" name="Please enter a valid money amount.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid money amount.</source>
-        <target>Bitte geben Sie einen gültigen Geldbetrag ein.</target>
-      </segment>
-    </unit>
-    <unit id="PRxiOhB" name="Please enter a number.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a number.</source>
-        <target>Bitte geben Sie eine gültige Zahl ein.</target>
-      </segment>
-    </unit>
-    <unit id="seAdKJo" name="The password is invalid.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The password is invalid.</source>
-        <target>Das Kennwort ist ungültig.</target>
-      </segment>
-    </unit>
-    <unit id="A5k0Q20" name="Please enter a percentage value.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a percentage value.</source>
-        <target>Bitte geben Sie einen gültigen Prozentwert ein.</target>
-      </segment>
-    </unit>
-    <unit id="rH6V.WA" name="The values do not match.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The values do not match.</source>
-        <target>Die Werte stimmen nicht überein.</target>
-      </segment>
-    </unit>
-    <unit id="Eopl1Sm" name="Please enter a valid time.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid time.</source>
-        <target>Bitte geben Sie eine gültige Uhrzeit ein.</target>
-      </segment>
-    </unit>
-    <unit id="ll14Sm9" name="Please select a valid timezone.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid timezone.</source>
-        <target>Bitte wählen Sie eine gültige Zeitzone.</target>
-      </segment>
-    </unit>
-    <unit id="1xP1kmd" name="Please enter a valid URL.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid URL.</source>
-        <target>Bitte geben Sie eine gültige URL ein.</target>
-      </segment>
-    </unit>
-    <unit id="iMmAsrC" name="Please enter a valid search term.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid search term.</source>
-        <target>Bitte geben Sie einen gültigen Suchbegriff ein.</target>
-      </segment>
-    </unit>
-    <unit id="GRMTXRX" name="Please provide a valid phone number.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please provide a valid phone number.</source>
-        <target>Bitte geben Sie eine gültige Telefonnummer ein.</target>
-      </segment>
-    </unit>
-    <unit id="WkYuMDd" name="The checkbox has an invalid value.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>The checkbox has an invalid value.</source>
-        <target>Das Kontrollkästchen hat einen ungültigen Wert.</target>
-      </segment>
-    </unit>
-    <unit id="lY5Mzyl" name="Please enter a valid email address.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid email address.</source>
-        <target>Bitte geben Sie eine gültige E-Mail-Adresse ein.</target>
-      </segment>
-    </unit>
-    <unit id="TzSC4.o" name="Please select a valid option.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid option.</source>
-        <target>Bitte wählen Sie eine gültige Option.</target>
-      </segment>
-    </unit>
-    <unit id="qGRcTk7" name="Please select a valid range.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please select a valid range.</source>
-        <target>Bitte wählen Sie einen gültigen Bereich.</target>
-      </segment>
-    </unit>
-    <unit id="PU.w6nC" name="Please enter a valid week.">
-      <notes>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>Please enter a valid week.</source>
-        <target>Bitte geben Sie eine gültige Woche ein.</target>
-      </segment>
-    </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Gib deinem Beitrag eine Zusammenfassung!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Dein Beitrag sollte einen Inhalt haben!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Der Beitragsinhalt ist zu kurz (mindestens {{ limit }} Zeichen)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Bitte gib einen Kommentar ein!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Der Kommentar ist zu kurz (mindestens {{ limit }} Zeichen)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Der Kommentar ist zu lang (maximal {{ limit }} Zeichen)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Der Inhalt des Kommentars wird als Spam eingestuft.</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-        <note category="state" priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Zu viele Tags (höchstens {{ limit }} Tags sind erlaubt)</target>
+        <source>user.not_valid_display_name</source>
+        <target>Ungültiger Anzeigename</target>
       </segment>
     </unit>
   </file>

--- a/translations/validators.el.xlf
+++ b/translations/validators.el.xlf
@@ -1,163 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="validators.en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="el">
+  <file id="validators.el">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Αυτή η τιμή πρέπει να είναι false.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Αυτή η τιμή πρέπει να είναι true.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι τύπου{{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Αυτή η τιμή πρέπει να είναι κενή.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Η τιμή που επιλέξατε δεν είναι έγκυρη επιλογή.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Πρέπει να επιλέξετε τουλάχιστον {{ limit }} επιλογές.|Πρέπει να επιλέξετε τουλάχιστον {{ limit }} επιλογές.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Πρέπει να επιλέξετε τουλάχιστον {{ limit }} επιλογές.|Πρέπει να επιλέξετε τουλάχιστον {{ limit }} επιλογές.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Μία ή περισσότερες από τις δεδομένες τιμές δεν είναι έγκυρες.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Αυτό το πεδίο δεν αναμενόταν.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Αυτό το πεδίο λείπει.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη ημερομηνία.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη ημερομηνία και ωρα.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη διεύθυνση email.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Δεν ήταν δυνατή η εύρεση του αρχείου.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Το αρχείο δεν είναι αναγνώσιμο.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Το αρχείο είναι πολύ μεγάλο ({{ size }} {{ suffix }}). Το επιτρεπόμενο μέγιστο μέγεθος είναι {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Ο τύπος του αρχείου δεν είναι έγκυρος({{ type }}). Οι επιτρεπόμενοι τύποι είναι {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
-        <target>Αυτή η τιμή πρέπει να είναι {{limit}} ή μικρότερη.</target>
-      </segment>
-    </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Αυτή η τιμή είναι πολύ μεγάλη. Θα πρέπει να έχει {{limit}} χαρακτήρες ή λιγότερο. | Αυτή η τιμή είναι πολύ μεγάλη. Θα πρέπει να έχει {{limit}} χαρακτήρες ή λιγότερους.</target>
+        <target>Αυτή η τιμή πρέπει να είναι {{ limit }} ή μικρότερη.</target>
       </segment>
     </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
-        <target>Αυτή η τιμή πρέπει να είναι {{limit}} ή μεγαλύτερη.</target>
-      </segment>
-    </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Αυτή η τιμή είναι πολύ μικρή. Θα πρέπει να έχει {{limit}} χαρακτήρες ή περισσότερο. | Αυτή η τιμή είναι πολύ μικρή. Θα πρέπει να έχει {{limit}} χαρακτήρες ή περισσότερους.</target>
+        <target>Αυτή η τιμή πρέπει να είναι {{ limit }} ή μεγαλύτερη.</target>
       </segment>
     </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Αυτή η τιμή δεν πρέπει να είναι κενή.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Αυτή η τιμή δεν πρέπει να είναι απροσδιοριστη.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Αυτή η τιμή πρέπει να είναι απροσδιοριστη.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη ώρα.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη διεύθυνση URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>Το αρχείο είναι πολύ μεγάλο. Το επιτρεπόμενο μέγιστο μέγεθος είναι {{limit}} {{suffix}}.</target>
+        <target>Το αρχείο είναι πολύ μεγάλο. Το επιτρεπόμενο μέγιστο μέγεθος είναι {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Το αρχείο είναι πολύ μεγάλο.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Δεν ήταν δυνατή η μεταφόρτωση του αρχείου.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Αυτή η τιμή πρέπει να είναι έγκυρος αριθμός.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Αυτό το αρχείο δεν είναι έγκυρη εικόνα.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Αυτή δεν είναι έγκυρη διεύθυνση IP.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη γλώσσα.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρο locale.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη χώρα.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Αυτή η τιμή χρησιμοποιείται ήδη.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Δεν ήταν δυνατή η ανίχνευση του μεγέθους της εικόνας.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>Το πλάτος της εικόνας είναι πολύ μεγάλο ({{width}} px). Το επιτρεπόμενο μέγιστο πλάτος είναι {{max_width}} px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>Το πλάτος της εικόνας είναι πολύ μικρό ({{width}} px). Το αναμενόμενο ελάχιστο πλάτος είναι {{min_width}} px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>Το ύψος της εικόνας είναι πολύ μεγάλο ({{height}} px). Το επιτρεπόμενο μέγιστο ύψος είναι {{max_height}} px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>Το ύψος της εικόνας είναι πολύ μικρό ({{height}} px). Το ελάχιστο αναμενόμενο ύψος είναι {{min_height}} px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Αυτή η τιμή πρέπει να είναι ο τρέχων κωδικός πρόσβασης του χρήστη.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Αυτή η τιμή πρέπει να έχει ακριβώς {{limit}} χαρακτήρα. | Αυτή η τιμή θα πρέπει να έχει ακριβώς {{limit}} χαρακτήρες.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Το αρχείο μεταφορτώθηκε μόνο εν μέρει.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Δεν μεταφορτώθηκε κανένα αρχείο.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>Δεν διαμορφώθηκε προσωρινός φάκελος στο php.ini ή ο διαμορφωμένος φάκελος δεν υπάρχει.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Δεν είναι δυνατή η εγγραφή προσωρινού αρχείου στο δίσκο.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Μια επέκταση PHP προκάλεσε την αποτυχία της μεταφόρτωσης.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Αυτή η συλλογή θα πρέπει να περιέχει {{limit}} στοιχεία ή περισσότερα. | Αυτή η συλλογή πρέπει να περιέχει στοιχεία {{limit}} ή περισσότερα.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Αυτή η συλλογή θα πρέπει να περιέχει {{limit}} στοιχεία ή λιγότερο. | Αυτή η συλλογή θα πρέπει να περιέχει στοιχεία {{limit}} ή λιγότερα.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Αυτή η συλλογή θα πρέπει να περιέχει ακριβώς {{limit}} στοιχεία. | Αυτή η συλλογή θα πρέπει να περιέχει ακριβώς {{limit}} στοιχεία.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Ακυρο νουμερο κάρτας.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Μη υποστηριζόμενος τύπος κάρτας ή μη έγκυρος αριθμός κάρτας.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Αυτός δεν είναι έγκυρος διεθνής αριθμός τραπεζικού λογαριασμού (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρο ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρο ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Αυτή η τιμή δεν είναι ούτε έγκυρη ISBN-10 ούτε έγκυρη ISBN-13.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρο ISSN.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρο νόμισμα.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι ίση με {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι μεγαλύτερη από {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι μεγαλύτερη ή ίση με {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Αυτή η τιμή πρέπει να είναι ίδια με {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι ίδια με αυτήν {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι μικρότερη ή ίση με{{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Αυτή η τιμή δεν πρέπει να είναι ίση με {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Αυτή η τιμή δεν πρέπει να είναι ίδια με αυτήν {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Η αναλογία εικόνας είναι πολύ μεγάλη ({{ratio}}). Η επιτρεπόμενη μέγιστη αναλογία είναι {{max_ratio}}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Η αναλογία εικόνας είναι πολύ μικρή ({{ratio}}). Η αναμενόμενη ελάχιστη αναλογία είναι {{min_ratio}}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
-        <target>Η εικόνα είναι τετράγωνη ({{width}} x {{height}} px). Δεν επιτρέπονται τετράγωνες εικόνες.</target>
-      </segment>
-    </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>Η εικόνα έχει οριζόντιο προσανατολισμό ({{width}} x {{height}} px). Δεν επιτρέπονται εικόνες με οριζόντιο προσανατολισμό.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>Η εικόνα είναι κατακόρυφη ({{width}} x {{height}} px). Δεν επιτρέπονται εικόνες με προσανατολισμό σε πορτραίτο.</target>
+        <target>Η εικόνα είναι τετράγωνη ({{ width }} x {{ height }} px). Δεν επιτρέπονται τετράγωνες εικόνες.</target>
       </segment>
     </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Δεν επιτρέπεται κενό αρχείο.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
-        <target>Αυτή η τιμή δεν ταιριάζει με το αναμενόμενο charset {{charset}}.</target>
+        <target>Αυτή η τιμή δεν ταιριάζει με το αναμενόμενο charset {{ charset }}.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Αυτός δεν είναι έγκυρος κωδικός αναγνώρισης επιχείρησης (BIC).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Σφάλμα</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Αυτό δεν είναι έγκυρο UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>Αυτή η τιμή πρέπει να είναι πολλαπλάσιο του {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-        <target>Αυτός ο κωδικός αναγνώρισης επιχείρησης (BIC) δεν σχετίζεται με τον IBAN {{iban}}.</target>
+        <target>Αυτός ο κωδικός αναγνώρισης επιχείρησης (BIC) δεν σχετίζεται με τον IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Αυτή η τιμή πρέπει να είναι έγκυρος τυπος JSON.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Αυτή η συλλογή πρέπει να περιέχει μόνο μοναδικά στοιχεία.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Αυτή η τιμή πρέπει να είναι θετική.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Αυτή η τιμή πρέπει να είναι θετική ή μηδενική.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Αυτή η τιμή πρέπει να είναι αρνητική.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Αυτή η τιμή πρέπει να είναι είτε αρνητική είτε μηδενική.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Αυτή η τιμή δεν είναι έγκυρη ζώνη ώρας.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Αυτός ο κωδικός πρόσβασης έχει διαρρεύσει σε παραβίαση δεδομένων, δεν πρέπει να χρησιμοποιείται. Χρησιμοποιήστε έναν άλλο κωδικό πρόσβασης.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
-        <target>Αυτή η τιμή πρέπει να κυμαίνεται μεταξύ {{min}} και {{max}}.</target>
+        <target>Αυτή η τιμή πρέπει να κυμαίνεται μεταξύ {{ min }} και {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Αυτή η φόρμα δεν πρέπει να περιέχει επιπλέον πεδία.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Το μεταφορτωμένο αρχείο ήταν πολύ μεγάλο. Δοκιμάστε να ανεβάσετε ένα μικρότερο αρχείο.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Το διακριτικό CSRF δεν είναι έγκυρο. Δοκιμάστε να υποβάλετε ξανά τη φόρμα.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Δώστε μια περίληψη στην ανάρτησή σας!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Η ανάρτησή σας πρέπει να έχει κάποιο περιεχόμενο!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Το περιεχόμενο της ανάρτησης είναι πολύ μικρό (ελάχιστο {{limit}} χαρακτήρες)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Πάρα πολλές ετικέτες (προσθέστε {{limit}} ή λιγότερες)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Μην αφήσετε το σχόλιό σας κενό!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Το σχόλιο είναι πολύ μικρό ({{limit}} ελάχιστοι χαρακτήρες)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Το σχόλιο είναι πολύ μεγάλο ({{limit}} χαρακτήρες το μέγιστο)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Το περιεχόμενο αυτού του σχολίου θεωρείται ανεπιθύμητο.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
-        <target>Υπάρχει ήδη χρήστης με {{value}} email.</target>
+        <target>Υπάρχει ήδη χρήστης με {{ value }} email.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
-        <target>Υπάρχει ήδη χρήστης με όνομα χρήστη {{value}}.</target>
+        <target>Υπάρχει ήδη χρήστης με όνομα χρήστη {{ value }}.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Λανθασμένος κωδικός. Ο κωδικός πρόσβασης πρέπει να περιέχει τουλάχιστον 6 χαρακτήρες.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Ακυρη διεύθυνση ηλεκτρονικού ταχυδρομείου</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Το όνομα χρήστη πρέπει να περιέχει μόνο πεζούς λατινικούς χαρακτήρες, αριθμούς και κάτω παύλες.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Μη έγκυρο εμφανιζόμενο όνομα</target>

--- a/translations/validators.en.xlf
+++ b/translations/validators.en.xlf
@@ -2,162 +2,194 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
   <file id="validators.en">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>This value should be false.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>This value should be true.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>This value should be of type {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>This value should be blank.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>The value you selected is not a valid choice.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>One or more of the given values is invalid.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>This field was not expected.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>This field is missing.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>This value is not a valid date.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>This value is not a valid datetime.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>This value is not a valid email address.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>The file could not be found.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>The file is not readable.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>This value should be {{ limit }} or less.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>This value should be {{ limit }} or more.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>This value should not be blank.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>This value should not be null.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>This value should be null.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>This value is not valid.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>This value is not a valid time.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>This value is not a valid URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>The file is too large.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>The file could not be uploaded.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>This value should be a valid number.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>This file is not a valid image.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>This is not a valid IP address.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>This value is not a valid language.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>This value is not a valid locale.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>This value is not a valid country.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>This value is already used.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>The size of the image could not be detected.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>This value should be the user's current password.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>The file was only partially uploaded.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>No file was uploaded.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>No temporary folder was configured in php.ini, or the configured folder does not exist.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Cannot write temporary file to disk.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>A PHP extension caused the upload to fail.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Invalid card number.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Unsupported card type or invalid card number.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>This is not a valid International Bank Account Number (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>This value is not a valid ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>This value is not a valid ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>This value is neither a valid ISBN-10 nor a valid ISBN-13.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>This value is not a valid ISSN.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>This value is not a valid currency.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>This value should be equal to {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>This value should be greater than {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>This value should be greater than or equal to {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>This value should be less than {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>This value should be less than or equal to {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>This value should not be equal to {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>An empty file is not allowed.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>This value does not match the expected {{ charset }} charset.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>This is not a valid Business Identifier Code (BIC).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Error</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>This is not a valid UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>This value should be a multiple of {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>This value should be valid JSON.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>This collection should contain only unique elements.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>This value should be positive.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>This value should be either positive or zero.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>This value should be negative.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>This value should be either negative or zero.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>This value is not a valid timezone.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>This password has been leaked in a data breach, it must not be used. Please use another password.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>This value should be between {{ min }} and {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>This form should not contain extra fields.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>The uploaded file was too large. Please try to upload a smaller file.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>The CSRF token is invalid. Please try to resubmit the form.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Give your post a summary!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Your post should have some content!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Post content is too short ({{ limit }} characters minimum)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Too many tags (add {{ limit }} tags or less)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Please don't leave your comment blank!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Comment is too short ({{ limit }} characters minimum)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Comment is too long ({{ limit }} characters maximum)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>The content of this comment is considered spam.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
         <target>A user with {{ value }} email already exists.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
         <target>A user with {{ value }} username already exists.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Invalid password. The password should contain at least 6 characters.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Invalid email</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>The username must contain only lowercase latin characters, numbers and underscores.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Invalid display name</target>

--- a/translations/validators.es.xlf
+++ b/translations/validators.es.xlf
@@ -2,162 +2,194 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="es">
   <file id="validators.es">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Este valor debería ser falso.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Este valor debería ser verdadero.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Este valor debería ser de tipo {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Este valor debería estar vacío.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>El valor seleccionado no es una opción válida.</target>
       </segment>
     </unit>
-    <unit id="u81CkP8" name="0d999f2">
-      <segment>
-        <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-        <target>Debe seleccionar al menos {{ limit }} opción.|Debe seleccionar al menos {{ limit }} opciones.</target>
-      </segment>
-    </unit>
-    <unit id="nIvOQ_o" name="0824486">
-      <segment>
-        <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-        <target>Debe seleccionar como máximo {{ limit }} opción.|Debe seleccionar como máximo {{ limit }} opciones.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Uno o más de los valores indicados no son válidos.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Este campo no se esperaba.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Este campo está desaparecido.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Este valor no es una fecha válida.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Este valor no es una fecha y hora válidas.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Este valor no es una dirección de email válida.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>No se pudo encontrar el archivo.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>No se puede leer el archivo.</target>
       </segment>
     </unit>
-    <unit id="JocOVM2" name="1ad411a">
-      <segment>
-        <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>El archivo es demasiado grande ({{ size }} {{ suffix }}). El tamaño máximo permitido es {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="YW21SPH" name="30a318d">
-      <segment>
-        <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-        <target>El tipo mime del archivo no es válido ({{ type }}). Los tipos mime válidos son {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Este valor debería ser {{ limit }} o menos.</target>
       </segment>
     </unit>
-    <unit id="HX7TOFm" name="0e0c1e1">
-      <segment>
-        <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-        <target>Este valor es demasiado largo. Debería tener {{ limit }} carácter o menos.|Este valor es demasiado largo. Debería tener {{ limit }} caracteres o menos.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Este valor debería ser {{ limit }} o más.</target>
       </segment>
     </unit>
-    <unit id="ekfrU.c" name="5188ff9">
-      <segment>
-        <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-        <target>Este valor es demasiado corto. Debería tener {{ limit }} carácter o más.|Este valor es demasiado corto. Debería tener {{ limit }} caracteres o más.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Este valor no debería estar vacío.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Este valor no debería ser nulo.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Este valor debería ser nulo.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Este valor no es válido.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Este valor no es una hora válida.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Este valor no es una URL válida.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>El archivo es demasiado grande. El tamaño máximo permitido es {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>El archivo es demasiado grande.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>No se pudo subir el archivo.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Este valor debería ser un número válido.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>El archivo no es una imagen válida.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Esto no es una dirección IP válida.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Este valor no es un idioma válido.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Este valor no es una localización válida.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Este valor no es un país válido.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Este valor ya se ha utilizado.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>No se pudo determinar el tamaño de la imagen.</target>
       </segment>
     </unit>
-    <unit id="zVtJJEa" name="266051e">
-      <segment>
-        <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-        <target>El ancho de la imagen es demasiado grande ({{ width }}px). El ancho máximo permitido es de {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="s8LFQGC" name="c1c23f9">
-      <segment>
-        <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-        <target>El ancho de la imagen es demasiado pequeño ({{ width }}px). El ancho mínimo requerido es {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="Z.NgqFj" name="9a128f7">
-      <segment>
-        <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-        <target>La altura de la imagen es demasiado grande ({{ height }}px). La altura máxima permitida es de {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="AW1lWVM" name="8a4cd70">
-      <segment>
-        <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-        <target>La altura de la imagen es demasiado pequeña ({{ height }}px). La altura mínima requerida es de {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Este valor debería ser la contraseña actual del usuario.</target>
       </segment>
     </unit>
-    <unit id="gYImVyV" name="fd389d6">
-      <segment>
-        <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-        <target>Este valor debería tener exactamente {{ limit }} carácter.|Este valor debería tener exactamente {{ limit }} caracteres.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>El archivo fue sólo subido parcialmente.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Ningún archivo fue subido.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>Ninguna carpeta temporal fue configurada en php.ini o la carpeta configurada no existe.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>No se pudo escribir el archivo temporal en el disco.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Una extensión de PHP hizo que la subida fallara.</target>
       </segment>
     </unit>
-    <unit id="gTJYRl6" name="b54c218">
-      <segment>
-        <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-        <target>Esta colección debe contener {{ limit }} elemento o más.|Esta colección debe contener {{ limit }} elementos o más.</target>
-      </segment>
-    </unit>
-    <unit id="FFn3lVn" name="949632c">
-      <segment>
-        <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-        <target>Esta colección debe contener {{ limit }} elemento o menos.|Esta colección debe contener {{ limit }} elementos o menos.</target>
-      </segment>
-    </unit>
-    <unit id="bSdilZv" name="e0582dc">
-      <segment>
-        <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-        <target>Esta colección debe contener exactamente {{ limit }} elemento.|Esta colección debe contener exactamente {{ limit }} elementos.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Número de tarjeta inválido.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Tipo de tarjeta no soportado o número de tarjeta inválido.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Esto no es un International Bank Account Number (IBAN) válido.</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Este valor no es un ISBN-10 válido.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Este valor no es un ISBN-13 válido.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Este valor no es ni un ISBN-10 válido ni un ISBN-13 válido.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Este valor no es un ISSN válido.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Este valor no es una divisa válida.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Este valor debería ser igual que {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Este valor debería ser mayor que {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Este valor debería ser mayor o igual que {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="bOF1fpm" name="9670078">
-      <segment>
-        <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Este valor debería ser idéntico a {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Este valor debería ser menor que {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Este valor debería ser menor o igual que {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Este valor debería ser distinto de {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="Bi22JLt" name="0eedf91">
-      <segment>
-        <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Este valor no debería ser idéntico a {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="VczCWzQ" name="9c3ad0f">
-      <segment>
-        <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-        <target>La proporción de la imagen es demasiado grande ({{ ratio }}). La máxima proporción permitida es {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="v57PXhq" name="4376d45">
-      <segment>
-        <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-        <target>La proporción de la imagen es demasiado pequeña ({{ ratio }}). La mínima proporción permitida es {{ min_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>La imagen es cuadrada ({{ width }}x{{ height }}px). Las imágenes cuadradas no están permitidas.</target>
       </segment>
     </unit>
-    <unit id="G_lu2qW" name="1dc128a">
-      <segment>
-        <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-        <target>La imagen está orientada horizontalmente ({{ width }}x{{ height }}px). Las imágenes orientadas horizontalmente no están permitidas.</target>
-      </segment>
-    </unit>
-    <unit id="sFyGx4B" name="9e27714">
-      <segment>
-        <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-        <target>La imagen está orientada verticalmente ({{ width }}x{{ height }}px). Las imágenes orientadas verticalmente no están permitidas.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>No está permitido un archivo vacío.</target>
@@ -458,339 +508,211 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>La codificación de caracteres para este valor debería ser {{ charset }}.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>No es un Código de Identificación Bancaria (BIC) válido.</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Error</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Este valor no es un UUID válido.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>Este valor debería ser múltiplo de {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Este Código de Identificación Bancaria (BIC) no está asociado con el IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Este valor debería ser un JSON válido.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Esta colección debería tener exclusivamente elementos únicos.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Este valor debería ser positivo.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Este valor debería ser positivo o igual a cero.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Este valor debería ser negativo.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Este valor debería ser negativo o igual a cero.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Este valor no es una zona horaria válida.</target>
       </segment>
     </unit>
-    <unit id="40dnsod" name="7e27e92">
-      <segment>
-        <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-        <target>Esta contraseña no se puede utilizar porque está incluida en un listado de contraseñas públicas obtenido gracias a fallos de seguridad de otros sitios y aplicaciones. Por favor utilice otra contraseña.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Este valor debería estar entre {{ min }} y {{ max }}.</target>
       </segment>
     </unit>
-    <unit id="7g313cV" name="This value is not a valid hostname.">
-      <segment>
-        <source>This value is not a valid hostname.</source>
-        <target>Este valor no es un nombre de host válido.</target>
-      </segment>
-    </unit>
-    <unit id="xwtBimR" name="d165c02">
-      <segment>
-        <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-        <target>El número de elementos en esta colección debería ser múltiplo de {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="FDRZr.s" name="This value should satisfy at least one of the following constraints:">
-      <segment>
-        <source>This value should satisfy at least one of the following constraints:</source>
-        <target>Este valor debería satisfacer al menos una de las siguientes restricciones:</target>
-      </segment>
-    </unit>
-    <unit id="WwY0IGI" name="Each element of this collection should satisfy its own set of constraints.">
-      <segment>
-        <source>Each element of this collection should satisfy its own set of constraints.</source>
-        <target>Cada elemento de esta colección debería satisfacer su propio conjunto de restricciones.</target>
-      </segment>
-    </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Este formulario no debería contener campos adicionales.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>El archivo subido es demasiado grande. Por favor, suba un archivo más pequeño.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>El token CSRF no es válido. Por favor, pruebe a enviar nuevamente el formulario.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Debe seleccionar al menos {{ limit }} opción.|Debe seleccionar al menos {{ limit }} opciones.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Debe seleccionar como máximo {{ limit }} opción.|Debe seleccionar como máximo {{ limit }} opciones.</target>
-      </segment>
-    </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>El archivo es demasiado grande ({{ size }} {{ suffix }}). El tamaño máximo permitido es {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>El tipo mime del archivo no es válido ({{ type }}). Los tipos mime válidos son {{ types }}.</target>
-      </segment>
-    </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Este valor es demasiado largo. Debería tener {{ limit }} carácter o menos.|Este valor es demasiado largo. Debería tener {{ limit }} caracteres o menos.</target>
-      </segment>
-    </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Este valor es demasiado corto. Debería tener {{ limit }} carácter o más.|Este valor es demasiado corto. Debería tener {{ limit }} caracteres o más.</target>
-      </segment>
-    </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>El ancho de la imagen es demasiado grande ({{ width }}px). El ancho máximo permitido es de {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>El ancho de la imagen es demasiado pequeño ({{ width }}px). El ancho mínimo requerido es {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>La altura de la imagen es demasiado grande ({{ height }}px). La altura máxima permitida es de {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>La altura de la imagen es demasiado pequeña ({{ height }}px). La altura mínima requerida es de {{ min_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Este valor debería tener exactamente {{ limit }} carácter.|Este valor debería tener exactamente {{ limit }} caracteres.</target>
-      </segment>
-    </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Esta colección debe contener {{ limit }} elemento o más.|Esta colección debe contener {{ limit }} elementos o más.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Esta colección debe contener {{ limit }} elemento o menos.|Esta colección debe contener {{ limit }} elementos o menos.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Esta colección debe contener exactamente {{ limit }} elemento.|Esta colección debe contener exactamente {{ limit }} elementos.</target>
-      </segment>
-    </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Este valor debería ser idéntico a {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Este valor no debería ser idéntico a {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>La proporción de la imagen es demasiado grande ({{ ratio }}). La máxima proporción permitida es {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>La proporción de la imagen es demasiado pequeña ({{ ratio }}). La mínima proporción permitida es {{ min_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>La imagen está orientada horizontalmente ({{ width }}x{{ height }}px). Las imágenes orientadas horizontalmente no están permitidas.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>La imagen está orientada verticalmente ({{ width }}x{{ height }}px). Las imágenes orientadas verticalmente no están permitidas.</target>
-      </segment>
-    </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Esta contraseña no se puede utilizar porque está incluida en un listado de contraseñas públicas obtenido gracias a fallos de seguridad de otros sitios y aplicaciones. Por favor utilice otra contraseña.</target>
-      </segment>
-    </unit>
-    <unit id="PG_l9lY" name="d165c02">
-      <segment>
-        <source>d165c02</source>
-        <target>El número de elementos en esta colección debería ser múltiplo de {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
+    <unit id="LDy5h0B" name="user.duplicate_email">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:24</note>
       </notes>
       <segment>
-        <source>post.blank_summary</source>
-        <target>No es posible dejar el resumen del artículo vacío.</target>
+        <source>user.duplicate_email</source>
+        <target>Ya existe un usuario con el correo electrónico {{ value }}.</target>
       </segment>
     </unit>
-    <unit id="BZOzjk." name="post.blank_content">
+    <unit id="D4OMpCY" name="user.duplicate_username">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:25</note>
       </notes>
       <segment>
-        <source>post.blank_content</source>
-        <target>No es posible dejar el contenido del artículo vacío.</target>
+        <source>user.duplicate_username</source>
+        <target>Ya existe un usuario con el nombre de usuario {{ value }}.</target>
       </segment>
     </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
+    <unit id="HjWW.NS" name="user.not_valid_password">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:57</note>
       </notes>
       <segment>
-        <source>post.too_short_content</source>
-        <target>El contenido del artículo es demasiado corto ({{ limit }} caracteres como mínimo)</target>
+        <source>user.not_valid_password</source>
+        <target>Contraseña no válida. La contraseña debe contener al menos 6 caracteres.</target>
       </segment>
     </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
+    <unit id="fkXL.k6" name="user.not_valid_email">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:49</note>
       </notes>
       <segment>
-        <source>post.too_many_tags</source>
-        <target>Demasiadas etiquetas (añade {{ limit }} como máximo)</target>
+        <source>user.not_valid_email</source>
+        <target>Correo electrónico no válido</target>
       </segment>
     </unit>
-    <unit id="ARUoKOV" name="comment.blank">
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:43</note>
       </notes>
       <segment>
-        <source>comment.blank</source>
-        <target>No es posible dejar el contenido del comentario vacío.</target>
+        <source>user.username_invalid_characters</source>
+        <target>El nombre de usuario solo puede contener letras latinas minúsculas, números y guiones bajos.</target>
       </segment>
     </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
       </notes>
       <segment>
-        <source>comment.too_short</source>
-        <target>El comentario es demasiado corto ({{ limit }} caracteres como mínimo)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>El comentario es demasiado largo ({{ limit }} caracteres como máximo)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>El contenido del comentario se considera spam.</target>
+        <source>user.not_valid_display_name</source>
+        <target>Nombre para mostrar no válido</target>
       </segment>
     </unit>
   </file>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -2,162 +2,194 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="fr">
   <file id="validators.fr">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Cette valeur doit être fausse.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Cette valeur doit être vraie.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Cette valeur doit être de type {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Cette valeur doit être vide</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>La valeur que vous avez sélectionnée n'est pas un choix valide.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Vous devez sélectionner au moins {{limit}} choix. | Vous devez sélectionner au moins {{limit}} choix.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Vous devez sélectionner au plus {{limit}} choix. | Vous devez sélectionner au plus {{limit}} choix.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Une ou plusieurs des valeurs données ne sont pas valides.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Ce champ n'était pas attendu.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Ce champ est manquant.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Cette valeur n'est pas une date valide.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Cette valeur n'est pas une date / heure valide.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Le format de l'adresse email est invalide.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Le fichier est introuvable.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Le fichier n'est pas lisible.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Le fichier est trop volumineux ({{size}} {{suffix}}). La taille maximale autorisée est {{limit}} {{suffix}}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Le type mime du fichier n'est pas valide ({{type}}). Les types mime autorisés sont {{types}}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
-        <target>Cette valeur doit être inférieure ou égale à {{limit}}.</target>
-      </segment>
-    </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Cette valeur est trop longue. Elle doit contenir au maximum {{limit}} caractère. | Cette valeur est trop longue. Elle doit contenir au maximum {{limit}} caractères.</target>
+        <target>Cette valeur doit être inférieure ou égale à {{ limit }}.</target>
       </segment>
     </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
-        <target>Cette valeur doit être égale ou supérieure à {{limit}}.</target>
-      </segment>
-    </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Cette valeur est trop courte. Elle doit contenir au minimum {{limit}} caractère. | Cette valeur est trop courte. Elle doit contenir au minimum {{limit}} caractères.</target>
+        <target>Cette valeur doit être égale ou supérieure à {{ limit }}.</target>
       </segment>
     </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Cette valeur ne doit pas être vide.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Cette valeur ne doit pas être nulle.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Cette valeur doit être nulle.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Cette valeur n'est pas valide.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Cette valeur n'est pas une heure valide.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>L' URL n'est pas valide.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>Le fichier est trop volumineux. La taille maximale autorisée est {{limit}} {{suffix}}.</target>
+        <target>Le fichier est trop volumineux. La taille maximale autorisée est {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Le fichier est trop volumineux.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Le fichier n'a pas pu être téléchargé.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Cette valeur doit être un nombre valide.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Ce fichier n'est pas une image valide.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>L'adresse IP n'est pas valide.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Cette valeur n'est pas une langue valide.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Cette valeur n'est pas un paramètre régional valide.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Cette valeur n'est pas un pays valide.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Cette valeur est déjà utilisée.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>La taille de l'image n'a pas pu être détectée.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>La largeur de l'image est trop grande ({{width}} px). La largeur maximale autorisée est de {{max_width}} px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>La largeur de l'image est trop petite ({{width}} px). La largeur minimale attendue est de {{min_width}} px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>La hauteur de l'image est trop grande ({{height}} px). La hauteur maximale autorisée est de {{max_height}} px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>La hauteur de l'image est trop petite ({{height}} px). La hauteur minimale attendue est de {{min_height}} px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Cette valeur doit être le mot de passe actuel de l'utilisateur.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Cette valeur doit avoir exactement {{limit}} caractère. | Cette valeur doit avoir exactement {{limit}} caractères.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Le fichier n'a été que partiellement téléchargé.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Aucun fichier n'a été téléchargé.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>Aucun dossier temporaire n'a été configuré dans php.ini ou le dossier configuré n'existe pas.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Impossible d'écrire le fichier temporaire sur le disque.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Une extension PHP a provoqué l'échec du téléchargement.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Cette collection doit contenir au minimum {{limit}} élément. | Cette collection doit contenir au minimum {{limit}} éléments.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Cette collection doit contenir au mamaximum {{limit}} élément. | Cette collection doit contenir au mamaximum {{limit}} éléments.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Cette collection doit contenir exactement {{limit}} élément. | Cette collection doit contenir exactement {{limit}} éléments.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Numéro de carte invalide.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Type de carte non pris en charge ou numéro de carte non valide.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Ce n'est pas un numéro de compte bancaire international (IBAN) valide.</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Cette valeur n'est pas un ISBN-10 valide.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Cette valeur n'est pas un ISBN-13 valide.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Cette valeur n'est ni un ISBN-10 valide ni un ISBN-13 valide.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Cette valeur n'est pas un ISSN valide.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Cette valeur n'est pas une devise valide.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
-        <target>Cette valeur doit être égale à {{compare_value}}.</target>
+        <target>Cette valeur doit être égale à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
-        <target>Cette valeur doit être supérieure à {{compare_value}}.</target>
+        <target>Cette valeur doit être supérieure à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
-        <target>Cette valeur doit être supérieure ou égale à {{compare_value}}.</target>
-      </segment>
-    </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Cette valeur doit être identique à {{compare_value_type}} {{compare_value}}.</target>
+        <target>Cette valeur doit être supérieure ou égale à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
-        <target>Cette valeur doit être inférieure à {{compare_value}}.</target>
+        <target>Cette valeur doit être inférieure à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
-        <target>Cette valeur doit être inférieure ou égale à {{compare_value}}.</target>
+        <target>Cette valeur doit être inférieure ou égale à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
-        <target>Cette valeur ne doit pas être égale à {{compare_value}}.</target>
-      </segment>
-    </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Cette valeur ne doit pas être identique à {{compare_value_type}} {{compare_value}}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Le ratio de l'image est trop grand ({{ratio}}). Le ratio maximal autorisé est de {{max_ratio}}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Le ratio de l'image est trop petit ({{ratio}}). Le ratio minimum autorisé est de {{min_ratio}}.</target>
+        <target>Cette valeur ne doit pas être égale à {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
-        <target>L'image est carrée ({{width}} x {{height}} px). Les images carrées ne sont pas autorisées.</target>
-      </segment>
-    </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>L'image est orientée paysage ({{width}} x {{height}} px). Les images orientées paysage ne sont pas autorisées.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>L'image est orientée portrait ({{width}} x {{height}} px). Les images orientées portrait ne sont pas autorisées.</target>
+        <target>L'image est carrée ({{ width }} x {{ height }} px). Les images carrées ne sont pas autorisées.</target>
       </segment>
     </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Un fichier vide n'est pas autorisé.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
-        <target>Cette valeur ne correspond pas au jeu de caractères {{charset}} attendu.</target>
+        <target>Cette valeur ne correspond pas au jeu de caractères {{ charset }} attendu.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Ce n'est pas un code d'identification d'entreprise (BIC) valide.</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Erreur</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Ce n'est pas un UUID valide.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Cette valeur doit être un multiple de {{compare_value}}.</target>
+        <target>Cette valeur doit être un multiple de {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
-        <target>Ce code d'identification d'entreprise (BIC) n'est pas associé à l'IBAN {{iban}}.</target>
+        <target>Ce code d'identification d'entreprise (BIC) n'est pas associé à l'IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Cette valeur doit être un JSON valide.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Cette collection ne doit contenir que des éléments uniques.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Cette valeur doit être positive.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Cette valeur doit être positive ou égale à zéro.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Cette valeur doit être négative.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Cette valeur doit être négative ou égale à zéro.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Le fuseau horaire n'est pas valide.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Ce mot de passe a été divulgué lors d'une violation de données, il ne doit pas être utilisé. Veuillez utiliser un autre mot de passe.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
-        <target>Cette valeur doit être comprise entre {{min}} et {{max}}.</target>
+        <target>Cette valeur doit être comprise entre {{ min }} et {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Ce formulaire ne doit pas contenir de champs supplémentaires.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Le fichier téléchargé était trop volumineux. Veuillez essayer de télécharger un fichier plus petit.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Le jeton CSRF n'est pas valide. Veuillez réessayer de soumettre le formulaire.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Donnez à votre publication un résumé !</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Votre publication devrait avoir du contenu !</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>le contenu de votre publication est trop court ({{limit}} caractères minimum)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Trop de balises (ajoutez au maximum {{limit}} balises ).</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Veuillez ne pas laisser votre commentaire vide !</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Le commentaire est trop court ({{limit}} caractères minimum)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Le commentaire est trop long ({{limit}} caractères maximum)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Le contenu de ce commentaire est considéré comme un spam.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
-        <target>Cette adresse e-mail {{value}} est déjà utilisée.</target>
+        <target>Cette adresse e-mail {{ value }} est déjà utilisée.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
-        <target>Le nom d'utilisateur {{value}} existe déjà.</target>
+        <target>Le nom d'utilisateur {{ value }} existe déjà.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Mot de passe incorrect. Le mot de passe doit contenir au moins 6 caractères.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Email invalide</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Le nom d'utilisateur ne doit contenir que des caractères latins minuscules, des chiffres et des traits de soulignement.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Nom d'affichage non valide</target>

--- a/translations/validators.hu.xlf
+++ b/translations/validators.hu.xlf
@@ -1,446 +1,719 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="hu" target-language="hu" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="zh5oKD9" resname="This value should be false.">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="hu">
+  <file id="validators.hu">
+    <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be false.</source>
         <target>Ennek az értéknek hamisnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="NN2_iru" resname="This value should be true.">
+      </segment>
+    </unit>
+    <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be true.</source>
         <target>Ennek az értéknek igaznak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="OjM_kpf" resname="This value should be of type {{ type }}.">
+      </segment>
+    </unit>
+    <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
+      <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Ennek az értéknek {{ type }} típusúnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="f0P5pBD" resname="This value should be blank.">
+      </segment>
+    </unit>
+    <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be blank.</source>
         <target>Ennek az értéknek üresnek kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="ih.4TRN" resname="The value you selected is not a valid choice.">
+      </segment>
+    </unit>
+    <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
+      <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>A választott érték érvénytelen.</target>
-      </trans-unit>
-      <trans-unit id="u81CkP8" resname="You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.">
-        <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-        <target>Legalább {{ limit }} értéket kell kiválasztani.|Legalább {{ limit }} értéket kell kiválasztani.</target>
-      </trans-unit>
-      <trans-unit id="nIvOQ_o" resname="You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.">
-        <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-        <target>Legfeljebb {{ limit }} értéket lehet kiválasztani.|Legfeljebb {{ limit }} értéket lehet kiválasztani.</target>
-      </trans-unit>
-      <trans-unit id="87zjiHi" resname="One or more of the given values is invalid.">
+      </segment>
+    </unit>
+    <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
+      <segment>
         <source>One or more of the given values is invalid.</source>
         <target>A megadott értékek közül legalább egy érvénytelen.</target>
-      </trans-unit>
-      <trans-unit id="3NeQftv" resname="This field was not expected.">
+      </segment>
+    </unit>
+    <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
+      <segment>
         <source>This field was not expected.</source>
         <target>Nem várt mező.</target>
-      </trans-unit>
-      <trans-unit id="SwMV4zp" resname="This field is missing.">
+      </segment>
+    </unit>
+    <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
+      <segment>
         <source>This field is missing.</source>
         <target>Ez a mező hiányzik.</target>
-      </trans-unit>
-      <trans-unit id="LO2vFKN" resname="This value is not a valid date.">
+      </segment>
+    </unit>
+    <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid date.</source>
         <target>Ez az érték nem egy érvényes dátum.</target>
-      </trans-unit>
-      <trans-unit id="86dU_nv" resname="This value is not a valid datetime.">
+      </segment>
+    </unit>
+    <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
+      <segment>
         <source>This value is not a valid datetime.</source>
         <target>Ez az érték nem egy érvényes időpont.</target>
-      </trans-unit>
-      <trans-unit id="PSvNXdi" resname="This value is not a valid email address.">
+      </segment>
+    </unit>
+    <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
+      <segment>
         <source>This value is not a valid email address.</source>
         <target>Ez az érték nem egy érvényes e-mail cím.</target>
-      </trans-unit>
-      <trans-unit id="3KeHbZy" resname="The file could not be found.">
+      </segment>
+    </unit>
+    <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
+      <segment>
         <source>The file could not be found.</source>
         <target>A fájl nem található.</target>
-      </trans-unit>
-      <trans-unit id="KtJhQZo" resname="The file is not readable.">
+      </segment>
+    </unit>
+    <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
+      <segment>
         <source>The file is not readable.</source>
         <target>A fájl nem olvasható.</target>
-      </trans-unit>
-      <trans-unit id="JocOVM2" resname="The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.">
-        <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>A fájl túl nagy ({{ size }} {{ suffix }}). A legnagyobb megengedett méret {{ limit }} {{ suffix }}.</target>
-      </trans-unit>
-      <trans-unit id="YW21SPH" resname="The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.">
-        <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-        <target>A fájl MIME típusa érvénytelen ({{ type }}). Az engedélyezett MIME típusok: {{ types }}.</target>
-      </trans-unit>
-      <trans-unit id="NubOmrs" resname="This value should be {{ limit }} or less.">
+      </segment>
+    </unit>
+    <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
+      <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Ez az érték legfeljebb {{ limit }} lehet.</target>
-      </trans-unit>
-      <trans-unit id="HX7TOFm" resname="This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.">
-        <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-        <target>Ez az érték túl hosszú. Legfeljebb {{ limit }} karaktert tartalmazhat.|Ez az érték túl hosszú. Legfeljebb {{ limit }} karaktert tartalmazhat.</target>
-      </trans-unit>
-      <trans-unit id="qgR8M_U" resname="This value should be {{ limit }} or more.">
+      </segment>
+    </unit>
+    <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
+      <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Ez az érték legalább {{ limit }} kell, hogy legyen.</target>
-      </trans-unit>
-      <trans-unit id="ekfrU.c" resname="This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.">
-        <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-        <target>Ez az érték túl rövid. Legalább {{ limit }} karaktert kell tartalmaznia.|Ez az érték túl rövid. Legalább {{ limit }} karaktert kell tartalmaznia.</target>
-      </trans-unit>
-      <trans-unit id="1KV4L.t" resname="This value should not be blank.">
+      </segment>
+    </unit>
+    <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
+      <segment>
         <source>This value should not be blank.</source>
         <target>Ez az érték nem lehet üres.</target>
-      </trans-unit>
-      <trans-unit id="2G4Vepm" resname="This value should not be null.">
+      </segment>
+    </unit>
+    <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
+      <segment>
         <source>This value should not be null.</source>
         <target>Ez az érték nem lehet null.</target>
-      </trans-unit>
-      <trans-unit id="yDc3m6E" resname="This value should be null.">
+      </segment>
+    </unit>
+    <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be null.</source>
         <target>Ennek az értéknek nullnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="zKzWejA" resname="This value is not valid.">
+      </segment>
+    </unit>
+    <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
+      <segment>
         <source>This value is not valid.</source>
         <target>Ez az érték nem érvényes.</target>
-      </trans-unit>
-      <trans-unit id="HSuBZpQ" resname="This value is not a valid time.">
+      </segment>
+    </unit>
+    <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
+      <segment>
         <source>This value is not a valid time.</source>
         <target>Ez az érték nem egy érvényes időpont.</target>
-      </trans-unit>
-      <trans-unit id="snWc_QT" resname="This value is not a valid URL.">
+      </segment>
+    </unit>
+    <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
+      <segment>
         <source>This value is not a valid URL.</source>
         <target>Ez az érték nem egy érvényes URL.</target>
-      </trans-unit>
-      <trans-unit id="jpaLsb2" resname="The two values should be equal.">
+      </segment>
+    </unit>
+    <unit id="jpaLsb2" name="The two values should be equal.">
+      <segment>
         <source>The two values should be equal.</source>
         <target>A két értéknek azonosnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="fIlB1B_" resname="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      </segment>
+    </unit>
+    <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
+      <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>A fájl túl nagy. A megengedett maximális méret: {{ limit }} {{ suffix }}.</target>
-      </trans-unit>
-      <trans-unit id="tW7o0t9" resname="The file is too large.">
+      </segment>
+    </unit>
+    <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
+      <segment>
         <source>The file is too large.</source>
         <target>A fájl túl nagy.</target>
-      </trans-unit>
-      <trans-unit id=".exF5Ww" resname="The file could not be uploaded.">
+      </segment>
+    </unit>
+    <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
+      <segment>
         <source>The file could not be uploaded.</source>
         <target>A fájl nem tölthető fel.</target>
-      </trans-unit>
-      <trans-unit id="d7sS5yw" resname="This value should be a valid number.">
+      </segment>
+    </unit>
+    <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
+      <segment>
         <source>This value should be a valid number.</source>
         <target>Ennek az értéknek érvényes számnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="BS2Ez6i" resname="This file is not a valid image.">
+      </segment>
+    </unit>
+    <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
+      <segment>
         <source>This file is not a valid image.</source>
         <target>Ez a fájl nem egy érvényes kép.</target>
-      </trans-unit>
-      <trans-unit id="ydcT9kU" resname="This is not a valid IP address.">
+      </segment>
+    </unit>
+    <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
+      <segment>
         <source>This is not a valid IP address.</source>
         <target>Ez az érték nem egy érvényes IP cím.</target>
-      </trans-unit>
-      <trans-unit id="lDOGNFX" resname="This value is not a valid language.">
+      </segment>
+    </unit>
+    <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid language.</source>
         <target>Ez az érték nem egy érvényes nyelv.</target>
-      </trans-unit>
-      <trans-unit id="y9IdYkA" resname="This value is not a valid locale.">
+      </segment>
+    </unit>
+    <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid locale.</source>
         <target>Ez az érték nem egy érvényes területi beállítás.</target>
-      </trans-unit>
-      <trans-unit id="1YC0pOd" resname="This value is not a valid country.">
+      </segment>
+    </unit>
+    <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid country.</source>
         <target>Ez az érték nem egy érvényes ország.</target>
-      </trans-unit>
-      <trans-unit id="B5ebaMp" resname="This value is already used.">
+      </segment>
+    </unit>
+    <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
+      <segment>
         <source>This value is already used.</source>
         <target>Ez az érték már használatban van.</target>
-      </trans-unit>
-      <trans-unit id="L6097a6" resname="The size of the image could not be detected.">
+      </segment>
+    </unit>
+    <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
+      <segment>
         <source>The size of the image could not be detected.</source>
         <target>A kép méretét nem lehet megállapítani.</target>
-      </trans-unit>
-      <trans-unit id="zVtJJEa" resname="The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.">
-        <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-        <target>A kép szélessége túl nagy ({{ width }}px). A megengedett legnagyobb szélesség {{ max_width }}px.</target>
-      </trans-unit>
-      <trans-unit id="s8LFQGC" resname="The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.">
-        <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-        <target>A kép szélessége túl kicsi ({{ width }}px). Az elvárt legkisebb szélesség {{ min_width }}px.</target>
-      </trans-unit>
-      <trans-unit id="Z.NgqFj" resname="The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.">
-        <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-        <target>A kép magassága túl nagy ({{ height }}px). A megengedett legnagyobb magasság {{ max_height }}px.</target>
-      </trans-unit>
-      <trans-unit id="AW1lWVM" resname="The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.">
-        <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-        <target>A kép magassága túl kicsi ({{ height }}px). Az elvárt legkisebb magasság {{ min_height }}px.</target>
-      </trans-unit>
-      <trans-unit id="PSdMNab" resname="This value should be the user's current password.">
+      </segment>
+    </unit>
+    <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
+      <segment>
         <source>This value should be the user's current password.</source>
         <target>Ez az érték a felhasználó jelenlegi jelszavával kell megegyezzen.</target>
-      </trans-unit>
-      <trans-unit id="gYImVyV" resname="This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.">
-        <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-        <target>Ennek az értéknek pontosan {{ limit }} karaktert kell tartalmaznia.|Ennek az értéknek pontosan {{ limit }} karaktert kell tartalmaznia.</target>
-      </trans-unit>
-      <trans-unit id="xJ2Bcr_" resname="The file was only partially uploaded.">
+      </segment>
+    </unit>
+    <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
+      <segment>
         <source>The file was only partially uploaded.</source>
         <target>A fájl csak részben lett feltöltve.</target>
-      </trans-unit>
-      <trans-unit id="HzkJDtF" resname="No file was uploaded.">
+      </segment>
+    </unit>
+    <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
+      <segment>
         <source>No file was uploaded.</source>
         <target>Nem lett fájl feltöltve.</target>
-      </trans-unit>
-      <trans-unit id="mHfEaB3" resname="No temporary folder was configured in php.ini.">
+      </segment>
+    </unit>
+    <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
+      <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>Nincs ideiglenes könyvtár beállítva a php.ini-ben.</target>
-      </trans-unit>
-      <trans-unit id="y9K3BGb" resname="Cannot write temporary file to disk.">
+      </segment>
+    </unit>
+    <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
+      <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Az ideiglenes fájl nem írható a lemezre.</target>
-      </trans-unit>
-      <trans-unit id="kx3yHIM" resname="A PHP extension caused the upload to fail.">
+      </segment>
+    </unit>
+    <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
+      <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Egy PHP bővítmény miatt a feltöltés nem sikerült.</target>
-      </trans-unit>
-      <trans-unit id="gTJYRl6" resname="This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.">
-        <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-        <target>Ennek a gyűjteménynek legalább {{ limit }} elemet kell tartalmaznia.|Ennek a gyűjteménynek legalább {{ limit }} elemet kell tartalmaznia.</target>
-      </trans-unit>
-      <trans-unit id="FFn3lVn" resname="This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.">
-        <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-        <target>Ez a gyűjtemény legfeljebb {{ limit }} elemet tartalmazhat.|Ez a gyűjtemény legfeljebb {{ limit }} elemet tartalmazhat.</target>
-      </trans-unit>
-      <trans-unit id="bSdilZv" resname="This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.">
-        <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-        <target>Ennek a gyűjteménynek pontosan {{ limit }} elemet kell tartalmaznia.|Ennek a gyűjteménynek pontosan {{ limit }} elemet kell tartalmaznia.</target>
-      </trans-unit>
-      <trans-unit id="MAzmID7" resname="Invalid card number.">
+      </segment>
+    </unit>
+    <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
+      <segment>
         <source>Invalid card number.</source>
         <target>Érvénytelen kártyaszám.</target>
-      </trans-unit>
-      <trans-unit id="c3REGK3" resname="Unsupported card type or invalid card number.">
+      </segment>
+    </unit>
+    <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
+      <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Nem támogatott kártyatípus vagy érvénytelen kártyaszám.</target>
-      </trans-unit>
-      <trans-unit id="XSVzcbV" resname="This is not a valid International Bank Account Number (IBAN).">
+      </segment>
+    </unit>
+    <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
+      <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Érvénytelen nemzetközi bankszámlaszám (IBAN).</target>
-      </trans-unit>
-      <trans-unit id="yHirwNr" resname="This value is not a valid ISBN-10.">
+      </segment>
+    </unit>
+    <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Ez az érték nem egy érvényes ISBN-10.</target>
-      </trans-unit>
-      <trans-unit id="c_q0_ua" resname="This value is not a valid ISBN-13.">
+      </segment>
+    </unit>
+    <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Ez az érték nem egy érvényes ISBN-13.</target>
-      </trans-unit>
-      <trans-unit id="M4FlD6n" resname="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      </segment>
+    </unit>
+    <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
+      <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Ez az érték nem egy érvényes ISBN-10 vagy ISBN-13.</target>
-      </trans-unit>
-      <trans-unit id="cuct0Ow" resname="This value is not a valid ISSN.">
+      </segment>
+    </unit>
+    <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Ez az érték nem egy érvényes ISSN.</target>
-      </trans-unit>
-      <trans-unit id="JBLs1a1" resname="This value is not a valid currency.">
+      </segment>
+    </unit>
+    <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
+      <segment>
         <source>This value is not a valid currency.</source>
         <target>Ez az érték nem egy érvényes pénznem.</target>
-      </trans-unit>
-      <trans-unit id="c.WxzFW" resname="This value should be equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Ez az érték legyen {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="_jdjkwq" resname="This value should be greater than {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Ez az érték nagyobb legyen, mint {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="o8A8a0H" resname="This value should be greater than or equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Ez az érték nagyobb vagy egyenlő legyen, mint {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="bOF1fpm" resname="This value should be identical to {{ compared_value_type }} {{ compared_value }}.">
-        <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Ez az érték ugyanolyan legyen, mint {{ compared_value_type }} {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="jG0QFKw" resname="This value should be less than {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Ez az érték kisebb legyen, mint {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="9lWrKmm" resname="This value should be less than or equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Ez az érték kisebb vagy egyenlő legyen, mint {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="ftTwGs." resname="This value should not be equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
+      <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Ez az érték ne legyen {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="Bi22JLt" resname="This value should not be identical to {{ compared_value_type }} {{ compared_value }}.">
-        <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>Ez az érték ne legyen ugyanolyan, mint {{ compared_value_type }} {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="VczCWzQ" resname="The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.">
-        <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-        <target>A képarány túl nagy ({{ ratio }}). A megengedett legnagyobb képarány {{ max_ratio }}.</target>
-      </trans-unit>
-      <trans-unit id="v57PXhq" resname="The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.">
-        <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-        <target>A képarány túl kicsi ({{ ratio }}). A megengedett legkisebb képarány {{ min_ratio }}.</target>
-      </trans-unit>
-      <trans-unit id="rpajj.a" resname="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      </segment>
+    </unit>
+    <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
+      <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>A kép négyzet alakú ({{ width }}x{{ height }}px). A négyzet alakú képek nem engedélyezettek.</target>
-      </trans-unit>
-      <trans-unit id="G_lu2qW" resname="The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.">
-        <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-        <target>A kép fekvő tájolású ({{ width }}x{{ height }}px). A fekvő tájolású képek nem engedélyezettek.</target>
-      </trans-unit>
-      <trans-unit id="sFyGx4B" resname="The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.">
-        <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-        <target>A kép álló tájolású ({{ width }}x{{ height }}px). Az álló tájolású képek nem engedélyezettek.</target>
-      </trans-unit>
-      <trans-unit id="jZgqcpL" resname="An empty file is not allowed.">
+      </segment>
+    </unit>
+    <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
+      <segment>
         <source>An empty file is not allowed.</source>
         <target>Üres fájl nem megengedett.</target>
-      </trans-unit>
-      <trans-unit id="bcfVezI" resname="The host could not be resolved.">
+      </segment>
+    </unit>
+    <unit id="bcfVezI" name="The host could not be resolved.">
+      <segment>
         <source>The host could not be resolved.</source>
         <target>Az állomásnevet nem lehet feloldani.</target>
-      </trans-unit>
-      <trans-unit id="NtzKvgt" resname="This value does not match the expected {{ charset }} charset.">
+      </segment>
+    </unit>
+    <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
+      <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Ez az érték nem az elvárt {{ charset }} karakterkódolást használja.</target>
-      </trans-unit>
-      <trans-unit id="Wi2y9.N" resname="This is not a valid Business Identifier Code (BIC).">
+      </segment>
+    </unit>
+    <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
+      <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Érvénytelen nemzetközi bankazonosító kód (BIC/SWIFT).</target>
-      </trans-unit>
-      <trans-unit id="VKDowX6" resname="Error">
+      </segment>
+    </unit>
+    <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
+      <segment>
         <source>Error</source>
         <target>Hiba</target>
-      </trans-unit>
-      <trans-unit id="8zqt0Ik" resname="This is not a valid UUID.">
+      </segment>
+    </unit>
+    <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
+      <segment>
         <source>This is not a valid UUID.</source>
         <target>Érvénytelen egyedi azonosító (UUID).</target>
-      </trans-unit>
-      <trans-unit id="ru.4wkH" resname="This value should be a multiple of {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
+      <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>Ennek az értéknek oszthatónak kell lennie a következővel: {{ compared_value }}</target>
-      </trans-unit>
-      <trans-unit id="M3vyK6s" resname="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      </segment>
+    </unit>
+    <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
+      <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Ez a Bankazonosító kód (BIC) nem kapcsolódik az IBAN kódhoz ({{ iban }}).</target>
-      </trans-unit>
-      <trans-unit id="2v2xpAh" resname="This value should be valid JSON.">
+      </segment>
+    </unit>
+    <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be valid JSON.</source>
         <target>Ez az érték érvényes JSON kell, hogy legyen.</target>
-      </trans-unit>
-      <trans-unit id="WdvZfq." resname="This value should be positive.">
-        <source>This value should be positive.</source>
-        <target>Ennek az értéknek pozitívnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="ubHMK2q" resname="This value should be either positive or zero.">
-        <source>This value should be either positive or zero.</source>
-        <target>Ennek az értéknek pozitívnak vagy nullának kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="IwNTzo_" resname="This value should be negative.">
-        <source>This value should be negative.</source>
-        <target>Ennek az értéknek negatívnak kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="0GfwMfP" resname="This value should be either negative or zero.">
-        <source>This value should be either negative or zero.</source>
-        <target>Ennek az értéknek negatívnak vagy nullának kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="9CWVEGq" resname="This collection should contain only unique elements.">
+      </segment>
+    </unit>
+    <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
+      <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Ez a gyűjtemény csak egyedi elemeket tartalmazhat.</target>
-      </trans-unit>
-      <trans-unit id="fs3qQZR" resname="This value is not a valid timezone.">
+      </segment>
+    </unit>
+    <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be positive.</source>
+        <target>Ennek az értéknek pozitívnak kell lennie.</target>
+      </segment>
+    </unit>
+    <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either positive or zero.</source>
+        <target>Ennek az értéknek pozitívnak vagy nullának kell lennie.</target>
+      </segment>
+    </unit>
+    <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be negative.</source>
+        <target>Ennek az értéknek negatívnak kell lennie.</target>
+      </segment>
+    </unit>
+    <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either negative or zero.</source>
+        <target>Ennek az értéknek negatívnak vagy nullának kell lennie.</target>
+      </segment>
+    </unit>
+    <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
+      <segment>
         <source>This value is not a valid timezone.</source>
         <target>Ez az érték nem egy érvényes időzóna.</target>
-      </trans-unit>
-      <trans-unit id="40dnsod" resname="This password has been leaked in a data breach, it must not be used. Please use another password.">
-        <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-        <target>Ez a jelszó korábban egy adatvédelmi incidens során illetéktelenek kezébe került, így nem használható. Kérjük, használjon másik jelszót.</target>
-      </trans-unit>
-      <trans-unit id="VvxxWas" resname="This value should be between {{ min }} and {{ max }}.">
+      </segment>
+    </unit>
+    <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
+      <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Ennek az értéknek {{ min }} és {{ max }} között kell lennie.</target>
-      </trans-unit>
-      <trans-unit id="7g313cV" resname="This value is not a valid hostname.">
-        <source>This value is not a valid hostname.</source>
-        <target>Ez az érték nem egy érvényes állomásnév (hosztnév).</target>
-      </trans-unit>
-      <trans-unit id="xwtBimR" resname="The number of elements in this collection should be a multiple of {{ compared_value }}.">
-        <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
-        <target>A gyűjteményben lévő elemek számának oszthatónak kell lennie a következővel: {{ compared_value }}.</target>
-      </trans-unit>
-      <trans-unit id="FDRZr.s" resname="This value should satisfy at least one of the following constraints:">
-        <source>This value should satisfy at least one of the following constraints:</source>
-        <target>Ennek az értéknek meg kell felelni legalább egynek a következő feltételek közül:</target>
-      </trans-unit>
-      <trans-unit id="WwY0IGI" resname="Each element of this collection should satisfy its own set of constraints.">
-        <source>Each element of this collection should satisfy its own set of constraints.</source>
-        <target>A gyűjtemény minden elemének meg kell felelni a saját feltételeinek.</target>
-      </trans-unit>
-      <trans-unit id=".SEaaBa" resname="This form should not contain extra fields.">
+      </segment>
+    </unit>
+    <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
+      <segment>
         <source>This form should not contain extra fields.</source>
         <target>Ez a mezőcsoport nem tartalmazhat extra mezőket.</target>
-      </trans-unit>
-      <trans-unit id="WPnLAh9" resname="The uploaded file was too large. Please try to upload a smaller file.">
+      </segment>
+    </unit>
+    <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
+      <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>A feltöltött fájl túl nagy. Kérem, próbáljon egy kisebb fájlt feltölteni.</target>
-      </trans-unit>
-      <trans-unit id="fvxWW3V" resname="The CSRF token is invalid. Please try to resubmit the form.">
+      </segment>
+    </unit>
+    <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
+      <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Érvénytelen CSRF token. Kérem, próbálja újra elküldeni az űrlapot.</target>
-      </trans-unit>
-      <trans-unit id="eo1zeih" resname="This value is not a valid HTML5 color.">
-        <source>This value is not a valid HTML5 color.</source>
-        <target>Ez az érték nem egy érvényes HTML5 szín.</target>
-      </trans-unit>
-      <trans-unit id="TG1D5NO" resname="post.blank_summary">
-        <source>post.blank_summary</source>
-        <target>Írj hozzá egy összefoglaló részt!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="BZOzjk." resname="post.blank_content">
-        <source>post.blank_content</source>
-        <target>A posztnak tartalmaznia kell valami tartalmat!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="S6M.YWY" resname="post.too_short_content">
-        <source>post.too_short_content</source>
-        <target>A poszt túl rövid! (minimum {{ limit }} karakter)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="niM7JYj" resname="post.too_many_tags">
-        <source>post.too_many_tags</source>
-        <target>Túl sok cimke (maximum {{ limit }} cimke lehet)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="ARUoKOV" resname="comment.blank">
-        <source>comment.blank</source>
-        <target>Kérlek ne hagyd üresen a kommentet!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="J.L_ppQ" resname="comment.too_short">
-        <source>comment.too_short</source>
-        <target>A komment túl rövid! (minimum {{ limit }} karakter)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id=".bkQKXb" resname="comment.too_long">
-        <source>comment.too_long</source>
-        <target>A komment túl hosszú! (maximum {{ limit }} karakter lehet)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="cTT8h4_" resname="comment.is_spam">
-        <source>comment.is_spam</source>
-        <target>A komment tartalma spamnek tűnik.</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-    </body>
+      </segment>
+    </unit>
+    <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_email</source>
+        <target>Már létezik felhasználó a következő e-mail címmel: {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_username</source>
+        <target>Már létezik felhasználó a következő felhasználónévvel: {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_password</source>
+        <target>Érvénytelen jelszó. A jelszónak legalább 6 karaktert kell tartalmaznia.</target>
+      </segment>
+    </unit>
+    <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_email</source>
+        <target>Érvénytelen e-mail cím</target>
+      </segment>
+    </unit>
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
+      <segment>
+        <source>user.username_invalid_characters</source>
+        <target>A felhasználónév csak kisbetűs latin karaktereket, számokat és aláhúzásjeleket tartalmazhat.</target>
+      </segment>
+    </unit>
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_display_name</source>
+        <target>Érvénytelen megjelenített név</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/validators.it.xlf
+++ b/translations/validators.it.xlf
@@ -1,67 +1,718 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="it">
   <file id="validators.it">
-    <unit id="TG1D5NO" name="post.blank_summary">
+    <unit id="zh5oKD9" name="This value should be false.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
       </notes>
       <segment>
-        <source>post.blank_summary</source>
-        <target>Da' una descrizione al tuo post!</target>
+        <source>This value should be false.</source>
+        <target>Questo valore dovrebbe essere falso.</target>
       </segment>
     </unit>
-    <unit id="BZOzjk." name="post.blank_content">
+    <unit id="NN2_iru" name="This value should be true.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
       </notes>
       <segment>
-        <source>post.blank_content</source>
-        <target>Da' un contenuto al tuo post!</target>
+        <source>This value should be true.</source>
+        <target>Questo valore dovrebbe essere vero.</target>
       </segment>
     </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
+    <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
       </notes>
       <segment>
-        <source>post.too_short_content</source>
-        <target>Il contenuto del post è troppo breve (minimo {{ limit }} caratteri)</target>
+        <source>This value should be of type {{ type }}.</source>
+        <target>Questo valore dovrebbe essere di tipo {{ type }}.</target>
       </segment>
     </unit>
-    <unit id="ARUoKOV" name="comment.blank">
+    <unit id="f0P5pBD" name="This value should be blank.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
       </notes>
       <segment>
-        <source>comment.blank</source>
-        <target>Per favore non lasciare in bianco il tuo commento!</target>
+        <source>This value should be blank.</source>
+        <target>Questo valore dovrebbe essere vuoto.</target>
       </segment>
     </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
+    <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
       </notes>
       <segment>
-        <source>comment.too_short</source>
-        <target>Il commento è troppo breve (minimo {{ limit }} caratteri)</target>
+        <source>The value you selected is not a valid choice.</source>
+        <target>Il valore selezionato non è una scelta valida.</target>
       </segment>
     </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
+    <unit id="87zjiHi" name="One or more of the given values is invalid.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
       </notes>
       <segment>
-        <source>comment.too_long</source>
-        <target>Il commento è troppo lungo (massimo {{ limit }} caratteri)</target>
+        <source>One or more of the given values is invalid.</source>
+        <target>Uno o più valori inseriti non sono validi.</target>
       </segment>
     </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
+    <unit id="3NeQftv" name="This field was not expected.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
       </notes>
       <segment>
-        <source>comment.is_spam</source>
-        <target>Il contenuto di questo commento è considerato come spam.</target>
+        <source>This field was not expected.</source>
+        <target>Questo campo non è stato previsto.</target>
+      </segment>
+    </unit>
+    <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
+      <segment>
+        <source>This field is missing.</source>
+        <target>Questo campo è mancante.</target>
+      </segment>
+    </unit>
+    <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid date.</source>
+        <target>Questo valore non è una data valida.</target>
+      </segment>
+    </unit>
+    <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid datetime.</source>
+        <target>Questo valore non è una data e ora valida.</target>
+      </segment>
+    </unit>
+    <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid email address.</source>
+        <target>Questo valore non è un indirizzo email valido.</target>
+      </segment>
+    </unit>
+    <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
+      <segment>
+        <source>The file could not be found.</source>
+        <target>Non è stato possibile trovare il file.</target>
+      </segment>
+    </unit>
+    <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
+      <segment>
+        <source>The file is not readable.</source>
+        <target>Il file non è leggibile.</target>
+      </segment>
+    </unit>
+    <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or less.</source>
+        <target>Questo valore dovrebbe essere {{ limit }} o inferiore.</target>
+      </segment>
+    </unit>
+    <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or more.</source>
+        <target>Questo valore dovrebbe essere {{ limit }} o superiore.</target>
+      </segment>
+    </unit>
+    <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
+      <segment>
+        <source>This value should not be blank.</source>
+        <target>Questo valore non dovrebbe essere vuoto.</target>
+      </segment>
+    </unit>
+    <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should not be null.</source>
+        <target>Questo valore non dovrebbe essere nullo.</target>
+      </segment>
+    </unit>
+    <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be null.</source>
+        <target>Questo valore dovrebbe essere nullo.</target>
+      </segment>
+    </unit>
+    <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not valid.</source>
+        <target>Questo valore non è valido.</target>
+      </segment>
+    </unit>
+    <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid time.</source>
+        <target>Questo valore non è un'ora valida.</target>
+      </segment>
+    </unit>
+    <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid URL.</source>
+        <target>Questo valore non è un URL valido.</target>
+      </segment>
+    </unit>
+    <unit id="jpaLsb2" name="The two values should be equal.">
+      <segment>
+        <source>The two values should be equal.</source>
+        <target>I due valori dovrebbero essere uguali.</target>
+      </segment>
+    </unit>
+    <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
+      <segment>
+        <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+        <target>Il file è troppo grande. La dimensione massima è {{ limit }} {{ suffix }}.</target>
+      </segment>
+    </unit>
+    <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
+      <segment>
+        <source>The file is too large.</source>
+        <target>Il file è troppo grande.</target>
+      </segment>
+    </unit>
+    <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
+      <segment>
+        <source>The file could not be uploaded.</source>
+        <target>Il file non può essere caricato.</target>
+      </segment>
+    </unit>
+    <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
+      <segment>
+        <source>This value should be a valid number.</source>
+        <target>Questo valore dovrebbe essere un numero.</target>
+      </segment>
+    </unit>
+    <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
+      <segment>
+        <source>This file is not a valid image.</source>
+        <target>Questo file non è una immagine valida.</target>
+      </segment>
+    </unit>
+    <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
+      <segment>
+        <source>This is not a valid IP address.</source>
+        <target>Questo non è un indirizzo IP valido.</target>
+      </segment>
+    </unit>
+    <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid language.</source>
+        <target>Questo valore non è una lingua valida.</target>
+      </segment>
+    </unit>
+    <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid locale.</source>
+        <target>Questo valore non è una impostazione regionale valida.</target>
+      </segment>
+    </unit>
+    <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid country.</source>
+        <target>Questo valore non è una nazione valida.</target>
+      </segment>
+    </unit>
+    <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
+      <segment>
+        <source>This value is already used.</source>
+        <target>Questo valore è già stato utilizzato.</target>
+      </segment>
+    </unit>
+    <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
+      <segment>
+        <source>The size of the image could not be detected.</source>
+        <target>La dimensione dell'immagine non può essere determinata.</target>
+      </segment>
+    </unit>
+    <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
+      <segment>
+        <source>This value should be the user's current password.</source>
+        <target>Questo valore dovrebbe essere la password attuale dell'utente.</target>
+      </segment>
+    </unit>
+    <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
+      <segment>
+        <source>The file was only partially uploaded.</source>
+        <target>Il file è stato caricato solo parzialmente.</target>
+      </segment>
+    </unit>
+    <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
+      <segment>
+        <source>No file was uploaded.</source>
+        <target>Nessun file è stato caricato.</target>
+      </segment>
+    </unit>
+    <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
+      <segment>
+        <source>No temporary folder was configured in php.ini.</source>
+        <target>Nessuna cartella temporanea è stata configurata in php.ini, o la cartella configurata non esiste.</target>
+      </segment>
+    </unit>
+    <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
+      <segment>
+        <source>Cannot write temporary file to disk.</source>
+        <target>Impossibile scrivere il file temporaneo sul disco.</target>
+      </segment>
+    </unit>
+    <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
+      <segment>
+        <source>A PHP extension caused the upload to fail.</source>
+        <target>Un'estensione PHP ha causato il fallimento del caricamento.</target>
+      </segment>
+    </unit>
+    <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
+      <segment>
+        <source>Invalid card number.</source>
+        <target>Numero di carta non valido.</target>
+      </segment>
+    </unit>
+    <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
+      <segment>
+        <source>Unsupported card type or invalid card number.</source>
+        <target>Tipo di carta non supportato o numero non valido.</target>
+      </segment>
+    </unit>
+    <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
+      <segment>
+        <source>This is not a valid International Bank Account Number (IBAN).</source>
+        <target>Questo non è un codice IBAN (International Bank Account Number) valido.</target>
+      </segment>
+    </unit>
+    <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-10.</source>
+        <target>Questo valore non è un codice ISBN-10 valido.</target>
+      </segment>
+    </unit>
+    <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-13.</source>
+        <target>Questo valore non è un codice ISBN-13 valido.</target>
+      </segment>
+    </unit>
+    <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
+      <segment>
+        <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
+        <target>Questo valore non è un codice ISBN-10 o ISBN-13 valido.</target>
+      </segment>
+    </unit>
+    <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISSN.</source>
+        <target>Questo valore non è un codice ISSN valido.</target>
+      </segment>
+    </unit>
+    <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid currency.</source>
+        <target>Questo valore non è una valuta valida.</target>
+      </segment>
+    </unit>
+    <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be equal to {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere uguale a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere maggiore di {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than or equal to {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere maggiore o uguale a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere minore di {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than or equal to {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere minore o uguale a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should not be equal to {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere diverso da {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
+      <segment>
+        <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
+        <target>L'immagine è quadrata ({{ width }}x{{ height }}px). Le immagini quadrate non sono consentite.</target>
+      </segment>
+    </unit>
+    <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
+      <segment>
+        <source>An empty file is not allowed.</source>
+        <target>Un file vuoto non è consentito.</target>
+      </segment>
+    </unit>
+    <unit id="bcfVezI" name="The host could not be resolved.">
+      <segment>
+        <source>The host could not be resolved.</source>
+        <target>L'host non può essere risolto.</target>
+      </segment>
+    </unit>
+    <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
+      <segment>
+        <source>This value does not match the expected {{ charset }} charset.</source>
+        <target>Questo valore non corrisponde al charset {{ charset }} previsto.</target>
+      </segment>
+    </unit>
+    <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
+      <segment>
+        <source>This is not a valid Business Identifier Code (BIC).</source>
+        <target>Questo non è un codice identificativo aziendale (BIC) valido.</target>
+      </segment>
+    </unit>
+    <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
+      <segment>
+        <source>Error</source>
+        <target>Errore</target>
+      </segment>
+    </unit>
+    <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
+      <segment>
+        <source>This is not a valid UUID.</source>
+        <target>Questo non è un UUID valido.</target>
+      </segment>
+    </unit>
+    <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
+      <segment>
+        <source>This value should be a multiple of {{ compared_value }}.</source>
+        <target>Questo valore dovrebbe essere un multiplo di {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
+      <segment>
+        <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+        <target>Questo codice identificativo bancario (BIC) non è associato all'IBAN {{ iban }}.</target>
+      </segment>
+    </unit>
+    <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be valid JSON.</source>
+        <target>Questo valore dovrebbe essere un JSON valido.</target>
+      </segment>
+    </unit>
+    <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
+      <segment>
+        <source>This collection should contain only unique elements.</source>
+        <target>Questa collezione dovrebbe contenere solo elementi unici.</target>
+      </segment>
+    </unit>
+    <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be positive.</source>
+        <target>Questo valore dovrebbe essere positivo.</target>
+      </segment>
+    </unit>
+    <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either positive or zero.</source>
+        <target>Questo valore dovrebbe essere positivo oppure zero.</target>
+      </segment>
+    </unit>
+    <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be negative.</source>
+        <target>Questo valore dovrebbe essere negativo.</target>
+      </segment>
+    </unit>
+    <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either negative or zero.</source>
+        <target>Questo valore dovrebbe essere negativo oppure zero.</target>
+      </segment>
+    </unit>
+    <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid timezone.</source>
+        <target>Questo valore non è un fuso orario valido.</target>
+      </segment>
+    </unit>
+    <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
+      <segment>
+        <source>This value should be between {{ min }} and {{ max }}.</source>
+        <target>Questo valore dovrebbe essere compreso tra {{ min }} e {{ max }}.</target>
+      </segment>
+    </unit>
+    <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
+      <segment>
+        <source>This form should not contain extra fields.</source>
+        <target>Questo form non dovrebbe contenere nessun campo extra.</target>
+      </segment>
+    </unit>
+    <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
+      <segment>
+        <source>The uploaded file was too large. Please try to upload a smaller file.</source>
+        <target>Il file caricato è troppo grande. Per favore, carica un file più piccolo.</target>
+      </segment>
+    </unit>
+    <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
+      <segment>
+        <source>The CSRF token is invalid. Please try to resubmit the form.</source>
+        <target>Il token CSRF non è valido. Prova a reinviare il form.</target>
+      </segment>
+    </unit>
+    <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_email</source>
+        <target>Esiste già un utente con l'email {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_username</source>
+        <target>Esiste già un utente con il nome utente {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_password</source>
+        <target>Password non valida. La password deve contenere almeno 6 caratteri.</target>
+      </segment>
+    </unit>
+    <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_email</source>
+        <target>Email non valida</target>
+      </segment>
+    </unit>
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
+      <segment>
+        <source>user.username_invalid_characters</source>
+        <target>Il nome utente deve contenere solo lettere latine minuscole, numeri e trattini bassi.</target>
+      </segment>
+    </unit>
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_display_name</source>
+        <target>Nome visualizzato non valido</target>
       </segment>
     </unit>
   </file>

--- a/translations/validators.nl.xlf
+++ b/translations/validators.nl.xlf
@@ -1,163 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="nl" trgLang="nl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="nl">
   <file id="validators.nl">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Deze waarde moet onwaar zijn.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Deze waarde moet waar zijn.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Deze waarde moet van het type {{ type }} zijn.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Deze waarde moet leeg zijn.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>De geselecteerde waarde is geen geldige optie.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Selecteer ten minste {{ limit }} optie.|Selecteer ten minste {{ limit }} opties.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Selecteer maximaal {{ limit }} optie.|Selecteer maximaal {{ limit }} opties.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Eén of meer van de ingegeven waarden zijn ongeldig.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Dit veld werd niet verwacht.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Dit veld ontbreekt.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Deze waarde is geen geldige datum.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Deze waarde is geen geldige datum en tijd.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Deze waarde is geen geldig e-mailadres.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Het bestand kon niet gevonden worden.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Het bestand is niet leesbaar.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Het bestand is te groot ({{ size }} {{ suffix }}). Toegestane maximum grootte is {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Het mime type van het bestand is ongeldig ({{ type }}). Toegestane mime types zijn {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Deze waarde moet {{ limit }} of minder zijn.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Deze waarde is te lang. Hij mag maximaal {{ limit }} teken bevatten.|Deze waarde is te lang. Hij mag maximaal {{ limit }} tekens bevatten.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Deze waarde moet {{ limit }} of meer zijn.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Deze waarde is te kort. Hij moet tenminste {{ limit }} teken bevatten.|Deze waarde is te kort. Hij moet tenminste {{ limit }} tekens bevatten.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Deze waarde mag niet leeg zijn.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Deze waarde mag niet null zijn.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Deze waarde moet null zijn.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Deze waarde is niet geldig.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Deze waarde is geen geldige tijd.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Deze waarde is geen geldige URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>Het bestand is te groot. Toegestane maximum grootte is {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Het bestand is te groot.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Het bestand kon niet worden geüpload.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Deze waarde moet een geldig getal zijn.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Dit bestand is geen geldige afbeelding.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Dit is geen geldig IP-adres.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Deze waarde is geen geldige taal.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Deze waarde is geen geldige locale.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Deze waarde is geen geldig land.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Deze waarde wordt al gebruikt.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>De grootte van de afbeelding kon niet bepaald worden.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>De afbeelding is te breed ({{ width }}px). De maximaal toegestane breedte is {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>De afbeelding is niet breed genoeg ({{ width }}px). De minimaal verwachte breedte is {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>De afbeelding is te hoog ({{ height }}px). De maximaal toegestane hoogte is {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>De afbeelding is niet hoog genoeg ({{ height }}px). De minimaal verwachte hoogte is {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Deze waarde moet het huidige wachtwoord van de gebruiker zijn.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Deze waarde moet exact {{ limit }} teken lang zijn.|Deze waarde moet exact {{ limit }} tekens lang zijn.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Het bestand is slechts gedeeltelijk geüpload.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Er is geen bestand geüpload.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>Er is geen tijdelijke map geconfigureerd in php.ini, of de gespecificeerde map bestaat niet.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Kan het tijdelijke bestand niet wegschrijven op disk.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>De upload is mislukt vanwege een PHP-extensie.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Deze collectie moet {{ limit }} element of meer bevatten.|Deze collectie moet {{ limit }} elementen of meer bevatten.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Deze collectie moet {{ limit }} element of minder bevatten.|Deze collectie moet {{ limit }} elementen of minder bevatten.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Deze collectie moet exact {{ limit }} element bevatten.|Deze collectie moet exact {{ limit }} elementen bevatten.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Ongeldig creditcardnummer.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Niet-ondersteund type creditcard of ongeldig nummer.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Dit is geen geldig internationaal bankrekeningnummer (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Deze waarde is geen geldige ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Deze waarde is geen geldige ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Deze waarde is geen geldige ISBN-10 of ISBN-13 waarde.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Deze waarde is geen geldige ISSN waarde.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Deze waarde is geen geldige valuta.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Deze waarde moet gelijk zijn aan {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Deze waarde moet groter zijn dan {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Deze waarde moet groter dan of gelijk aan {{ compared_value }} zijn.</target>
       </segment>
     </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Deze waarde moet identiek zijn aan {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Deze waarde moet minder zijn dan {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Deze waarde moet minder dan of gelijk aan {{ compared_value }} zijn.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Deze waarde mag niet gelijk zijn aan {{ compared_value }}.</target>
       </segment>
     </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Deze waarde mag niet identiek zijn aan {{ compared_value_type }} {{ compared_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>De afbeeldingsverhouding is te groot ({{ ratio }}). Maximale verhouding is {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>De afbeeldingsverhouding is te klein ({{ ratio }}). Minimale verhouding is {{ min_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>De afbeelding is vierkant ({{ width }}x{{ height }}px). Vierkante afbeeldingen zijn niet toegestaan.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>De afbeelding is liggend ({{ width }}x{{ height }}px). Liggende afbeeldingen zijn niet toegestaan.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>De afbeelding is staand ({{ width }}x{{ height }}px). Staande afbeeldingen zijn niet toegestaan.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Lege bestanden zijn niet toegestaan.</target>
@@ -458,174 +508,211 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Deze waarde is niet in de verwachte tekencodering {{ charset }}.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Dit is geen geldige bedrijfsidentificatiecode (BIC/SWIFT).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Fout</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Dit is geen geldige UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>Deze waarde zou een meervoud van {{ compared_value }} moeten zijn.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Deze bedrijfsidentificatiecode (BIC) is niet gekoppeld aan IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Deze waarde moet geldige JSON zijn.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Deze collectie moet alleen unieke elementen bevatten.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Deze waarde moet positief zijn.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Deze waarde moet positief of gelijk aan nul zijn.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Deze waarde moet negatief zijn.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Deze waarde moet negatief of gelijk aan nul zijn.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Deze waarde is geen geldige tijdzone.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Dit wachtwoord is gelekt vanwege een data-inbreuk, het moet niet worden gebruikt. Kies een ander wachtwoord.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Deze waarde moet zich tussen {{ min }} en {{ max }} bevinden.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Dit formulier mag geen extra velden bevatten.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Het geüploade bestand is te groot. Probeer een kleiner bestand te uploaden.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>De CSRF-token is ongeldig. Probeer het formulier opnieuw te versturen.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
+    <unit id="LDy5h0B" name="user.duplicate_email">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:24</note>
       </notes>
       <segment>
-        <source>post.blank_summary</source>
-        <target>Geef uw bericht een samenvatting.</target>
+        <source>user.duplicate_email</source>
+        <target>Er bestaat al een gebruiker met het e-mailadres {{ value }}.</target>
       </segment>
     </unit>
-    <unit id="BZOzjk." name="post.blank_content">
+    <unit id="D4OMpCY" name="user.duplicate_username">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:25</note>
       </notes>
       <segment>
-        <source>post.blank_content</source>
-        <target>Uw bericht heeft nog geen inhoud.</target>
+        <source>user.duplicate_username</source>
+        <target>Er bestaat al een gebruiker met de gebruikersnaam {{ value }}.</target>
       </segment>
     </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
+    <unit id="HjWW.NS" name="user.not_valid_password">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:57</note>
       </notes>
       <segment>
-        <source>post.too_short_content</source>
-        <target>Bericht inhoud is te kort (minimaal {{ limit }} karakters)</target>
+        <source>user.not_valid_password</source>
+        <target>Ongeldig wachtwoord. Het wachtwoord moet minstens 6 tekens bevatten.</target>
       </segment>
     </unit>
-    <unit id="ARUoKOV" name="comment.blank">
+    <unit id="fkXL.k6" name="user.not_valid_email">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:49</note>
       </notes>
       <segment>
-        <source>comment.blank</source>
-        <target>Vul alstublieft een reactie in.</target>
+        <source>user.not_valid_email</source>
+        <target>Ongeldig e-mailadres</target>
       </segment>
     </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:43</note>
       </notes>
       <segment>
-        <source>comment.too_short</source>
-        <target>Reactie is te kort (minimaal {{ limit }} karakters)</target>
+        <source>user.username_invalid_characters</source>
+        <target>De gebruikersnaam mag alleen kleine Latijnse letters, cijfers en underscores bevatten.</target>
       </segment>
     </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
       </notes>
       <segment>
-        <source>comment.too_long</source>
-        <target>Reactie is te lang (maximaal {{ limit }} karakters)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>De inhoud van deze reactie wordt als spam gemarkeerd.</target>
+        <source>user.not_valid_display_name</source>
+        <target>Ongeldige weergavenaam</target>
       </segment>
     </unit>
   </file>

--- a/translations/validators.pl.xlf
+++ b/translations/validators.pl.xlf
@@ -1,67 +1,718 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="pl" trgLang="pl">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pl">
   <file id="validators.pl">
-    <unit id="TG1D5NO" name="post.blank_summary">
+    <unit id="zh5oKD9" name="This value should be false.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
       </notes>
       <segment>
-        <source>post.blank_summary</source>
-        <target>Dodaj podsumowanie Twojego artykułu!</target>
+        <source>This value should be false.</source>
+        <target>Ta wartość powinna być fałszem.</target>
       </segment>
     </unit>
-    <unit id="BZOzjk." name="post.blank_content">
+    <unit id="NN2_iru" name="This value should be true.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
       </notes>
       <segment>
-        <source>post.blank_content</source>
-        <target>Treść artykułu nie może być pusta!</target>
+        <source>This value should be true.</source>
+        <target>Ta wartość powinna być prawdą.</target>
       </segment>
     </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
+    <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
       </notes>
       <segment>
-        <source>post.too_short_content</source>
-        <target>Treść artykułu jest za krótka (minimum: {{ limit }} znak)|Treść artykułu jest za krótka (minimum: {{ limit }} znaki)|Treść artykułu jest za krótka (minimum: {{ limit }} znaków)</target>
+        <source>This value should be of type {{ type }}.</source>
+        <target>Ta wartość powinna być typu {{ type }}.</target>
       </segment>
     </unit>
-    <unit id="ARUoKOV" name="comment.blank">
+    <unit id="f0P5pBD" name="This value should be blank.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
       </notes>
       <segment>
-        <source>comment.blank</source>
-        <target>Pole komentarza nie może być puste!</target>
+        <source>This value should be blank.</source>
+        <target>Ta wartość powinna być pusta.</target>
       </segment>
     </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
+    <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
       </notes>
       <segment>
-        <source>comment.too_short</source>
-        <target>Twój komentarz jest za krótki (minimum: {{ limit }} znak)|Twój komentarz jest za krótki (minimum: {{ limit }} znaki)|Twój komentarz jest za krótki (minimum: {{ limit }} znaków)</target>
+        <source>The value you selected is not a valid choice.</source>
+        <target>Ta wartość powinna być jedną z podanych opcji.</target>
       </segment>
     </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
+    <unit id="87zjiHi" name="One or more of the given values is invalid.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
       </notes>
       <segment>
-        <source>comment.too_long</source>
-        <target>Twój komentarz jest za długi (maksimum: {{ limit }} znak)|Twój komentarz jest za długi (maksimum: {{ limit }} znaki)|Twój komentarz jest za długi (maksimum: {{ limit }} znaków)</target>
+        <source>One or more of the given values is invalid.</source>
+        <target>Jedna lub więcej z podanych wartości jest nieprawidłowa.</target>
       </segment>
     </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
+    <unit id="3NeQftv" name="This field was not expected.">
       <notes>
-        <note priority="1">obsolete</note>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
       </notes>
       <segment>
-        <source>comment.is_spam</source>
-        <target>Twój komentarz został uznany za spam.</target>
+        <source>This field was not expected.</source>
+        <target>Tego pola się nie spodziewano.</target>
+      </segment>
+    </unit>
+    <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
+      <segment>
+        <source>This field is missing.</source>
+        <target>Tego pola brakuje.</target>
+      </segment>
+    </unit>
+    <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid date.</source>
+        <target>Ta wartość nie jest prawidłową datą.</target>
+      </segment>
+    </unit>
+    <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid datetime.</source>
+        <target>Ta wartość nie jest prawidłową datą i czasem.</target>
+      </segment>
+    </unit>
+    <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid email address.</source>
+        <target>Ta wartość nie jest prawidłowym adresem email.</target>
+      </segment>
+    </unit>
+    <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
+      <segment>
+        <source>The file could not be found.</source>
+        <target>Plik nie mógł zostać odnaleziony.</target>
+      </segment>
+    </unit>
+    <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
+      <segment>
+        <source>The file is not readable.</source>
+        <target>Nie można odczytać pliku.</target>
+      </segment>
+    </unit>
+    <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or less.</source>
+        <target>Ta wartość powinna wynosić {{ limit }} lub mniej.</target>
+      </segment>
+    </unit>
+    <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or more.</source>
+        <target>Ta wartość powinna wynosić {{ limit }} lub więcej.</target>
+      </segment>
+    </unit>
+    <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
+      <segment>
+        <source>This value should not be blank.</source>
+        <target>Ta wartość nie powinna być pusta.</target>
+      </segment>
+    </unit>
+    <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should not be null.</source>
+        <target>Ta wartość nie powinna być nullem.</target>
+      </segment>
+    </unit>
+    <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be null.</source>
+        <target>Ta wartość powinna być nullem.</target>
+      </segment>
+    </unit>
+    <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not valid.</source>
+        <target>Ta wartość jest nieprawidłowa.</target>
+      </segment>
+    </unit>
+    <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid time.</source>
+        <target>Ta wartość nie jest prawidłowym czasem.</target>
+      </segment>
+    </unit>
+    <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid URL.</source>
+        <target>Ta wartość nie jest prawidłowym adresem URL.</target>
+      </segment>
+    </unit>
+    <unit id="jpaLsb2" name="The two values should be equal.">
+      <segment>
+        <source>The two values should be equal.</source>
+        <target>Obie wartości powinny być równe.</target>
+      </segment>
+    </unit>
+    <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
+      <segment>
+        <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+        <target>Plik jest za duży. Maksymalny dozwolony rozmiar to {{ limit }} {{ suffix }}.</target>
+      </segment>
+    </unit>
+    <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
+      <segment>
+        <source>The file is too large.</source>
+        <target>Plik jest za duży.</target>
+      </segment>
+    </unit>
+    <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
+      <segment>
+        <source>The file could not be uploaded.</source>
+        <target>Plik nie mógł być wgrany.</target>
+      </segment>
+    </unit>
+    <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
+      <segment>
+        <source>This value should be a valid number.</source>
+        <target>Ta wartość powinna być prawidłową liczbą.</target>
+      </segment>
+    </unit>
+    <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
+      <segment>
+        <source>This file is not a valid image.</source>
+        <target>Ten plik nie jest obrazem.</target>
+      </segment>
+    </unit>
+    <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
+      <segment>
+        <source>This is not a valid IP address.</source>
+        <target>To nie jest prawidłowy adres IP.</target>
+      </segment>
+    </unit>
+    <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid language.</source>
+        <target>Ta wartość nie jest prawidłowym językiem.</target>
+      </segment>
+    </unit>
+    <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid locale.</source>
+        <target>Ta wartość nie jest prawidłową lokalizacją.</target>
+      </segment>
+    </unit>
+    <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid country.</source>
+        <target>Ta wartość nie jest prawidłową nazwą kraju.</target>
+      </segment>
+    </unit>
+    <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
+      <segment>
+        <source>This value is already used.</source>
+        <target>Ta wartość jest już wykorzystywana.</target>
+      </segment>
+    </unit>
+    <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
+      <segment>
+        <source>The size of the image could not be detected.</source>
+        <target>Nie można wykryć rozmiaru obrazka.</target>
+      </segment>
+    </unit>
+    <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
+      <segment>
+        <source>This value should be the user's current password.</source>
+        <target>Ta wartość powinna być aktualnym hasłem użytkownika.</target>
+      </segment>
+    </unit>
+    <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
+      <segment>
+        <source>The file was only partially uploaded.</source>
+        <target>Plik został wgrany tylko częściowo.</target>
+      </segment>
+    </unit>
+    <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
+      <segment>
+        <source>No file was uploaded.</source>
+        <target>Żaden plik nie został wgrany.</target>
+      </segment>
+    </unit>
+    <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
+      <segment>
+        <source>No temporary folder was configured in php.ini.</source>
+        <target>W php.ini nie skonfigurowano folderu tymczasowego lub skonfigurowany folder nie istnieje.</target>
+      </segment>
+    </unit>
+    <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
+      <segment>
+        <source>Cannot write temporary file to disk.</source>
+        <target>Nie można zapisać pliku tymczasowego na dysku.</target>
+      </segment>
+    </unit>
+    <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
+      <segment>
+        <source>A PHP extension caused the upload to fail.</source>
+        <target>Rozszerzenie PHP spowodowało błąd podczas wgrywania.</target>
+      </segment>
+    </unit>
+    <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
+      <segment>
+        <source>Invalid card number.</source>
+        <target>Nieprawidłowy numer karty.</target>
+      </segment>
+    </unit>
+    <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
+      <segment>
+        <source>Unsupported card type or invalid card number.</source>
+        <target>Nieobsługiwany rodzaj karty lub nieprawidłowy numer karty.</target>
+      </segment>
+    </unit>
+    <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
+      <segment>
+        <source>This is not a valid International Bank Account Number (IBAN).</source>
+        <target>To nie jest prawidłowy międzynarodowy numer rachunku bankowego (IBAN).</target>
+      </segment>
+    </unit>
+    <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-10.</source>
+        <target>Ta wartość nie jest prawidłowym numerem ISBN-10.</target>
+      </segment>
+    </unit>
+    <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-13.</source>
+        <target>Ta wartość nie jest prawidłowym numerem ISBN-13.</target>
+      </segment>
+    </unit>
+    <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
+      <segment>
+        <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
+        <target>Ta wartość nie jest prawidłowym numerem ISBN-10 ani ISBN-13.</target>
+      </segment>
+    </unit>
+    <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISSN.</source>
+        <target>Ta wartość nie jest prawidłowym numerem ISSN.</target>
+      </segment>
+    </unit>
+    <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid currency.</source>
+        <target>Ta wartość nie jest prawidłową walutą.</target>
+      </segment>
+    </unit>
+    <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be equal to {{ compared_value }}.</source>
+        <target>Ta wartość powinna być równa {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than {{ compared_value }}.</source>
+        <target>Ta wartość powinna być większa niż {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than or equal to {{ compared_value }}.</source>
+        <target>Ta wartość powinna być większa bądź równa {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than {{ compared_value }}.</source>
+        <target>Ta wartość powinna być mniejsza niż {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than or equal to {{ compared_value }}.</source>
+        <target>Ta wartość powinna być mniejsza bądź równa {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should not be equal to {{ compared_value }}.</source>
+        <target>Ta wartość nie powinna być równa {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
+      <segment>
+        <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
+        <target>Obraz jest kwadratem ({{ width }}x{{ height }}px). Kwadratowe obrazy nie są akceptowane.</target>
+      </segment>
+    </unit>
+    <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
+      <segment>
+        <source>An empty file is not allowed.</source>
+        <target>Plik nie może być pusty.</target>
+      </segment>
+    </unit>
+    <unit id="bcfVezI" name="The host could not be resolved.">
+      <segment>
+        <source>The host could not be resolved.</source>
+        <target>Nazwa hosta nie została rozpoznana.</target>
+      </segment>
+    </unit>
+    <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
+      <segment>
+        <source>This value does not match the expected {{ charset }} charset.</source>
+        <target>Ta wartość nie pasuje do oczekiwanego zestawu znaków {{ charset }}.</target>
+      </segment>
+    </unit>
+    <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
+      <segment>
+        <source>This is not a valid Business Identifier Code (BIC).</source>
+        <target>To nie jest prawidłowy kod identyfikacyjny podmiotu (BIC).</target>
+      </segment>
+    </unit>
+    <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
+      <segment>
+        <source>Error</source>
+        <target>Błąd</target>
+      </segment>
+    </unit>
+    <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
+      <segment>
+        <source>This is not a valid UUID.</source>
+        <target>To nie jest prawidłowy identyfikator UUID.</target>
+      </segment>
+    </unit>
+    <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
+      <segment>
+        <source>This value should be a multiple of {{ compared_value }}.</source>
+        <target>Ta wartość powinna być wielokrotnością {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
+      <segment>
+        <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+        <target>Ten kod BIC (Business Identifier Code) nie jest powiązany z międzynarodowym numerem rachunku bankowego (IBAN) {{ iban }}.</target>
+      </segment>
+    </unit>
+    <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be valid JSON.</source>
+        <target>Ta wartość powinna być prawidłowym formatem JSON.</target>
+      </segment>
+    </unit>
+    <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
+      <segment>
+        <source>This collection should contain only unique elements.</source>
+        <target>Ten zbiór powinien zawierać tylko unikalne elementy.</target>
+      </segment>
+    </unit>
+    <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be positive.</source>
+        <target>Ta wartość powinna być dodatnia.</target>
+      </segment>
+    </unit>
+    <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either positive or zero.</source>
+        <target>Ta wartość powinna być dodatnia lub równa zero.</target>
+      </segment>
+    </unit>
+    <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be negative.</source>
+        <target>Ta wartość powinna być ujemna.</target>
+      </segment>
+    </unit>
+    <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either negative or zero.</source>
+        <target>Ta wartość powinna być ujemna lub równa zero.</target>
+      </segment>
+    </unit>
+    <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid timezone.</source>
+        <target>Ta wartość nie jest prawidłową strefą czasową.</target>
+      </segment>
+    </unit>
+    <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
+      <segment>
+        <source>This value should be between {{ min }} and {{ max }}.</source>
+        <target>Ta wartość powinna być pomiędzy {{ min }} a {{ max }}.</target>
+      </segment>
+    </unit>
+    <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
+      <segment>
+        <source>This form should not contain extra fields.</source>
+        <target>Ten formularz nie powinien zawierać dodatkowych pól.</target>
+      </segment>
+    </unit>
+    <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
+      <segment>
+        <source>The uploaded file was too large. Please try to upload a smaller file.</source>
+        <target>Wgrany plik był za duży. Proszę spróbować wgrać mniejszy plik.</target>
+      </segment>
+    </unit>
+    <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
+      <segment>
+        <source>The CSRF token is invalid. Please try to resubmit the form.</source>
+        <target>Token CSRF jest nieprawidłowy. Proszę spróbować wysłać formularz ponownie.</target>
+      </segment>
+    </unit>
+    <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_email</source>
+        <target>Użytkownik z adresem e-mail {{ value }} już istnieje.</target>
+      </segment>
+    </unit>
+    <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_username</source>
+        <target>Użytkownik o nazwie {{ value }} już istnieje.</target>
+      </segment>
+    </unit>
+    <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_password</source>
+        <target>Nieprawidłowe hasło. Hasło powinno zawierać co najmniej 6 znaków.</target>
+      </segment>
+    </unit>
+    <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_email</source>
+        <target>Nieprawidłowy adres e-mail</target>
+      </segment>
+    </unit>
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
+      <segment>
+        <source>user.username_invalid_characters</source>
+        <target>Nazwa użytkownika może zawierać tylko małe litery łacińskie, cyfry i podkreślenia.</target>
+      </segment>
+    </unit>
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_display_name</source>
+        <target>Nieprawidłowa nazwa wyświetlana</target>
       </segment>
     </unit>
   </file>

--- a/translations/validators.pt_BR.xlf
+++ b/translations/validators.pt_BR.xlf
@@ -1,50 +1,719 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="pt-BR" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="TG1D5NO" resname="post.blank_summary">
-        <source>post.blank_summary</source>
-        <target>Informe um sumário para o seu post!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="BZOzjk." resname="post.blank_content">
-        <source>post.blank_content</source>
-        <target>Informe um conteúdo para o seu post!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="S6M.YWY" resname="post.too_short_content">
-        <source>post.too_short_content</source>
-        <target>O conteúdo do post está muito curto (mínimo de {{ limit }} caracteres)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="niM7JYj" resname="post.too_many_tags">
-        <source>post.too_many_tags</source>
-        <target>Tags demais (adicione {{ limit }} tags ou menos)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="ARUoKOV" resname="comment.blank">
-        <source>comment.blank</source>
-        <target>Por favor, não deixe seu comentário vazio!</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="J.L_ppQ" resname="comment.too_short">
-        <source>comment.too_short</source>
-        <target>O comentário está muito curto (mínimo de {{ limit }} caracteres)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id=".bkQKXb" resname="comment.too_long">
-        <source>comment.too_long</source>
-        <target>O comentário está muito grande (máximo de {{ limit }} caracteres)</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-      <trans-unit id="cTT8h4_" resname="comment.is_spam">
-        <source>comment.is_spam</source>
-        <target>O conteúdo desse comentário é considerado spam.</target>
-        <note priority="1">obsolete</note>
-      </trans-unit>
-    </body>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="pt-BR">
+  <file id="validators.pt_BR">
+    <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be false.</source>
+        <target>Este valor deve ser falso.</target>
+      </segment>
+    </unit>
+    <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be true.</source>
+        <target>Este valor deve ser verdadeiro.</target>
+      </segment>
+    </unit>
+    <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
+      <segment>
+        <source>This value should be of type {{ type }}.</source>
+        <target>Este valor deve ser do tipo {{ type }}.</target>
+      </segment>
+    </unit>
+    <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be blank.</source>
+        <target>Este valor deve ser vazio.</target>
+      </segment>
+    </unit>
+    <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
+      <segment>
+        <source>The value you selected is not a valid choice.</source>
+        <target>O valor selecionado não é uma opção válida.</target>
+      </segment>
+    </unit>
+    <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
+      <segment>
+        <source>One or more of the given values is invalid.</source>
+        <target>Um ou mais valores informados são inválidos.</target>
+      </segment>
+    </unit>
+    <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
+      <segment>
+        <source>This field was not expected.</source>
+        <target>Este campo não era esperado.</target>
+      </segment>
+    </unit>
+    <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
+      <segment>
+        <source>This field is missing.</source>
+        <target>Este campo está ausente.</target>
+      </segment>
+    </unit>
+    <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid date.</source>
+        <target>Este valor não é uma data válida.</target>
+      </segment>
+    </unit>
+    <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid datetime.</source>
+        <target>Este valor não é uma data e hora válida.</target>
+      </segment>
+    </unit>
+    <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid email address.</source>
+        <target>Este valor não é um endereço de e-mail válido.</target>
+      </segment>
+    </unit>
+    <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
+      <segment>
+        <source>The file could not be found.</source>
+        <target>O arquivo não foi encontrado.</target>
+      </segment>
+    </unit>
+    <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
+      <segment>
+        <source>The file is not readable.</source>
+        <target>O arquivo não pode ser lido.</target>
+      </segment>
+    </unit>
+    <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or less.</source>
+        <target>Este valor deve ser {{ limit }} ou menos.</target>
+      </segment>
+    </unit>
+    <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
+      <segment>
+        <source>This value should be {{ limit }} or more.</source>
+        <target>Este valor deve ser {{ limit }} ou mais.</target>
+      </segment>
+    </unit>
+    <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
+      <segment>
+        <source>This value should not be blank.</source>
+        <target>Este valor não deve ser vazio.</target>
+      </segment>
+    </unit>
+    <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should not be null.</source>
+        <target>Este valor não deve ser nulo.</target>
+      </segment>
+    </unit>
+    <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be null.</source>
+        <target>Este valor deve ser nulo.</target>
+      </segment>
+    </unit>
+    <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not valid.</source>
+        <target>Este valor não é válido.</target>
+      </segment>
+    </unit>
+    <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid time.</source>
+        <target>Este valor não é uma hora válida.</target>
+      </segment>
+    </unit>
+    <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid URL.</source>
+        <target>Este valor não é uma URL válida.</target>
+      </segment>
+    </unit>
+    <unit id="jpaLsb2" name="The two values should be equal.">
+      <segment>
+        <source>The two values should be equal.</source>
+        <target>Os dois valores devem ser iguais.</target>
+      </segment>
+    </unit>
+    <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
+      <segment>
+        <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+        <target>O arquivo é muito grande. O tamanho máximo permitido é de {{ limit }} {{ suffix }}.</target>
+      </segment>
+    </unit>
+    <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
+      <segment>
+        <source>The file is too large.</source>
+        <target>O arquivo é muito grande.</target>
+      </segment>
+    </unit>
+    <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
+      <segment>
+        <source>The file could not be uploaded.</source>
+        <target>O arquivo não pode ser enviado.</target>
+      </segment>
+    </unit>
+    <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
+      <segment>
+        <source>This value should be a valid number.</source>
+        <target>Este valor deve ser um número válido.</target>
+      </segment>
+    </unit>
+    <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
+      <segment>
+        <source>This file is not a valid image.</source>
+        <target>Este arquivo não é uma imagem válida.</target>
+      </segment>
+    </unit>
+    <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
+      <segment>
+        <source>This is not a valid IP address.</source>
+        <target>Este não é um endereço de IP válido.</target>
+      </segment>
+    </unit>
+    <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid language.</source>
+        <target>Este valor não é um idioma válido.</target>
+      </segment>
+    </unit>
+    <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid locale.</source>
+        <target>Este valor não é uma localidade válida.</target>
+      </segment>
+    </unit>
+    <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid country.</source>
+        <target>Este valor não é um país válido.</target>
+      </segment>
+    </unit>
+    <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
+      <segment>
+        <source>This value is already used.</source>
+        <target>Este valor já está sendo usado.</target>
+      </segment>
+    </unit>
+    <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
+      <segment>
+        <source>The size of the image could not be detected.</source>
+        <target>O tamanho da imagem não pode ser detectado.</target>
+      </segment>
+    </unit>
+    <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
+      <segment>
+        <source>This value should be the user's current password.</source>
+        <target>Este valor deve ser a senha atual do usuário.</target>
+      </segment>
+    </unit>
+    <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
+      <segment>
+        <source>The file was only partially uploaded.</source>
+        <target>O arquivo foi enviado apenas parcialmente.</target>
+      </segment>
+    </unit>
+    <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
+      <segment>
+        <source>No file was uploaded.</source>
+        <target>Nenhum arquivo foi enviado.</target>
+      </segment>
+    </unit>
+    <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
+      <segment>
+        <source>No temporary folder was configured in php.ini.</source>
+        <target>Nenhuma pasta temporária foi configurada no php.ini, ou a pasta configurada não existe.</target>
+      </segment>
+    </unit>
+    <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
+      <segment>
+        <source>Cannot write temporary file to disk.</source>
+        <target>Não foi possível escrever o arquivo temporário no disco.</target>
+      </segment>
+    </unit>
+    <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
+      <segment>
+        <source>A PHP extension caused the upload to fail.</source>
+        <target>Uma extensão PHP fez com que o envio falhasse.</target>
+      </segment>
+    </unit>
+    <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
+      <segment>
+        <source>Invalid card number.</source>
+        <target>Número de cartão inválido.</target>
+      </segment>
+    </unit>
+    <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
+      <segment>
+        <source>Unsupported card type or invalid card number.</source>
+        <target>Tipo de cartão não suportado ou número de cartão inválido.</target>
+      </segment>
+    </unit>
+    <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
+      <segment>
+        <source>This is not a valid International Bank Account Number (IBAN).</source>
+        <target>Este não é um Número Internacional de Conta Bancária (IBAN) válido.</target>
+      </segment>
+    </unit>
+    <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-10.</source>
+        <target>Este valor não é um ISBN-10 válido.</target>
+      </segment>
+    </unit>
+    <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISBN-13.</source>
+        <target>Este valor não é um ISBN-13 válido.</target>
+      </segment>
+    </unit>
+    <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
+      <segment>
+        <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
+        <target>Este valor não é um ISBN-10 e nem um ISBN-13 válido.</target>
+      </segment>
+    </unit>
+    <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid ISSN.</source>
+        <target>Este valor não é um ISSN válido.</target>
+      </segment>
+    </unit>
+    <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid currency.</source>
+        <target>Este não é um valor monetário válido.</target>
+      </segment>
+    </unit>
+    <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be equal to {{ compared_value }}.</source>
+        <target>Este valor deve ser igual a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than {{ compared_value }}.</source>
+        <target>Este valor deve ser maior que {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be greater than or equal to {{ compared_value }}.</source>
+        <target>Este valor deve ser maior ou igual a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than {{ compared_value }}.</source>
+        <target>Este valor deve ser menor que {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should be less than or equal to {{ compared_value }}.</source>
+        <target>Este valor deve ser menor ou igual a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
+      <segment>
+        <source>This value should not be equal to {{ compared_value }}.</source>
+        <target>Este valor não deve ser igual a {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
+      <segment>
+        <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
+        <target>A imagem está num formato quadrado ({{ width }}x{{ height }}px). Imagens com formato quadrado não são permitidas.</target>
+      </segment>
+    </unit>
+    <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
+      <segment>
+        <source>An empty file is not allowed.</source>
+        <target>Arquivo vazio não é permitido.</target>
+      </segment>
+    </unit>
+    <unit id="bcfVezI" name="The host could not be resolved.">
+      <segment>
+        <source>The host could not be resolved.</source>
+        <target>O host não pôde ser resolvido.</target>
+      </segment>
+    </unit>
+    <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
+      <segment>
+        <source>This value does not match the expected {{ charset }} charset.</source>
+        <target>Este valor não corresponde ao charset {{ charset }} esperado.</target>
+      </segment>
+    </unit>
+    <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
+      <segment>
+        <source>This is not a valid Business Identifier Code (BIC).</source>
+        <target>Este não é um Código de Identificação de Negócio (BIC) válido.</target>
+      </segment>
+    </unit>
+    <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
+      <segment>
+        <source>Error</source>
+        <target>Erro</target>
+      </segment>
+    </unit>
+    <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
+      <segment>
+        <source>This is not a valid UUID.</source>
+        <target>Este não é um UUID válido.</target>
+      </segment>
+    </unit>
+    <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
+      <segment>
+        <source>This value should be a multiple of {{ compared_value }}.</source>
+        <target>Este valor deve ser múltiplo de {{ compared_value }}.</target>
+      </segment>
+    </unit>
+    <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
+      <segment>
+        <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
+        <target>Este Código Identificador Bancário (BIC) não está associado ao IBAN {{ iban }}.</target>
+      </segment>
+    </unit>
+    <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
+      <segment>
+        <source>This value should be valid JSON.</source>
+        <target>Este valor deve ser um JSON válido.</target>
+      </segment>
+    </unit>
+    <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
+      <segment>
+        <source>This collection should contain only unique elements.</source>
+        <target>Esta coleção deve conter somente elementos únicos.</target>
+      </segment>
+    </unit>
+    <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be positive.</source>
+        <target>Este valor deve ser positivo.</target>
+      </segment>
+    </unit>
+    <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either positive or zero.</source>
+        <target>Este valor deve ser positivo ou zero.</target>
+      </segment>
+    </unit>
+    <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be negative.</source>
+        <target>Este valor deve ser negativo.</target>
+      </segment>
+    </unit>
+    <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either negative or zero.</source>
+        <target>Este valor deve ser negativo ou zero.</target>
+      </segment>
+    </unit>
+    <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid timezone.</source>
+        <target>Este valor não representa um fuso horário válido.</target>
+      </segment>
+    </unit>
+    <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
+      <segment>
+        <source>This value should be between {{ min }} and {{ max }}.</source>
+        <target>Este valor deve estar entre {{ min }} e {{ max }}.</target>
+      </segment>
+    </unit>
+    <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
+      <segment>
+        <source>This form should not contain extra fields.</source>
+        <target>Este formulário não deve conter campos adicionais.</target>
+      </segment>
+    </unit>
+    <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
+      <segment>
+        <source>The uploaded file was too large. Please try to upload a smaller file.</source>
+        <target>O arquivo enviado é muito grande. Por favor, tente enviar um arquivo menor.</target>
+      </segment>
+    </unit>
+    <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
+      <segment>
+        <source>The CSRF token is invalid. Please try to resubmit the form.</source>
+        <target>O token CSRF é inválido. Por favor, tente reenviar o formulário.</target>
+      </segment>
+    </unit>
+    <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_email</source>
+        <target>Já existe um usuário com o e-mail {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_username</source>
+        <target>Já existe um usuário com o nome de usuário {{ value }}.</target>
+      </segment>
+    </unit>
+    <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_password</source>
+        <target>Senha inválida. A senha deve conter pelo menos 6 caracteres.</target>
+      </segment>
+    </unit>
+    <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_email</source>
+        <target>E-mail inválido</target>
+      </segment>
+    </unit>
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
+      <segment>
+        <source>user.username_invalid_characters</source>
+        <target>O nome de usuário deve conter apenas letras latinas minúsculas, números e sublinhados.</target>
+      </segment>
+    </unit>
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_display_name</source>
+        <target>Nome de exibição inválido</target>
+      </segment>
+    </unit>
   </file>
 </xliff>

--- a/translations/validators.ru.xlf
+++ b/translations/validators.ru.xlf
@@ -1,163 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="ru" trgLang="ru">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="ru">
   <file id="validators.ru">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Это значение должно быть ложным.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Это значение должно быть верным.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Это значение должно быть типа {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Это значение должно быть пустым.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Выбранное вами значение не является допустимым.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Вы должны выбрать не менее {{ limit }} вариантов. | Вы должны выбрать не менее {{ limit }} вариантов.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Вы должны выбрать не более {{ limit }} вариантов. | Вы должны выбрать не более {{ limit }} вариантов.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Одно или несколько указанных значений недопустимы.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Это поле не ожидалось.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Это поле отсутствует.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Это значение не является действительной датой.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Это значение не является допустимой датой и временем.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Это значение не является действительным адресом электронной почты.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Файл не найден.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Файл не читается.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Файл слишком большой ({{ size }} {{ suffix }}). Допустимый максимальный размер: {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Недопустимый MIME-тип файла ({{ type }}). Допустимые MIME-типы: {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Это значение должно быть {{ limit }} или меньше.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Это слишком длинное значение. Оно должно содержать не более {{ limit }} символов. | Это значение слишком длинное. Оно должно содержать не более {{ limit }} символов.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Это значение должно быть {{ limit }} или больше.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Это слишком короткое значение. Оно должно содержать символ {{ limit }} или более. | Это значение слишком короткое. Оно должно содержать {{ limit }} символов или более.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Это значение не должно быть пустым.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Это значение не должно быть нулевым.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Это значение должно быть нулевым.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Это недопустимое значение.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Это значение не является допустимым временем.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Это значение не является допустимым URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>Файл слишком большой. Допустимый максимальный размер файла: {{ limit }} {{суффикс}}.</target>
+        <target>Файл слишком большой. Допустимый максимальный размер файла: {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Файл слишком большой.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Не удалось загрузить файл.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Это значение должно быть действительным числом.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Этот файл не является действительным изображением.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Это недействительный IP-адрес.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Это значение не является допустимым языком.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Это значение не является допустимым языковым стандартом.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Это значение не является допустимой страной.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Это значение уже используется.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Не удалось определить размер изображения.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>Ширина изображения слишком велика ({{ width }} пикселей). Допустимая максимальная ширина составляет {{ max_width }} пикселей.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>Ширина изображения слишком мала ({{ width }} пикселей). Минимальная ожидаемая ширина составляет {{ min_width }} пикселей.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>Высота изображения слишком велика ({{ height }} пикселей). Допустимая максимальная высота: {{ max_height }} пикселей.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>Высота изображения слишком мала ({{ height }} пикселей). Минимальная ожидаемая высота составляет {{ min_height }} пикселей.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Это значение должно быть текущим паролем пользователя.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Это значение должно содержать ровно {{ limit }} символов. | Это значение должно содержать ровно {{ limit }} символов.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Файл был загружен только частично.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Файл не загружен.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>В php.ini не была настроена временная папка или настроенная папка не существует.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Невозможно записать временный файл на диск.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Расширение PHP привело к сбою загрузки.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Эта коллекция должна содержать {{ limit }} элементов или больше. | Эта коллекция должна содержать {{ limit }} элементов или больше.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Эта коллекция должна содержать {{ limit }} элементов или меньше. | Эта коллекция должна содержать {{ limit }} элементов или меньше.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Эта коллекция должна содержать ровно {{ limit }} элементов. | Эта коллекция должна содержать ровно {{ limit }} элементов.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Неверный номер карты.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Неподдерживаемый тип карты или неверный номер карты.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Это недействительный международный номер банковского счёта (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Это значение не является действительным ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Это значение не является действительным ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Это значение не является ни действительным ISBN-10, ни действительным ISBN-13.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Это значение не является действительным ISSN.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Это значение не является действующей валютой.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть равно {{ compare_value }}.</target>
+        <target>Это значение должно быть равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
-        <target>Это значение должно быть больше {{ compare_value }}.</target>
+        <target>Это значение должно быть больше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть больше или равно {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Это значение должно быть идентично {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Это значение должно быть больше или равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
-        <target>Это значение должно быть меньше {{ compare_value }}.</target>
+        <target>Это значение должно быть меньше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть меньше или равно {{ compare_value }}.</target>
+        <target>Это значение должно быть меньше или равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
-        <target>Это значение не должно быть равным {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Это значение не должно быть идентичным {{ compare_value_type }} {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Соотношение сторон изображения слишком велико ({{ ratio }}). Допустимое максимальное соотношение: {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Коэффициент изображения слишком мал ({{ ratio }}). Ожидаемое минимальное соотношение: {{ min_ratio }}.</target>
+        <target>Это значение не должно быть равным {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>Изображение квадратное ({{ width }} x {{ height }} пикселей). Квадратные изображения не допускаются.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>Изображение ориентировано в альбомной ориентации ({{ width }} x {{ height }} пикселей). Изображения с альбомной ориентацией не допускаются.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>Изображение ориентировано в портретной ориентации ({{ width }} x {{ height }} пикселей). Портретно-ориентированные изображения не допускаются.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Пустой файл не допускается.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Это значение не соответствует ожидаемой кодировке {{ charset }}.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Это недействительный код бизнес-идентификатора (BIC).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Ошибка</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Это недействительный UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Это значение должно быть кратным {{ compare_value }}.</target>
+        <target>Это значение должно быть кратным {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Этот код бизнес-идентификатора (BIC) не связан с IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Это значение должно быть корректным JSON.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Эта коллекция должна содержать только уникальные элементы.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Это значение должно быть положительным.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Это значение должно быть положительным или нулевым.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Это значение должно быть отрицательным.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Это значение должно быть либо отрицательным, либо нулевым.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Это значение не является допустимым часовым поясом.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Этот пароль скомпрометирован в результате утечки данных, его нельзя использовать. Пожалуйста, используйте другой пароль.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Это значение должно быть между {{ min }} и {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Эта форма не должна содержать лишних полей.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Загруженный файл был слишком большим. Пожалуйста, попробуйте загрузить файл меньшего размера.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Токен CSRF недействителен. Пожалуйста, попробуйте повторно отправить форму.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Дайте краткое содержание вашему посту!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Ваш пост должен содержать контент!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Содержание сообщения слишком короткое (минимум {{ limit }} символов)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Слишком много тегов (добавьте тегов {{ limit }} или меньше)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Пожалуйста, не оставляйте свой комментарий пустым!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Комментарий слишком короткий (минимум {{ limit }} символов)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Комментарий слишком длинный (максимум {{ limit }} символов)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Содержание этого комментария считается спамом.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
         <target>Пользователь с адресом электронной почты {{ value }} уже существует.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
         <target>Пользователь с именем пользователя {{ value }} уже существует.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Неправильный пароль. Пароль должен содержать не менее 6 символов.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Неверный адрес электронной почты</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Имя пользователя должно содержать только латинские символы нижнего регистра, цифры и символы подчеркивания.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Недействительное отображаемое имя</target>

--- a/translations/validators.tr.xlf
+++ b/translations/validators.tr.xlf
@@ -1,163 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
-  <file id="validators.en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="tr">
+  <file id="validators.tr">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Bu değer false olmalıdır.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Bu değer true olmalıdır.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Bu değer {{ type }} türünde olmalıdır.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Bu değer boş olmalıdır.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Seçtiğiniz değer geçerli bir seçim değil.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>En az {{ limit }} seçenek seçebilirsiniz.|En az {{ limit }} seçenek seçebilirsiniz.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>En fazla {{ limit }} seçenek seçebilirsiniz.|En fazla {{ limit }} seçenek seçebilirsiniz..</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Verilen değerlerden biri veya daha fazlası geçersiz.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Bu alan beklenmiyordu.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Bu alan eksik.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Bu değer geçerli bir tarih değil.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Bu değer geçerli bir tarih saat değil.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Bu değer, geçerli bir e-posta adresi değil.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Dosya bulunamadı.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Dosya okunabilir değil.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Dosya boyutu ({{ size }} {{ suffix }}) çok büyük. İzin verilen maksimum dosya boyutu {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>({{ type }}) dosya tipi geçersiz. İzin verilen dosya türleri {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Bu değer {{ limit }} veya daha az olmalıdır.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Bu değer çok uzun. {{ limit }} veya daha az karakter içermelidir.|Bu değer çok uzun. {{ limit }} veya daha az karakter içermelidir.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Bu değer, {{ limit }} veya daha fazla olmalıdır.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Bu değer çok kıza. {{ limit }} veya daha fazla karakter içermelidir.|Bu değer çok kıza. {{ limit }} veya daha fazla karakter içermelidir.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Bu değer boş bırakılmamalıdır.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Bu değer hükümsüz olmamalıdır.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Bu değer hükümsüz olmalıdır.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Bu değer geçerli değil.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Bu değer geçerli bir zaman değil.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Bu değer, geçerli bir URL değil.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>Dosya çok büyük. İzin verilen maksimum boyut {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Dosya çok büyük.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Dosya yüklenemedi.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Bu değer geçerli bir sayı olmalıdır.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Bu dosya geçerli bir resim değil.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Bu geçerli bir IP adresi değil.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Bu değer, geçerli bir dil değil.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Bu değer, geçerli bir yerel ayar değil.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
         <target>Bu değer geçerli bir ülke değil.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Bu değer zaten kullanılıyor.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Görüntünün boyutu tespit edilemedi.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>Görüntü genişliği ({{ width }}px) çok büyük. İzin verilen maksimum genişlik {{ max_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>Görüntü genişliği ({{ width }}px) çok küçük. Beklenen minimum genişlik {{ min_width }}px.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>Görüntü yüksekliği ({{ height }}px) çok büyük. İzin verilen maksimum yükseklik {{ max_height }}px.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>Görüntü yüksekliği ({{ height }}px) çok küçük. Beklenen minimum yükseklik {{ min_height }}px.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Bu değer, kullanıcının mevcut şifresi olmalıdır.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Bu değer tam olarak {{ limit }} karaktere sahip olmalıdır.|Bu değer tam olarak {{ limit }} karaktere sahip olmalıdır.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Dosya yalnızca kısmen yüklendi.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Dosya yüklenmedi.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>php.ini'de hiçbir geçici klasör yapılandırılmamış veya yapılandırılmış klasör mevcut değil.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Geçici dosya diske yazılamıyor.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Bir PHP uzantısı, yüklemenin başarısız olmasına neden oldu.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Bu koleksiyon, {{ limit }} öğesi veya daha fazlasını içermelidir.|Bu koleksiyon, {{ limit }} öğesi veya daha fazlasını içermelidir.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Bu koleksiyon {{ limit }} veya daha az öğe içermelidir.|Bu koleksiyon {{ limit }} veya daha az öğe içermelidir.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Bu koleksiyon tam olarak {{ limit }} öğesini içermelidir.|Bu koleksiyon tam olarak {{ limit }} öğesini içermelidir.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Geçersiz kart numarası.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Desteklenmeyen kart türü veya geçersiz kart numarası.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Bu geçerli bir Uluslararası Banka Hesap Numarası (IBAN) değil.</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Bu değer, geçerli bir ISBN-10 değil.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Bu değer, geçerli bir ISBN-13 değil.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Bu değer ne geçerli bir ISBN-10 ne de geçerli bir ISBN-13'tür.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Bu değer geçerli bir ISSN değil.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Bu değer, geçerli bir para birimi değil.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerine eşit olmalıdır.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerinden büyük olmalıdır.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerine eşit veya daha büyük olmalıdır.</target>
       </segment>
     </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Bu değer {{ compared_value_type }} {{ compared_value }} değeriyle aynı olmalıdır.</target>
-      </segment>
-    </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerinden küçük olmalıdır.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerinden küçük veya eşit olmalıdır.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>Bu değer {{ compared_value }} değerine eşit olmamalıdır.</target>
       </segment>
     </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Bu değer {{ compared_value_type }} {{ compared_value }} değeriyle aynı olmamalıdır.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Görüntü oranı ({{ ratio }}) çok büyük. İzin verilen maksimum oran {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Görüntü oranı ({{ ratio }}) çok küçük. İzin verilen minimum oran {{ max_ratio }}.</target>
-      </segment>
-    </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>Görüntü kare ({{ width }}x{{ height }}px). Kare resimlere izin verilmez.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>Görüntü manzara odaklıdır ({{ width }}x{{ height }}px). Manzara odaklı resimlere izin verilmez.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>Görüntü portre odaklıdır ({{ width }}x{{ height }}px). Portre yönlü resimlere izin verilmez.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Boş bir dosyaya izin verilmez.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Bu değer beklenen {{ charset }} karakter kümesiyle eşleşmiyor.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Bu, geçerli bir İşletme Tanımlama Kodu (BIC) değil.</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Hata</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Bu geçerli bir UUID değil.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>Bu değer, {{ compared_value }} katı olmalıdır.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Bu İşletme Tanımlama Kodu (BIC), IBAN {{ iban }} ile ilişkili değil.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Bu değer geçerli JSON olmalıdır.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Bu koleksiyon yalnızca benzersiz öğeler içermelidir.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Bu değer pozitif olmalıdır.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Bu değer pozitif veya sıfır olmalıdır.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Bu değer negatif olmalıdır.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Bu değer, negatif veya sıfır olmalıdır.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Bu değer, geçerli bir saat dilimi değil.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Bu parola bir veri ihlalinde sızdırılmıştır, kullanılmamalıdır. Lütfen başka bir parola kullanın.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Bu değer, {{ min }} ile {{ max }} arasında olmalıdır.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Bu form fazladan alan içermemelidir.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Yüklenen dosya çok büyüktü. Lütfen daha küçük bir dosya yüklemeyi deneyin.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>CSRF jetonu geçersiz. Lütfen formu yeniden göndermeyi deneyin.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Gönderinize bir özet verin!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Gönderinizin bazı içerikler olmalı!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Gönderi içeriği çok kısa (minimum {{ limit }} karakter)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Çok fazla etiket ({{ limit }} veya daha az etiket ekleyin)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Lütfen yorumunuzu boş bırakmayın!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Yorum çok kısa (minimum {{ limit }} karakter)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Yorum çok uzun (maksimum {{ limit }} karakter)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Bu yorumun içeriği spam olarak kabul edilir.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
         <target>{{ value }} e-postasına sahip bir kullanıcı zaten var.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
         <target>{{ value }} kullanıcı adına sahip bir kullanıcı zaten var.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Geçersiz parola. Parola en az 6 karakter içermelidir.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Geçersiz e-posta</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Kullanıcı adı yalnızca küçük latin karakterler, sayılar ve alt çizgiler içermelidir.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Geçersiz ekran ad</target>

--- a/translations/validators.uk.xlf
+++ b/translations/validators.uk.xlf
@@ -1,163 +1,195 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="uk" trgLang="uk">
-  <file id="validators.en">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="uk">
+  <file id="validators.uk">
     <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
       <segment>
         <source>This value should be false.</source>
         <target>Це значення повинно бути хибним.</target>
       </segment>
     </unit>
     <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
       <segment>
         <source>This value should be true.</source>
         <target>Це значення повинно бути істинним.</target>
       </segment>
     </unit>
     <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
       <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>Це значення повинно бути типу {{ type }}.</target>
       </segment>
     </unit>
     <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
       <segment>
         <source>This value should be blank.</source>
         <target>Це значення повинно бути порожнім.</target>
       </segment>
     </unit>
     <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
       <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>Вибране вами значення не є допустимим.</target>
       </segment>
     </unit>
-    <unit id="7smtimf" name="0d999f2">
-      <segment>
-        <source>0d999f2</source>
-        <target>Ви повинні вибрати не менш, ніж {{ limit }} варіантів. | Ви повинні вибрати не менш, ніж {{ limit }} варіантів.</target>
-      </segment>
-    </unit>
-    <unit id="JRlXq2Z" name="0824486">
-      <segment>
-        <source>0824486</source>
-        <target>Ви повинні вибрати не більш, ніж {{ limit }} варіантів. | Ви повинні вибрати не більш, ніж {{ limit }} варіантів.</target>
-      </segment>
-    </unit>
     <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
       <segment>
         <source>One or more of the given values is invalid.</source>
         <target>Одне або декілька зазначених значень неприпустимі.</target>
       </segment>
     </unit>
     <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
       <segment>
         <source>This field was not expected.</source>
         <target>Це поле не очікувалося.</target>
       </segment>
     </unit>
     <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
       <segment>
         <source>This field is missing.</source>
         <target>Це поле відсутнє.</target>
       </segment>
     </unit>
     <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid date.</source>
         <target>Це значення не є дійсною датою.</target>
       </segment>
     </unit>
     <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid datetime.</source>
         <target>Це значення не є допустимою датою и часом.</target>
       </segment>
     </unit>
     <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
       <segment>
         <source>This value is not a valid email address.</source>
         <target>Це значення не є дійсною адресою електронної пошти.</target>
       </segment>
     </unit>
     <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
       <segment>
         <source>The file could not be found.</source>
         <target>Файл не знайдено.</target>
       </segment>
     </unit>
     <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
       <segment>
         <source>The file is not readable.</source>
         <target>Файл не може бути прочитаним.</target>
       </segment>
     </unit>
-    <unit id="2O3FbJ6" name="1ad411a">
-      <segment>
-        <source>1ad411a</source>
-        <target>Файл занадто великий ({{ size }} {{ suffix }}). Допустимий максимальний розмір: {{ limit }} {{ suffix }}.</target>
-      </segment>
-    </unit>
-    <unit id="p4L.BFV" name="30a318d">
-      <segment>
-        <source>30a318d</source>
-        <target>Неприпустимий MIME-тип файлу ({{ type }}). Допустимі MIME-типи: {{ types }}.</target>
-      </segment>
-    </unit>
     <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>Це значення повинно бути {{ limit }} або менше.</target>
       </segment>
     </unit>
-    <unit id="SjJg9Hy" name="0e0c1e1">
-      <segment>
-        <source>0e0c1e1</source>
-        <target>Це занадто довге значення. Воно повинно містити не більш, ніж {{ limit }} символів. | Це значення занадто довге. Воно повинно містити не більш, ніж {{ limit }} символів.</target>
-      </segment>
-    </unit>
     <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
       <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>Це значення повинно бути {{ limit }} або більше.</target>
       </segment>
     </unit>
-    <unit id="JJVWzKj" name="5188ff9">
-      <segment>
-        <source>5188ff9</source>
-        <target>Це занадто коротке значення. Воно повинно містити символ {{ limit }} або більше. | Це значення занадто коротке. Воно повинно містити {{ limit }} символів або більше.</target>
-      </segment>
-    </unit>
     <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
       <segment>
         <source>This value should not be blank.</source>
         <target>Це значення не повинно бути порожнім.</target>
       </segment>
     </unit>
     <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should not be null.</source>
         <target>Це значення не повинно бути нульовим.</target>
       </segment>
     </unit>
     <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
       <segment>
         <source>This value should be null.</source>
         <target>Це значення повинно бути нульовим.</target>
       </segment>
     </unit>
     <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
       <segment>
         <source>This value is not valid.</source>
         <target>Це неприпустиме значення.</target>
       </segment>
     </unit>
     <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid time.</source>
         <target>Це значення не є допустимим часом.</target>
       </segment>
     </unit>
     <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
       <segment>
         <source>This value is not a valid URL.</source>
         <target>Це значення не є допустимим URL.</target>
@@ -170,282 +202,300 @@
       </segment>
     </unit>
     <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
       <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>Файл занадто великий. Допустимий максимальний розмір: {{ limit }} {{суффикс}}.</target>
+        <target>Файл занадто великий. Допустимий максимальний розмір: {{ limit }} {{ suffix }}.</target>
       </segment>
     </unit>
     <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
       <segment>
         <source>The file is too large.</source>
         <target>Файл занадто великий.</target>
       </segment>
     </unit>
     <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
       <segment>
         <source>The file could not be uploaded.</source>
         <target>Не вдалося завантажити файл.</target>
       </segment>
     </unit>
     <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
       <segment>
         <source>This value should be a valid number.</source>
         <target>Це значення повинно бути дійсним числом.</target>
       </segment>
     </unit>
     <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
       <segment>
         <source>This file is not a valid image.</source>
         <target>Цей файл не є дійсним зображенням.</target>
       </segment>
     </unit>
     <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
       <segment>
         <source>This is not a valid IP address.</source>
         <target>Це недійсна IP-адреса.</target>
       </segment>
     </unit>
     <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid language.</source>
         <target>Це значення не є допустимою мовою.</target>
       </segment>
     </unit>
     <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid locale.</source>
         <target>Це значення не є допустимим мовним стандартом.</target>
       </segment>
     </unit>
     <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
       <segment>
         <source>This value is not a valid country.</source>
-            <target>Це значення не є допустимою країною.</target>
+        <target>Це значення не є допустимою країною.</target>
       </segment>
     </unit>
     <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
       <segment>
         <source>This value is already used.</source>
         <target>Це значення вже використовується.</target>
       </segment>
     </unit>
     <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
       <segment>
         <source>The size of the image could not be detected.</source>
         <target>Не вдалося визначити розмір зображення.</target>
       </segment>
     </unit>
-    <unit id="g9NoIBz" name="266051e">
-      <segment>
-        <source>266051e</source>
-        <target>Ширина зображення занадто велика ({{ width }} пікселів). Допустима максимальна ширина складає {{ max_width }} пікселів.</target>
-      </segment>
-    </unit>
-    <unit id="HTsQNva" name="c1c23f9">
-      <segment>
-        <source>c1c23f9</source>
-        <target>Ширина зображення занадто мала ({{ width }} пікселів). Мінімальна очікувана ширина складає {{ min_width }} пікселів.</target>
-      </segment>
-    </unit>
-    <unit id="h3PRqha" name="9a128f7">
-      <segment>
-        <source>9a128f7</source>
-        <target>Висота зображення занадто велика ({{ height }} пікселів). Допустима максимальна высота: {{ max_height }} пікселів.</target>
-      </segment>
-    </unit>
-    <unit id="IVraZ3b" name="8a4cd70">
-      <segment>
-        <source>8a4cd70</source>
-        <target>Висота зображення занадто мала ({{ height }} пікселів). Мінімальна очікувана высота складає {{ min_height }} пікселів.</target>
-      </segment>
-    </unit>
     <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
       <segment>
         <source>This value should be the user's current password.</source>
         <target>Це значення повинно бути поточним паролем користувача.</target>
       </segment>
     </unit>
-    <unit id="Anek_FY" name="fd389d6">
-      <segment>
-        <source>fd389d6</source>
-        <target>Це значення повинно містити рівно {{ limit }} символів. | Це значення повинно містити рівно {{ limit }} символів.</target>
-      </segment>
-    </unit>
     <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
       <segment>
         <source>The file was only partially uploaded.</source>
         <target>Файл завантажено тільки частково.</target>
       </segment>
     </unit>
     <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
       <segment>
         <source>No file was uploaded.</source>
         <target>Файл не завантажено.</target>
       </segment>
     </unit>
     <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
       <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>В php.ini не була налаштована тимчасова тека або налаштована тека не існує.</target>
       </segment>
     </unit>
     <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
       <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>Неможливо записати тимчасовий файл на диск.</target>
       </segment>
     </unit>
     <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
       <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>Розширення PHP привело до збою завантаження.</target>
       </segment>
     </unit>
-    <unit id="YuLxmhd" name="b54c218">
-      <segment>
-        <source>b54c218</source>
-        <target>Ця колекція повинна містити {{ limit }} елементів або більше. | Ця колекція повинна містити {{ limit }} елементів або більше.</target>
-      </segment>
-    </unit>
-    <unit id="qXV2OMI" name="949632c">
-      <segment>
-        <source>949632c</source>
-        <target>Ця колекція повинна містити {{ limit }} елементів або менше. | Ця колекція повинна містити {{ limit }} елементів або менше.</target>
-      </segment>
-    </unit>
-    <unit id="BnjGMFh" name="e0582dc">
-      <segment>
-        <source>e0582dc</source>
-        <target>Ця колекція повинна містити рівно {{ limit }} елементів. | Ця колекція повинна містити рівно {{ limit }} елементів.</target>
-      </segment>
-    </unit>
     <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
       <segment>
         <source>Invalid card number.</source>
         <target>Невірний номер карти.</target>
       </segment>
     </unit>
     <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
       <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>Тип карти не підтримується або невірний номер карти.</target>
       </segment>
     </unit>
     <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
       <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>Це недійсний міжнародний номер банківського рахунку (IBAN).</target>
       </segment>
     </unit>
     <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>Це значення не є дійсним ISBN-10.</target>
       </segment>
     </unit>
     <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>Це значення не є дійсним ISBN-13.</target>
       </segment>
     </unit>
     <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
       <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>Це значення не є ни дійсним ISBN-10, ні дійсним ISBN-13.</target>
       </segment>
     </unit>
     <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
       <segment>
         <source>This value is not a valid ISSN.</source>
         <target>Це значення не є дійсним ISSN.</target>
       </segment>
     </unit>
     <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
       <segment>
         <source>This value is not a valid currency.</source>
         <target>Це значення не є чинною валютою.</target>
       </segment>
     </unit>
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
-        <target>Це значення повинно дорівнювати {{ compare_value }}.</target>
+        <target>Це значення повинно дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
-        <target>Це значення повинно бути більше {{ compare_value }}.</target>
+        <target>Це значення повинно бути більше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
-        <target>Це значення повинно бути більше або дорівнювати {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="SreIWoo" name="9670078">
-      <segment>
-        <source>9670078</source>
-        <target>Це значення повинно бути ідентичним до {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Це значення повинно бути більше або дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
-        <target>Це значення повинно бути менше {{ compare_value }}.</target>
+        <target>Це значення повинно бути менше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
-        <target>Це значення повинно бути менше або дорівнювати {{ compare_value }}.</target>
+        <target>Це значення повинно бути менше або дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
-        <target>Це значення не повинно дорівнювати {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="JIjdvtb" name="0eedf91">
-      <segment>
-        <source>0eedf91</source>
-        <target>Це значення не повинно бути ідентичним {{ compare_value_type }} {{ compare_value }}.</target>
-      </segment>
-    </unit>
-    <unit id="vzvxzpR" name="9c3ad0f">
-      <segment>
-        <source>9c3ad0f</source>
-        <target>Співвідношення сторін зображення занадто велике ({{ ratio }}). Допустиме максимальне співвідношення: {{ max_ratio }}.</target>
-      </segment>
-    </unit>
-    <unit id="LiDaIWN" name="4376d45">
-      <segment>
-        <source>4376d45</source>
-        <target>Коэффициент зображення занадто мал ({{ ratio }}). Ожидаемое минимальное співвідношення: {{ min_ratio }}.</target>
+        <target>Це значення не повинно дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
       <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>Зображення квадратне ({{ width }} x {{ height }} пікселів). Квадратні зображення не допускаються.</target>
       </segment>
     </unit>
-    <unit id="501jWTO" name="1dc128a">
-      <segment>
-        <source>1dc128a</source>
-        <target>Зображення в альбомній орієнтації ({{ширина}} x {{высота}} пікселів). Зображення з альбомною орієнтацією не допускаються.</target>
-      </segment>
-    </unit>
-    <unit id="J4L.QnM" name="9e27714">
-      <segment>
-        <source>9e27714</source>
-        <target>Зображення в портретній орієнтації ({{ширина}} x {{высота}} пікселів). Портретно-орієнтовані зображення не допускаються.</target>
-      </segment>
-    </unit>
     <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
       <segment>
         <source>An empty file is not allowed.</source>
         <target>Порожній файл не допускается.</target>
@@ -458,216 +508,208 @@
       </segment>
     </unit>
     <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
       <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>Це значення не відповідає очікуваному кодуванню {{ charset }}.</target>
       </segment>
     </unit>
     <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
       <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>Це недійсний код бізнес-ідентифікатора (BIC).</target>
       </segment>
     </unit>
     <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
       <segment>
         <source>Error</source>
         <target>Помилка</target>
       </segment>
     </unit>
     <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
       <segment>
         <source>This is not a valid UUID.</source>
         <target>Це недійсний UUID.</target>
       </segment>
     </unit>
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Це значення повинно бути кратним {{ compare_value }}.</target>
+        <target>Це значення повинно бути кратним {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
       <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>Цей код бізнес-ідентифікатора (BIC) не пов'язаний з IBAN {{ iban }}.</target>
       </segment>
     </unit>
     <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
       <segment>
         <source>This value should be valid JSON.</source>
         <target>Це значення повинно бути коректним JSON.</target>
       </segment>
     </unit>
     <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
       <segment>
         <source>This collection should contain only unique elements.</source>
         <target>Ця колекція повинна містити тільки унікальні елементи.</target>
       </segment>
     </unit>
     <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
       <segment>
         <source>This value should be positive.</source>
         <target>Це значення повинно бути позитивним.</target>
       </segment>
     </unit>
     <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either positive or zero.</source>
         <target>Це значення повинно бути позитивним або нульовим.</target>
       </segment>
     </unit>
     <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
       <segment>
         <source>This value should be negative.</source>
         <target>Це значення повинно бути негативним.</target>
       </segment>
     </unit>
     <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
       <segment>
         <source>This value should be either negative or zero.</source>
         <target>Це значення повинно бути либо негативним, либо нульовим.</target>
       </segment>
     </unit>
     <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
       <segment>
         <source>This value is not a valid timezone.</source>
         <target>Це значення не є допустимим часовым поясом.</target>
       </segment>
     </unit>
-    <unit id="A3Gr4fn" name="7e27e92">
-      <segment>
-        <source>7e27e92</source>
-        <target>Цей пароль просочився у результаті витоку даних, його не можна використовувати. Будь ласка, скористайтеся іншим паролем.</target>
-      </segment>
-    </unit>
     <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
       <segment>
         <source>This value should be between {{ min }} and {{ max }}.</source>
         <target>Це значення повинно бути між {{ min }} і {{ max }}.</target>
       </segment>
     </unit>
     <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
       <segment>
         <source>This form should not contain extra fields.</source>
         <target>Ця форма не повинна містити зайвих полів.</target>
       </segment>
     </unit>
     <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
       <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>Загруженный файл занадто великий. Будь ласка, спробуйте завантажити файл меншого розміру.</target>
       </segment>
     </unit>
     <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
       <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>Токен CSRF недійсний. Будь ласка, спробуйте повторно надіслати форму.</target>
       </segment>
     </unit>
-    <unit id="TG1D5NO" name="post.blank_summary">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_summary</source>
-        <target>Дайте вашому посту резюме!</target>
-      </segment>
-    </unit>
-    <unit id="BZOzjk." name="post.blank_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.blank_content</source>
-        <target>Ваш пост повинен містити контент!</target>
-      </segment>
-    </unit>
-    <unit id="S6M.YWY" name="post.too_short_content">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_short_content</source>
-        <target>Зміст повідомлення занадто короткий (мінімум {{ limit }} символів)</target>
-      </segment>
-    </unit>
-    <unit id="niM7JYj" name="post.too_many_tags">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>post.too_many_tags</source>
-        <target>Занадто багато тегів (додайте тегів {{ limit }} або менше)</target>
-      </segment>
-    </unit>
-    <unit id="ARUoKOV" name="comment.blank">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.blank</source>
-        <target>Будь ласка, не залишайте свій коментар порожнім!</target>
-      </segment>
-    </unit>
-    <unit id="J.L_ppQ" name="comment.too_short">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_short</source>
-        <target>Коментар занадто короткий (мінімум {{ limit }} символів)</target>
-      </segment>
-    </unit>
-    <unit id=".bkQKXb" name="comment.too_long">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.too_long</source>
-        <target>Коментар занадто довгий (максимум {{ limit }} символів)</target>
-      </segment>
-    </unit>
-    <unit id="cTT8h4_" name="comment.is_spam">
-      <notes>
-        <note priority="1">obsolete</note>
-      </notes>
-      <segment>
-        <source>comment.is_spam</source>
-        <target>Зміст цього коментаря вважається спамом.</target>
-      </segment>
-    </unit>
     <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
       <segment>
         <source>user.duplicate_email</source>
         <target>Користувач з адресою електронної пошти {{ value }} вже існує.</target>
       </segment>
     </unit>
     <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
       <segment>
         <source>user.duplicate_username</source>
         <target>Користувач з ім'ям користувача {{ value }} вже існує.</target>
       </segment>
     </unit>
     <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
       <segment>
         <source>user.not_valid_password</source>
         <target>Неправильный пароль. Пароль повинен містити не менш ніж 6 символів.</target>
       </segment>
     </unit>
     <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
       <segment>
         <source>user.not_valid_email</source>
         <target>Невірна адреса електронної пошти</target>
       </segment>
     </unit>
     <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
       <segment>
         <source>user.username_invalid_characters</source>
         <target>Ім'я користувача повинно містити тільки латинські символи нижнього регістра, цифри і символи підкреслення.</target>
       </segment>
     </unit>
     <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
       <segment>
         <source>user.not_valid_display_name</source>
         <target>Недійсне відображене імʼя</target>

--- a/translations/validators.zh_CN.xlf
+++ b/translations/validators.zh_CN.xlf
@@ -1,354 +1,719 @@
 <?xml version="1.0" encoding="utf-8"?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="zh-CN" target-language="zh-CN" datatype="plaintext" original="file.ext">
-    <header>
-      <tool tool-id="symfony" tool-name="Symfony"/>
-    </header>
-    <body>
-      <trans-unit id="zh5oKD9" resname="This value should be false.">
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="zh-CN">
+  <file id="validators.zh_CN">
+    <unit id="zh5oKD9" name="This value should be false.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsFalse.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be false.</source>
         <target>该变量的值应为 false 。</target>
-      </trans-unit>
-      <trans-unit id="NN2_iru" resname="This value should be true.">
+      </segment>
+    </unit>
+    <unit id="NN2_iru" name="This value should be true.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsTrue.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be true.</source>
         <target>该变量的值应为 true 。</target>
-      </trans-unit>
-      <trans-unit id="OjM_kpf" resname="This value should be of type {{ type }}.">
+      </segment>
+    </unit>
+    <unit id="OjM_kpf" name="This value should be of type {{ type }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Type.php:36</note>
+        <note>vendor/symfony/validator/Validator/RecursiveContextualValidator.php:767</note>
+      </notes>
+      <segment>
         <source>This value should be of type {{ type }}.</source>
         <target>该变量的类型应为 {{ type }} 。</target>
-      </trans-unit>
-      <trans-unit id="f0P5pBD" resname="This value should be blank.">
+      </segment>
+    </unit>
+    <unit id="f0P5pBD" name="This value should be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Blank.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be blank.</source>
         <target>该变量值应为空。</target>
-      </trans-unit>
-      <trans-unit id="ih.4TRN" resname="The value you selected is not a valid choice.">
+      </segment>
+    </unit>
+    <unit id="ih.4TRN" name="The value you selected is not a valid choice.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:47</note>
+      </notes>
+      <segment>
         <source>The value you selected is not a valid choice.</source>
         <target>选定变量的值不是有效的选项。</target>
-      </trans-unit>
-      <trans-unit id="u81CkP8" resname="You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.">
-        <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-        <target>您至少要选择 {{ limit }} 个选项。</target>
-      </trans-unit>
-      <trans-unit id="nIvOQ_o" resname="You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.">
-        <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-        <target>您最多能选择 {{ limit }} 个选项。</target>
-      </trans-unit>
-      <trans-unit id="87zjiHi" resname="One or more of the given values is invalid.">
+      </segment>
+    </unit>
+    <unit id="87zjiHi" name="One or more of the given values is invalid.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Choice.php:48</note>
+      </notes>
+      <segment>
         <source>One or more of the given values is invalid.</source>
         <target>一个或者多个给定的值无效。</target>
-      </trans-unit>
-      <trans-unit id="3NeQftv" resname="This field was not expected.">
+      </segment>
+    </unit>
+    <unit id="3NeQftv" name="This field was not expected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:42</note>
+      </notes>
+      <segment>
         <source>This field was not expected.</source>
         <target>此字段是多余的。</target>
-      </trans-unit>
-      <trans-unit id="SwMV4zp" resname="This field is missing.">
+      </segment>
+    </unit>
+    <unit id="SwMV4zp" name="This field is missing.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Collection.php:43</note>
+      </notes>
+      <segment>
         <source>This field is missing.</source>
         <target>此字段缺失。</target>
-      </trans-unit>
-      <trans-unit id="LO2vFKN" resname="This value is not a valid date.">
+      </segment>
+    </unit>
+    <unit id="LO2vFKN" name="This value is not a valid date.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Date.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid date.</source>
         <target>该值不是一个有效的日期（date）。</target>
-      </trans-unit>
-      <trans-unit id="86dU_nv" resname="This value is not a valid datetime.">
+      </segment>
+    </unit>
+    <unit id="86dU_nv" name="This value is not a valid datetime.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DateTime.php:41</note>
+        <note>vendor/symfony/validator/Constraints/Range.php:50</note>
+      </notes>
+      <segment>
         <source>This value is not a valid datetime.</source>
         <target>该值不是一个有效的日期时间（datetime）。</target>
-      </trans-unit>
-      <trans-unit id="PSvNXdi" resname="This value is not a valid email address.">
+      </segment>
+    </unit>
+    <unit id="PSvNXdi" name="This value is not a valid email address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Email.php:54</note>
+      </notes>
+      <segment>
         <source>This value is not a valid email address.</source>
         <target>该值不是一个有效的邮件地址。</target>
-      </trans-unit>
-      <trans-unit id="3KeHbZy" resname="The file could not be found.">
+      </segment>
+    </unit>
+    <unit id="3KeHbZy" name="The file could not be found.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:57</note>
+      </notes>
+      <segment>
         <source>The file could not be found.</source>
         <target>文件未找到。</target>
-      </trans-unit>
-      <trans-unit id="KtJhQZo" resname="The file is not readable.">
+      </segment>
+    </unit>
+    <unit id="KtJhQZo" name="The file is not readable.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:58</note>
+      </notes>
+      <segment>
         <source>The file is not readable.</source>
         <target>文件不可读。</target>
-      </trans-unit>
-      <trans-unit id="JocOVM2" resname="The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.">
-        <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-        <target>文件太大 ({{ size }} {{ suffix }})。文件大小不可以超过 {{ limit }} {{ suffix }} 。</target>
-      </trans-unit>
-      <trans-unit id="YW21SPH" resname="The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.">
-        <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
-        <target>无效的文件类型 ({{ type }}) 。允许的文件类型有 {{ types }} 。</target>
-      </trans-unit>
-      <trans-unit id="NubOmrs" resname="This value should be {{ limit }} or less.">
+      </segment>
+    </unit>
+    <unit id="NubOmrs" name="This value should be {{ limit }} or less.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:48</note>
+      </notes>
+      <segment>
         <source>This value should be {{ limit }} or less.</source>
         <target>这个变量的值应该小于或等于 {{ limit }}。</target>
-      </trans-unit>
-      <trans-unit id="HX7TOFm" resname="This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.">
-        <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-        <target>字符串太长，长度不可超过 {{ limit }} 个字符。</target>
-      </trans-unit>
-      <trans-unit id="qgR8M_U" resname="This value should be {{ limit }} or more.">
+      </segment>
+    </unit>
+    <unit id="qgR8M_U" name="This value should be {{ limit }} or more.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:47</note>
+      </notes>
+      <segment>
         <source>This value should be {{ limit }} or more.</source>
         <target>该变量的值应该大于或等于 {{ limit }}。</target>
-      </trans-unit>
-      <trans-unit id="ekfrU.c" resname="This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.">
-        <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-        <target>字符串太短，长度不可少于 {{ limit }} 个字符。</target>
-      </trans-unit>
-      <trans-unit id="1KV4L.t" resname="This value should not be blank.">
+      </segment>
+    </unit>
+    <unit id="1KV4L.t" name="This value should not be blank.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotBlank.php:38</note>
+      </notes>
+      <segment>
         <source>This value should not be blank.</source>
         <target>该变量不应为空。</target>
-      </trans-unit>
-      <trans-unit id="2G4Vepm" resname="This value should not be null.">
+      </segment>
+    </unit>
+    <unit id="2G4Vepm" name="This value should not be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotNull.php:36</note>
+      </notes>
+      <segment>
         <source>This value should not be null.</source>
         <target>该变量不应为 null 。</target>
-      </trans-unit>
-      <trans-unit id="yDc3m6E" resname="This value should be null.">
+      </segment>
+    </unit>
+    <unit id="yDc3m6E" name="This value should be null.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/IsNull.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be null.</source>
         <target>该变量应为空 null 。</target>
-      </trans-unit>
-      <trans-unit id="zKzWejA" resname="This value is not valid.">
+      </segment>
+    </unit>
+    <unit id="zKzWejA" name="This value is not valid.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:188</note>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:61</note>
+        <note>vendor/symfony/validator/Constraints/Expression.php:40</note>
+        <note>vendor/symfony/validator/Constraints/Regex.php:37</note>
+      </notes>
+      <segment>
         <source>This value is not valid.</source>
         <target>该变量值无效 。</target>
-      </trans-unit>
-      <trans-unit id="HSuBZpQ" resname="This value is not a valid time.">
+      </segment>
+    </unit>
+    <unit id="HSuBZpQ" name="This value is not a valid time.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Time.php:39</note>
+      </notes>
+      <segment>
         <source>This value is not a valid time.</source>
         <target>该值不是一个有效的时间。</target>
-      </trans-unit>
-      <trans-unit id="snWc_QT" resname="This value is not a valid URL.">
+      </segment>
+    </unit>
+    <unit id="snWc_QT" name="This value is not a valid URL.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Url.php:37</note>
+      </notes>
+      <segment>
         <source>This value is not a valid URL.</source>
         <target>该值不是一个有效的 URL 。</target>
-      </trans-unit>
-      <trans-unit id="jpaLsb2" resname="The two values should be equal.">
+      </segment>
+    </unit>
+    <unit id="jpaLsb2" name="The two values should be equal.">
+      <segment>
         <source>The two values should be equal.</source>
         <target>这两个变量的值应该相等。</target>
-      </trans-unit>
-      <trans-unit id="fIlB1B_" resname="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      </segment>
+    </unit>
+    <unit id="fIlB1B_" name="The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:147</note>
+        <note>vendor/symfony/validator/Constraints/File.php:65</note>
+      </notes>
+      <segment>
         <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
         <target>文件太大，文件大小不可以超过 {{ limit }} {{ suffix }}。 </target>
-      </trans-unit>
-      <trans-unit id="tW7o0t9" resname="The file is too large.">
+      </segment>
+    </unit>
+    <unit id="tW7o0t9" name="The file is too large.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:153</note>
+        <note>vendor/symfony/validator/Constraints/File.php:66</note>
+      </notes>
+      <segment>
         <source>The file is too large.</source>
         <target>文件太大。</target>
-      </trans-unit>
-      <trans-unit id=".exF5Ww" resname="The file could not be uploaded.">
+      </segment>
+    </unit>
+    <unit id=".exF5Ww" name="The file could not be uploaded.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FileType.php:155</note>
+        <note>vendor/symfony/validator/Constraints/File.php:72</note>
+      </notes>
+      <segment>
         <source>The file could not be uploaded.</source>
         <target>无法上传此文件。</target>
-      </trans-unit>
-      <trans-unit id="d7sS5yw" resname="This value should be a valid number.">
+      </segment>
+    </unit>
+    <unit id="d7sS5yw" name="This value should be a valid number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:49</note>
+      </notes>
+      <segment>
         <source>This value should be a valid number.</source>
         <target>该值应该为有效的数字。</target>
-      </trans-unit>
-      <trans-unit id="1YC0pOd" resname="This value is not a valid country.">
-        <source>This value is not a valid country.</source>
-        <target>该值不是有效的国家名。</target>
-      </trans-unit>
-      <trans-unit id="BS2Ez6i" resname="This file is not a valid image.">
+      </segment>
+    </unit>
+    <unit id="BS2Ez6i" name="This file is not a valid image.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:82</note>
+      </notes>
+      <segment>
         <source>This file is not a valid image.</source>
         <target>该文件不是有效的图片。</target>
-      </trans-unit>
-      <trans-unit id="ydcT9kU" resname="This is not a valid IP address.">
+      </segment>
+    </unit>
+    <unit id="ydcT9kU" name="This is not a valid IP address.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Ip.php:85</note>
+      </notes>
+      <segment>
         <source>This is not a valid IP address.</source>
         <target>该值不是有效的IP地址。</target>
-      </trans-unit>
-      <trans-unit id="lDOGNFX" resname="This value is not a valid language.">
+      </segment>
+    </unit>
+    <unit id="lDOGNFX" name="This value is not a valid language.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Language.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid language.</source>
         <target>该值不是有效的语言名。</target>
-      </trans-unit>
-      <trans-unit id="y9IdYkA" resname="This value is not a valid locale.">
+      </segment>
+    </unit>
+    <unit id="y9IdYkA" name="This value is not a valid locale.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Locale.php:38</note>
+      </notes>
+      <segment>
         <source>This value is not a valid locale.</source>
         <target>该值不是有效的区域值（locale）。</target>
-      </trans-unit>
-      <trans-unit id="B5ebaMp" resname="This value is already used.">
+      </segment>
+    </unit>
+    <unit id="1YC0pOd" name="This value is not a valid country.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Country.php:38</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid country.</source>
+        <target>该值不是有效的国家名。</target>
+      </segment>
+    </unit>
+    <unit id="B5ebaMp" name="This value is already used.">
+      <notes>
+        <note>vendor/symfony/doctrine-bridge/Validator/Constraints/UniqueEntity.php:33</note>
+      </notes>
+      <segment>
         <source>This value is already used.</source>
         <target>该值已经被使用。</target>
-      </trans-unit>
-      <trans-unit id="L6097a6" resname="The size of the image could not be detected.">
+      </segment>
+    </unit>
+    <unit id="L6097a6" name="The size of the image could not be detected.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:83</note>
+      </notes>
+      <segment>
         <source>The size of the image could not be detected.</source>
         <target>不能解析图片大小。</target>
-      </trans-unit>
-      <trans-unit id="zVtJJEa" resname="The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.">
-        <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-        <target>图片太宽 ({{ width }}px)，最大宽度为 {{ max_width }}px 。</target>
-      </trans-unit>
-      <trans-unit id="s8LFQGC" resname="The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.">
-        <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-        <target>图片宽度不够 ({{ width }}px)，最小宽度为 {{ min_width }}px 。</target>
-      </trans-unit>
-      <trans-unit id="Z.NgqFj" resname="The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.">
-        <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-        <target>图片太高 ({{ height }}px)，最大高度为 {{ max_height }}px 。</target>
-      </trans-unit>
-      <trans-unit id="AW1lWVM" resname="The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.">
-        <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-        <target>图片高度不够 ({{ height }}px)，最小高度为 {{ min_height }}px 。</target>
-      </trans-unit>
-      <trans-unit id="PSdMNab" resname="This value should be the user's current password.">
+      </segment>
+    </unit>
+    <unit id="PSdMNab" name="This value should be the user's current password.">
+      <notes>
+        <note>vendor/symfony/security-core/Validator/Constraints/UserPassword.php:29</note>
+      </notes>
+      <segment>
         <source>This value should be the user's current password.</source>
         <target>该变量的值应为用户当前的密码。</target>
-      </trans-unit>
-      <trans-unit id="gYImVyV" resname="This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.">
-        <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>
-        <target>该变量应为 {{ limit }} 个字符。</target>
-      </trans-unit>
-      <trans-unit id="xJ2Bcr_" resname="The file was only partially uploaded.">
+      </segment>
+    </unit>
+    <unit id="xJ2Bcr_" name="The file was only partially uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:67</note>
+      </notes>
+      <segment>
         <source>The file was only partially uploaded.</source>
         <target>该文件的上传不完整。</target>
-      </trans-unit>
-      <trans-unit id="HzkJDtF" resname="No file was uploaded.">
+      </segment>
+    </unit>
+    <unit id="HzkJDtF" name="No file was uploaded.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:68</note>
+      </notes>
+      <segment>
         <source>No file was uploaded.</source>
         <target>没有上传任何文件。</target>
-      </trans-unit>
-      <trans-unit id="mHfEaB3" resname="No temporary folder was configured in php.ini.">
+      </segment>
+    </unit>
+    <unit id="mHfEaB3" name="No temporary folder was configured in php.ini.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:69</note>
+      </notes>
+      <segment>
         <source>No temporary folder was configured in php.ini.</source>
         <target>php.ini 里没有配置临时文件目录。</target>
-      </trans-unit>
-      <trans-unit id="y9K3BGb" resname="Cannot write temporary file to disk.">
+      </segment>
+    </unit>
+    <unit id="y9K3BGb" name="Cannot write temporary file to disk.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:70</note>
+      </notes>
+      <segment>
         <source>Cannot write temporary file to disk.</source>
         <target>临时文件写入磁盘失败。</target>
-      </trans-unit>
-      <trans-unit id="kx3yHIM" resname="A PHP extension caused the upload to fail.">
+      </segment>
+    </unit>
+    <unit id="kx3yHIM" name="A PHP extension caused the upload to fail.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:71</note>
+      </notes>
+      <segment>
         <source>A PHP extension caused the upload to fail.</source>
         <target>某个 PHP 扩展造成上传失败。</target>
-      </trans-unit>
-      <trans-unit id="gTJYRl6" resname="This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.">
-        <source>This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.</source>
-        <target>该集合最少应包含 {{ limit }} 个元素。</target>
-      </trans-unit>
-      <trans-unit id="FFn3lVn" resname="This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.">
-        <source>This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.</source>
-        <target>该集合最多包含 {{ limit }} 个元素。</target>
-      </trans-unit>
-      <trans-unit id="bSdilZv" resname="This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.">
-        <source>This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.</source>
-        <target>该集合应包含 {{ limit }} 个元素 element 。</target>
-      </trans-unit>
-      <trans-unit id="MAzmID7" resname="Invalid card number.">
+      </segment>
+    </unit>
+    <unit id="MAzmID7" name="Invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Luhn.php:42</note>
+      </notes>
+      <segment>
         <source>Invalid card number.</source>
         <target>无效的信用卡号。</target>
-      </trans-unit>
-      <trans-unit id="c3REGK3" resname="Unsupported card type or invalid card number.">
+      </segment>
+    </unit>
+    <unit id="c3REGK3" name="Unsupported card type or invalid card number.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/CardScheme.php:54</note>
+      </notes>
+      <segment>
         <source>Unsupported card type or invalid card number.</source>
         <target>不支持的信用卡类型或无效的信用卡号。</target>
-      </trans-unit>
-      <trans-unit id="XSVzcbV" resname="This is not a valid International Bank Account Number (IBAN).">
+      </segment>
+    </unit>
+    <unit id="XSVzcbV" name="This is not a valid International Bank Account Number (IBAN).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Iban.php:46</note>
+      </notes>
+      <segment>
         <source>This is not a valid International Bank Account Number (IBAN).</source>
         <target>该值不是有效的国际银行帐号（IBAN）。</target>
-      </trans-unit>
-      <trans-unit id="yHirwNr" resname="This value is not a valid ISBN-10.">
+      </segment>
+    </unit>
+    <unit id="yHirwNr" name="This value is not a valid ISBN-10.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:49</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISBN-10.</source>
         <target>该值不是有效的10位国际标准书号（ISBN-10）。</target>
-      </trans-unit>
-      <trans-unit id="c_q0_ua" resname="This value is not a valid ISBN-13.">
+      </segment>
+    </unit>
+    <unit id="c_q0_ua" name="This value is not a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:50</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISBN-13.</source>
         <target>该值不是有效的13位国际标准书号（ISBN-13）。</target>
-      </trans-unit>
-      <trans-unit id="M4FlD6n" resname="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      </segment>
+    </unit>
+    <unit id="M4FlD6n" name="This value is neither a valid ISBN-10 nor a valid ISBN-13.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Isbn.php:51</note>
+      </notes>
+      <segment>
         <source>This value is neither a valid ISBN-10 nor a valid ISBN-13.</source>
         <target>该值不是有效的国际标准书号（ISBN-10 或 ISBN-13）。</target>
-      </trans-unit>
-      <trans-unit id="cuct0Ow" resname="This value is not a valid ISSN.">
+      </segment>
+    </unit>
+    <unit id="cuct0Ow" name="This value is not a valid ISSN.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Issn.php:47</note>
+      </notes>
+      <segment>
         <source>This value is not a valid ISSN.</source>
         <target>该值不是有效的国际标准期刊号（ISSN）。</target>
-      </trans-unit>
-      <trans-unit id="JBLs1a1" resname="This value is not a valid currency.">
+      </segment>
+    </unit>
+    <unit id="JBLs1a1" name="This value is not a valid currency.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Currency.php:39</note>
+      </notes>
+      <segment>
         <source>This value is not a valid currency.</source>
         <target>该值不是有效的货币名（currency）。</target>
-      </trans-unit>
-      <trans-unit id="c.WxzFW" resname="This value should be equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/EqualTo.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
         <target>该值应等于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="_jdjkwq" resname="This value should be greater than {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThan.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
         <target>该值应大于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="o8A8a0H" resname="This value should be greater than or equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/GreaterThanOrEqual.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
         <target>该值应大于或等于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="bOF1fpm" resname="This value should be identical to {{ compared_value_type }} {{ compared_value }}.">
-        <source>This value should be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>该值应与 {{ compared_value_type }} {{ compared_value }} 相同。</target>
-      </trans-unit>
-      <trans-unit id="jG0QFKw" resname="This value should be less than {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThan.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be less than {{ compared_value }}.</source>
         <target>该值应小于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="9lWrKmm" resname="This value should be less than or equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/LessThanOrEqual.php:35</note>
+      </notes>
+      <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
         <target>该值应小于或等于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="ftTwGs." resname="This value should not be equal to {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NotEqualTo.php:35</note>
+      </notes>
+      <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
         <target>该值不应先等于 {{ compared_value }} 。</target>
-      </trans-unit>
-      <trans-unit id="Bi22JLt" resname="This value should not be identical to {{ compared_value_type }} {{ compared_value }}.">
-        <source>This value should not be identical to {{ compared_value_type }} {{ compared_value }}.</source>
-        <target>该值不应与 {{ compared_value_type }} {{ compared_value }} 相同。</target>
-      </trans-unit>
-      <trans-unit id="VczCWzQ" resname="The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.">
-        <source>The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-        <target>图片宽高比太大 ({{ ratio }})。允许的最大宽高比为 {{ max_ratio }}。</target>
-      </trans-unit>
-      <trans-unit id="v57PXhq" resname="The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.">
-        <source>The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-        <target>图片宽高比太小 ({{ ratio }})。允许的最大宽高比为 {{ min_ratio }}。</target>
-      </trans-unit>
-      <trans-unit id="rpajj.a" resname="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      </segment>
+    </unit>
+    <unit id="rpajj.a" name="The image is square ({{ width }}x{{ height }}px). Square images are not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Image.php:92</note>
+      </notes>
+      <segment>
         <source>The image is square ({{ width }}x{{ height }}px). Square images are not allowed.</source>
         <target>图片是方形的 ({{ width }}x{{ height }}px)。不允许使用方形的图片。</target>
-      </trans-unit>
-      <trans-unit id="G_lu2qW" resname="The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.">
-        <source>The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.</source>
-        <target>图片是横向的 ({{ width }}x{{ height }}px)。不允许使用横向的图片。</target>
-      </trans-unit>
-      <trans-unit id="sFyGx4B" resname="The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.">
-        <source>The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.</source>
-        <target>图片是纵向的 ({{ width }}x{{ height }}px)。不允许使用纵向的图片。</target>
-      </trans-unit>
-      <trans-unit id="jZgqcpL" resname="An empty file is not allowed.">
+      </segment>
+    </unit>
+    <unit id="jZgqcpL" name="An empty file is not allowed.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/File.php:62</note>
+      </notes>
+      <segment>
         <source>An empty file is not allowed.</source>
         <target>不允许使用空文件。</target>
-      </trans-unit>
-      <trans-unit id="bcfVezI" resname="The host could not be resolved.">
+      </segment>
+    </unit>
+    <unit id="bcfVezI" name="The host could not be resolved.">
+      <segment>
         <source>The host could not be resolved.</source>
         <target>主机名无法解析。</target>
-      </trans-unit>
-      <trans-unit id="NtzKvgt" resname="This value does not match the expected {{ charset }} charset.">
+      </segment>
+    </unit>
+    <unit id="NtzKvgt" name="This value does not match the expected {{ charset }} charset.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Length.php:57</note>
+      </notes>
+      <segment>
         <source>This value does not match the expected {{ charset }} charset.</source>
         <target>该值不符合 {{ charset }} 编码。</target>
-      </trans-unit>
-      <trans-unit id="Wi2y9.N" resname="This is not a valid Business Identifier Code (BIC).">
+      </segment>
+    </unit>
+    <unit id="Wi2y9.N" name="This is not a valid Business Identifier Code (BIC).">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:49</note>
+      </notes>
+      <segment>
         <source>This is not a valid Business Identifier Code (BIC).</source>
         <target>这不是有效的业务标识符代码（BIC)。</target>
-      </trans-unit>
-      <trans-unit id="VKDowX6" resname="Error">
+      </segment>
+    </unit>
+    <unit id="VKDowX6" name="Error">
+      <notes>
+        <note>assets/js/app/ajax-save.js:37</note>
+      </notes>
+      <segment>
         <source>Error</source>
         <target>错误</target>
-      </trans-unit>
-      <trans-unit id="8zqt0Ik" resname="This is not a valid UUID.">
+      </segment>
+    </unit>
+    <unit id="8zqt0Ik" name="This is not a valid UUID.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Uuid.php:80</note>
+      </notes>
+      <segment>
         <source>This is not a valid UUID.</source>
         <target>这不是有效的UUID。</target>
-      </trans-unit>
-      <trans-unit id="ru.4wkH" resname="This value should be a multiple of {{ compared_value }}.">
+      </segment>
+    </unit>
+    <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/DivisibleBy.php:34</note>
+      </notes>
+      <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
         <target>此值应为 {{ compared_value }} 的倍数。</target>
-      </trans-unit>
-      <trans-unit id="M3vyK6s" resname="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      </segment>
+    </unit>
+    <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Bic.php:50</note>
+      </notes>
+      <segment>
         <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
         <target>此业务标识符代码（BIC）与IBAN {{ iban }} 无关。</target>
-      </trans-unit>
-      <trans-unit id="2v2xpAh" resname="This value should be valid JSON.">
+      </segment>
+    </unit>
+    <unit id="2v2xpAh" name="This value should be valid JSON.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Json.php:36</note>
+      </notes>
+      <segment>
         <source>This value should be valid JSON.</source>
         <target>该值应该是有效的JSON。</target>
-      </trans-unit>
-      <trans-unit id=".SEaaBa" resname="This form should not contain extra fields.">
+      </segment>
+    </unit>
+    <unit id="9CWVEGq" name="This collection should contain only unique elements.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Unique.php:39</note>
+      </notes>
+      <segment>
+        <source>This collection should contain only unique elements.</source>
+        <target>该集合不能包含重复项。</target>
+      </segment>
+    </unit>
+    <unit id="WdvZfq." name="This value should be positive.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Positive.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be positive.</source>
+        <target>该值应为正数。</target>
+      </segment>
+    </unit>
+    <unit id="ubHMK2q" name="This value should be either positive or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/PositiveOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either positive or zero.</source>
+        <target>该值应为正数或零。</target>
+      </segment>
+    </unit>
+    <unit id="IwNTzo_" name="This value should be negative.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Negative.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be negative.</source>
+        <target>该值应为负数。</target>
+      </segment>
+    </unit>
+    <unit id="0GfwMfP" name="This value should be either negative or zero.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/NegativeOrZero.php:25</note>
+      </notes>
+      <segment>
+        <source>This value should be either negative or zero.</source>
+        <target>该值应为负数或零。</target>
+      </segment>
+    </unit>
+    <unit id="fs3qQZR" name="This value is not a valid timezone.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Timezone.php:35</note>
+      </notes>
+      <segment>
+        <source>This value is not a valid timezone.</source>
+        <target>该值不是有效的时区。</target>
+      </segment>
+    </unit>
+    <unit id="VvxxWas" name="This value should be between {{ min }} and {{ max }}.">
+      <notes>
+        <note>vendor/symfony/validator/Constraints/Range.php:46</note>
+      </notes>
+      <segment>
+        <source>This value should be between {{ min }} and {{ max }}.</source>
+        <target>该值应在 {{ min }} 和 {{ max }} 之间。</target>
+      </segment>
+    </unit>
+    <unit id=".SEaaBa" name="This form should not contain extra fields.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Validator/Type/FormTypeValidatorExtension.php:64</note>
+      </notes>
+      <segment>
         <source>This form should not contain extra fields.</source>
         <target>该表单中不可有额外字段.</target>
-      </trans-unit>
-      <trans-unit id="WPnLAh9" resname="The uploaded file was too large. Please try to upload a smaller file.">
+      </segment>
+    </unit>
+    <unit id="WPnLAh9" name="The uploaded file was too large. Please try to upload a smaller file.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Core/Type/FormType.php:181</note>
+      </notes>
+      <segment>
         <source>The uploaded file was too large. Please try to upload a smaller file.</source>
         <target>上传文件太大， 请重新尝试上传一个较小的文件.</target>
-      </trans-unit>
-      <trans-unit id="fvxWW3V" resname="The CSRF token is invalid. Please try to resubmit the form.">
+      </segment>
+    </unit>
+    <unit id="fvxWW3V" name="The CSRF token is invalid. Please try to resubmit the form.">
+      <notes>
+        <note>vendor/symfony/form/Extension/Csrf/Type/FormTypeCsrfExtension.php:101</note>
+      </notes>
+      <segment>
         <source>The CSRF token is invalid. Please try to resubmit the form.</source>
         <target>CSRF 验证符无效， 请重新提交.</target>
-      </trans-unit>
-    </body>
+      </segment>
+    </unit>
+    <unit id="LDy5h0B" name="user.duplicate_email">
+      <notes>
+        <note>src/Entity/User.php:24</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_email</source>
+        <target>使用电子邮件 {{ value }} 的用户已存在。</target>
+      </segment>
+    </unit>
+    <unit id="D4OMpCY" name="user.duplicate_username">
+      <notes>
+        <note>src/Entity/User.php:25</note>
+      </notes>
+      <segment>
+        <source>user.duplicate_username</source>
+        <target>使用用户名 {{ value }} 的用户已存在。</target>
+      </segment>
+    </unit>
+    <unit id="HjWW.NS" name="user.not_valid_password">
+      <notes>
+        <note>src/Entity/User.php:57</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_password</source>
+        <target>密码无效。密码应至少包含 6 个字符。</target>
+      </segment>
+    </unit>
+    <unit id="fkXL.k6" name="user.not_valid_email">
+      <notes>
+        <note>src/Entity/User.php:49</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_email</source>
+        <target>电子邮件无效</target>
+      </segment>
+    </unit>
+    <unit id="4eH4IFY" name="user.username_invalid_characters">
+      <notes>
+        <note>src/Entity/User.php:43</note>
+      </notes>
+      <segment>
+        <source>user.username_invalid_characters</source>
+        <target>用户名只能包含小写拉丁字母、数字和下划线。</target>
+      </segment>
+    </unit>
+    <unit id="4oq.CNw" name="user.not_valid_display_name">
+      <notes>
+        <note>src/Entity/User.php:35</note>
+        <note>src/Entity/User.php:36</note>
+      </notes>
+      <segment>
+        <source>user.not_valid_display_name</source>
+        <target>显示名称无效</target>
+      </segment>
+    </unit>
   </file>
 </xliff>


### PR DESCRIPTION
## Summary

Audits and repairs the `messages`, `security`, and `validators` translation catalogues (`translations/*.xlf`, 3 domains × ~14–16 locales), then adds two permanent tooling scripts to keep the catalogues correct and in sync going forward.

## Translation catalogue fixes

- **Removed dead and duplicate keys** from `messages.en.xlf` and `validators.en.xlf`, including deleted-template leftovers, superseded field labels, wrong-domain duplicates, 21 corrupted hex-keyed entries, and 8 obsolete demo entries in `validators.en.xlf`. Deleted `validators.it/pl/pt_BR.xlf`, which contained only those invalid entries.
- **Added missing keys:** `general.phrase.none` (messages) and the three Symfony login-throttling messages (security), which were referenced by the application but missing from the catalogues.
- **Synchronized every locale** with the English catalogue, ensuring identical key sets, ordering, and unit IDs across all 42 files. Recreated `validators.it/pl/pt_BR.xlf` from Symfony vendor catalogues, converted legacy XLIFF 1.2 files (`hu`, `pt_BR`, and `zh_CN` variants) to XLIFF 2.0, and corrected `<file id>` / `trgLang` mismatches (`el`, `tr`, and `uk`).
- **Fixed approximately 77 incorrect translations**, including unescaped Twig placeholders (`{{limit}}` → `{{ limit }}`), mistranslated placeholder names (e.g. German `%Stunden%` → `%hours%`), missing placeholders, incorrect translations (e.g. Russian "preview" translated as "list"), and structural issues such as missing `sr-only` spans and key-as-target fallbacks.
- **Regenerated `<notes>` blocks** for every catalogue, documenting actual usage locations. `messages` keys now reference in-repository `path:line` locations, while `security` and `validators` entries reference the originating Symfony/vendor source when no in-project usage exists.

## New tooling

- **`bin/validate-translations`** — a CI-safe validator (exit code `1` on failure) that verifies:
  - The expected manifest of `domain.locale.xlf` files (missing files are treated as errors).
  - Full structural parity with the English catalogue, including keys, unit IDs, `<notes>`, ordering, and byte-level skeleton structure.
  - Correct `<file id>` and `trgLang` headers (now enforced as hard errors).
  - Graceful reporting of malformed or truncated XML instead of fatal crashes.
  - That every `messages` key is referenced somewhere in the codebase (code, templates, themes, or bundled widgets), and every `trans()`, `|trans`, or `__()` call resolves to a real translation key.
- **`bin/update-translation-notes`** — regenerates `<notes>` blocks from actual usage and mirrors them identically into every locale. Falls back to Symfony vendor sources for `security` and `validators` entries without in-project references. Heuristic (non-exact) matches are prefixed with `~`, locations are sorted numerically by line number, and shared vendor directories are scanned only once.
- **Integrated into CI** (`.github/workflows/code_analysis.yaml`), adding `php bin/validate-translations` alongside the existing `lint:xliff` step.

## Testing

- `php bin/console lint:xliff translations/` — all 42 catalogue files validate successfully.
- `php bin/validate-translations` — passes cleanly (exit code `0`).
- `php bin/console debug:translation <locale> --domain=<domain>` — spot-checked across multiple locales and domains with zero missing keys.
- Fault injection (deleted locale file, corrupted `trgLang`, malformed XML, reordered/tampered `<notes>`, and duplicate keys) was correctly detected by `bin/validate-translations`, after which each change was reverted.


https://github.com/user-attachments/assets/8fba1269-e110-46e1-9846-1bcbb6b9c83d