### PR TITLE
fix(translations): remove stray whitespace inside placeholders (ru/uk)

### DIFF
--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -992,7 +992,7 @@
       </notes>
       <segment>
         <source>general.phrase.search-results-for-variable</source>
-        <target>Результаты поиска по запросу "% search%".</target>
+        <target>Результаты поиска по запросу "%search%".</target>
       </segment>
     </unit>
     <unit id="2CfJ3WY" name="general.phrase.search-results-for">
@@ -1002,7 +1002,7 @@
       </notes>
       <segment>
         <source>general.phrase.search-results-for</source>
-        <target>Результаты поиска по запросу "% search%".</target>
+        <target>Результаты поиска по запросу "%search%".</target>
       </segment>
     </unit>
     <unit id="V0VhH5g" name="general.phrase.no-search-results-for">

--- a/translations/messages.uk.xlf
+++ b/translations/messages.uk.xlf
@@ -988,7 +988,7 @@
             </notes>
             <segment>
                 <source>general.phrase.search-results-for-variable</source>
-                <target>Результати пошуку за запитом "% search%".</target>
+                <target>Результати пошуку за запитом "%search%".</target>
             </segment>
         </unit>
         <unit id="2CfJ3WY" name="general.phrase.search-results-for">
@@ -998,7 +998,7 @@
             </notes>
             <segment>
                 <source>general.phrase.search-results-for</source>
-                <target>Результати пошуку за запитом "% search%".</target>
+                <target>Результати пошуку за запитом "%search%".</target>
             </segment>
         </unit>
         <unit id="V0VhH5g" name="general.phrase.no-search-results-for">
@@ -2352,7 +2352,7 @@
         <unit id="pXtciRI" name="content.edit_missing_definition">
             <segment>
                 <source>content.edit_missing_definition</source>
-                <target>Визначення цього Типу контенту відсутнє! Редагування цього запису не працюватиме належним чином. Будь ласка, перевірте свій contenttypes.yaml, щоб впевнитися, що він містить% contenttype%.</target>
+                <target>Визначення цього Типу контенту відсутнє! Редагування цього запису не працюватиме належним чином. Будь ласка, перевірте свій contenttypes.yaml, щоб впевнитися, що він містить %contenttype%.</target>
             </segment>
         </unit>
         <unit id="RBJ0NMl" name="collection.select">


### PR DESCRIPTION
Follow up of https://github.com/bolt/core/pull/3753

## Summary

Fixes five translation placeholders in the Russian and Ukrainian message catalogues. The placeholder names contained stray whitespace, preventing Symfony from substituting the parameters and causing the raw placeholders to be shown to users.

## Changes

| File | Translation key | Before | After |
| --- | --- | --- | --- |
| `messages.ru.xlf` | `general.phrase.search-results-for` | `% search%` | `%search%` |
| `messages.ru.xlf` | `general.phrase.search-results-for-variable` | `% search%` | `%search%` |
| `messages.uk.xlf` | `general.phrase.search-results-for` | `% search%` | `%search%` |
| `messages.uk.xlf` | `general.phrase.search-results-for-variable` | `% search%` | `%search%` |
| `messages.uk.xlf` | `content.edit_missing_definition` | `містить% contenttype%` | `містить %contenttype%` |

## Root cause

Symfony performs parameter substitution using exact placeholder names. Because the translated strings used `% search%` instead of `%search%`, the parameter lookup failed and the placeholders were rendered verbatim instead of being replaced with their values.
