### PR TITLE
fix(translations): correct compared_value placeholder in ru/uk validators

### DIFF
--- a/translations/validators.ru.xlf
+++ b/translations/validators.ru.xlf
@@ -370,49 +370,49 @@
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть равно {{ compare_value }}.</target>
+        <target>Это значение должно быть равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
-        <target>Это значение должно быть больше {{ compare_value }}.</target>
+        <target>Это значение должно быть больше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть больше или равно {{ compare_value }}.</target>
+        <target>Это значение должно быть больше или равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="SreIWoo" name="9670078">
       <segment>
         <source>9670078</source>
-        <target>Это значение должно быть идентично {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Это значение должно быть идентично {{ compared_value_type }} {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
-        <target>Это значение должно быть меньше {{ compare_value }}.</target>
+        <target>Это значение должно быть меньше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
-        <target>Это значение должно быть меньше или равно {{ compare_value }}.</target>
+        <target>Это значение должно быть меньше или равно {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
-        <target>Это значение не должно быть равным {{ compare_value }}.</target>
+        <target>Это значение не должно быть равным {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="JIjdvtb" name="0eedf91">
       <segment>
         <source>0eedf91</source>
-        <target>Это значение не должно быть идентичным {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Это значение не должно быть идентичным {{ compared_value_type }} {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="vzvxzpR" name="9c3ad0f">
@@ -484,7 +484,7 @@
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Это значение должно быть кратным {{ compare_value }}.</target>
+        <target>Это значение должно быть кратным {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">

--- a/translations/validators.uk.xlf
+++ b/translations/validators.uk.xlf
@@ -370,49 +370,49 @@
     <unit id="c.WxzFW" name="This value should be equal to {{ compared_value }}.">
       <segment>
         <source>This value should be equal to {{ compared_value }}.</source>
-        <target>Це значення повинно дорівнювати {{ compare_value }}.</target>
+        <target>Це значення повинно дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="_jdjkwq" name="This value should be greater than {{ compared_value }}.">
       <segment>
         <source>This value should be greater than {{ compared_value }}.</source>
-        <target>Це значення повинно бути більше {{ compare_value }}.</target>
+        <target>Це значення повинно бути більше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="o8A8a0H" name="This value should be greater than or equal to {{ compared_value }}.">
       <segment>
         <source>This value should be greater than or equal to {{ compared_value }}.</source>
-        <target>Це значення повинно бути більше або дорівнювати {{ compare_value }}.</target>
+        <target>Це значення повинно бути більше або дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="SreIWoo" name="9670078">
       <segment>
         <source>9670078</source>
-        <target>Це значення повинно бути ідентичним до {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Це значення повинно бути ідентичним до {{ compared_value_type }} {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="jG0QFKw" name="This value should be less than {{ compared_value }}.">
       <segment>
         <source>This value should be less than {{ compared_value }}.</source>
-        <target>Це значення повинно бути менше {{ compare_value }}.</target>
+        <target>Це значення повинно бути менше {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="9lWrKmm" name="This value should be less than or equal to {{ compared_value }}.">
       <segment>
         <source>This value should be less than or equal to {{ compared_value }}.</source>
-        <target>Це значення повинно бути менше або дорівнювати {{ compare_value }}.</target>
+        <target>Це значення повинно бути менше або дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="ftTwGs." name="This value should not be equal to {{ compared_value }}.">
       <segment>
         <source>This value should not be equal to {{ compared_value }}.</source>
-        <target>Це значення не повинно дорівнювати {{ compare_value }}.</target>
+        <target>Це значення не повинно дорівнювати {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="JIjdvtb" name="0eedf91">
       <segment>
         <source>0eedf91</source>
-        <target>Це значення не повинно бути ідентичним {{ compare_value_type }} {{ compare_value }}.</target>
+        <target>Це значення не повинно бути ідентичним {{ compared_value_type }} {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="vzvxzpR" name="9c3ad0f">
@@ -484,7 +484,7 @@
     <unit id="ru.4wkH" name="This value should be a multiple of {{ compared_value }}.">
       <segment>
         <source>This value should be a multiple of {{ compared_value }}.</source>
-        <target>Це значення повинно бути кратним {{ compare_value }}.</target>
+        <target>Це значення повинно бути кратним {{ compared_value }}.</target>
       </segment>
     </unit>
     <unit id="M3vyK6s" name="This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.">


### PR DESCRIPTION
Follow up of https://github.com/bolt/core/pull/3753

Fixes a misspelled placeholder in the Russian and Ukrainian validator translations — the `d` was missing

| Placeholder | Correct placeholder | Occurrences |
| --- | --- | ---: |
| `{{ compare_value }}` | `{{ compared_value }}` | 18 |
| `{{ compare_value_type }}` | `{{ compared_value_type }}` | 4 |

Touches `translations/validators.ru.xlf` and `translations/validators.uk.xlf` (9 translation units in each file).