### PR TITLE
Fix failing Cypress E2E suite: login redirect (cookie_secure)

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -13,7 +13,11 @@ framework:
     handler_id: ~
     cookie_lifetime: 1209600 #expires in 14 days
     storage_factory_id: session.storage.factory.native
-    cookie_secure: true
+    # 'auto' sets the Secure flag only on HTTPS requests. Using `true` would force it on
+    # plain-HTTP installs too, where browsers then drop the cookie and, via the session
+    # domain constraint, restrict post-login redirects to HTTPS-only targets (which breaks
+    # the same-host redirect after login on HTTP). See LoginFormAuthenticator.
+    cookie_secure: 'auto'
     cookie_samesite: lax
   # When using the HTTP Cache, ESI allows to render page fragments separately
   # and with different cache configurations for each fragment

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -13,10 +13,6 @@ framework:
     handler_id: ~
     cookie_lifetime: 1209600 #expires in 14 days
     storage_factory_id: session.storage.factory.native
-    # 'auto' sets the Secure flag only on HTTPS requests. Using `true` would force it on
-    # plain-HTTP installs too, where browsers then drop the cookie and, via the session
-    # domain constraint, restrict post-login redirects to HTTPS-only targets (which breaks
-    # the same-host redirect after login on HTTP). See LoginFormAuthenticator.
     cookie_secure: 'auto'
     cookie_samesite: lax
   # When using the HTTP Cache, ESI allows to render page fragments separately

--- a/yaml-migrations/m_2026-08-03-framework.yaml
+++ b/yaml-migrations/m_2026-08-03-framework.yaml
@@ -1,0 +1,7 @@
+file: packages/framework.yaml
+since: 6.1.7
+
+add:
+  framework:
+    session:
+      cookie_secure: 'auto'


### PR DESCRIPTION
## Fix login redirect timeouts (`cookie_secure`)

### Problem

Every login-based test failed with:

> expected `http://127.0.0.1:8088/bolt/` but got `http://127.0.0.1:8088/`

Authentication succeeded, but users were redirected to the homepage instead of the Bolt dashboard, causing the `/bolt/` assertion to time out.

### Root cause

The regression resulted from the interaction of two independent commits:

| Commit | Change |
|--------|--------|
| `fbd0ed3a` — *Resolve framework configuration deprecations* | Set `cookie_secure: true` (previously omitted, using Symfony's default of `false`). |
| `db37ed5d` — *Block open redirect on login endpoint* | Replaced `new RedirectResponse(...)` with `HttpUtils::createRedirectResponse(...)` for post-login redirects. |

`HttpUtils::createRedirectResponse()` validates redirect targets against a regular expression generated from the session cookie configuration (`AddSessionDomainConstraintPass`). With `cookie_secure: true`, Symfony generates an **HTTPS-only** pattern (`{^https://<host>$}i`).

The failing flow was:

1. The Cypress `login` helper visits `/bolt`, so Symfony stores the target path as `http://127.0.0.1:8088/bolt`.
2. CI runs the application over plain HTTP (`symfony server:start --no-tls`).
3. After authentication, the saved `http://...` URL fails the HTTPS-only validation, so `createRedirectResponse()` falls back to `/`.
4. Authentication succeeds, but the user lands on the homepage, causing the `/bolt/` assertion to time out.

This was broader than a test-only issue. Any Bolt installation running over plain HTTP would also have broken login sessions because browsers discard `Secure` cookies on HTTP.

### The fix

`cookie_secure: 'auto'` is Symfony's recommended value for this deprecation. It applies the `Secure` flag only when the current request uses HTTPS.

As a result:

- On HTTP requests, redirect validation accepts both `http://` and `https://` same-host URLs, restoring the post-login redirect to `/bolt/`.
- On HTTPS requests, validation remains HTTPS-only, preserving protection against open redirects and scheme downgrades.

**Security impact:** None for correctly configured HTTPS deployments. On HTTPS, `auto` behaves identically to `true`. On HTTP, `true` never provided meaningful protection because browsers discard `Secure` cookies anyway.
