### PR TITLE
fix: repair broken Makefile targets and stale server docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,13 +46,11 @@ csclear: ## to clean cache and check coding style
 cscheck: ## to check coding style
 	make csclear
 	vendor/bin/ecs check src
-	vendor/bin/ecs check tests/php
 	make stancheck
 
 csfix: ## to fix coding style
 	make csclear
 	vendor/bin/ecs check src --fix
-	vendor/bin/ecs check tests/php --fix
 	make stancheck
 
 stancheck: ## to run phpstan

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ update:
 	$(COMPOSER) update && $(COMPOSER) outdated
 
 server: ## to start server
-	bin/console server:start 127.0.0.1:8088 -q || true
+	symfony server:start --no-tls --port=8088 -d || true
 
 server-stop: ## to stop server
-	bin/console server:stop
+	symfony server:stop
 
 cache: ## to clean cache
 	bin/console cache:clear

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ csfix: ## to fix coding style
 	make stancheck
 
 stancheck: ## to run phpstan
-	vendor/bin/phpstan --memory-limit=1G analyse -c phpstan.neon src
+	vendor/bin/phpstan --memory-limit=1G analyse src
 
 test: ## to run phpunit tests
 	vendor/bin/phpunit

--- a/SETUP.md
+++ b/SETUP.md
@@ -96,9 +96,6 @@ See the other options by running `npm run`.
 
   - Using the Symfony CLI tool, just run `symfony server:start`.
 
-  - Alternatively, run `bin/console server:start`
-  (if running `bin/console server:start`does not work because you don't have the pcntl extension, run `bin/console server:run`)
-
 In your browser, go to `http://127.0.0.1:8000/` for the frontend, and to
 `http://127.0.0.1:8000/bolt` for the Admin Panel.
 


### PR DESCRIPTION
## Summary

Fixes four broken `make` targets without changing project behavior. The changes align local development commands with the current Symfony 6.4 toolchain and existing CI configuration.

## Changes

- **`stancheck`**
  - Switched from `phpstan.neon` (gitignored and never committed) to the committed `phpstan.dist.neon`.
  - Fixes PHPStan aborting, which also restores `cscheck`, `csfix`, and `full-test`.
- **`server` / `server-stop`**
  - Replaced the removed `bin/console server:*` commands from the deprecated `symfony/web-server-bundle` with the Symfony CLI.
  - Matches the approach already used in CI and documented elsewhere in the project.
- **`cscheck` / `csfix`**
  - Removed `ecs check tests/php`, which lies outside the configured `ecs.php` scope (and CI's scope).
  - Prevents false failures where local commands exited with code 2 despite CI passing.
- **`SETUP.md`**
  - Removed obsolete references to `bin/console server:start` and `bin/console server:run`.
