### PR TITLE
fix(translations): restore dropped placeholders in bg/de/es/hu

### DIFF
--- a/translations/messages.bg.xlf
+++ b/translations/messages.bg.xlf
@@ -154,7 +154,7 @@
     <unit id="b_RPpcB" name="general.greeting">
       <segment>
         <source>general.greeting</source>
-        <target>Привет, админ!</target>
+        <target>Привет, %name%!</target>
       </segment>
     </unit>
     <unit id="bmdn3u9" name="action.logout">
@@ -1186,7 +1186,7 @@
     <unit id="tsc7_G3" name="listing_details_box.listing_template">
       <segment>
         <source>listing_details_box.listing_template</source>
-        <target>Шаблон за списък: %template%</target>
+        <target>Шаблон за списък: %template% (%listingRecords% записа)</target>
       </segment>
     </unit>
     <unit id="pPz9Ocx" name="listing_details_box.locales">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -2692,7 +2692,7 @@
       </notes>
       <segment>
         <source>reset_password.check_email_sent_text_2</source>
-        <target>Wenn Sie keine E-Mail erhalten, überprüfen Sie bitte Ihren Spam-Ordner oder versuchen Sie es erneut.</target>
+        <target>Wenn Sie keine E-Mail erhalten, überprüfen Sie bitte Ihren Spam-Ordner oder %tryagain%.</target>
       </segment>
     </unit>
     <unit id="dp42qbF" name="reset_password.email_title">
@@ -3094,7 +3094,7 @@
       </notes>
       <segment>
         <source>contenttypes.generic.overview</source>
-        <target>Seitenübersicht</target>
+        <target>Übersicht über %contenttypes%</target>
       </segment>
     </unit>
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
@@ -3112,7 +3112,7 @@
       </notes>
       <segment>
         <source>contenttypes.generic.recent</source>
-        <target>Neueste Seiten</target>
+        <target>Neueste %contenttypes%</target>
       </segment>
     </unit>
     <unit id="gB.9hTu" name="general.phrase.search-ellipsis">

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -721,7 +721,7 @@
     <unit id="0C9.Vmh" name="collection.add_item">
       <segment>
         <source>collection.add_item</source>
-        <target>Añadir elemento</target>
+        <target>Añadir un elemento nuevo a '%name%'</target>
       </segment>
     </unit>
     <unit id="ApPu4P_" name="collection.move_item_up">

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -1812,7 +1812,7 @@
     <unit id="munFS0n" name="title.filtered_by">
       <segment>
         <source>title.filtered_by</source>
-        <target><![CDATA[A <em>'%szűrő%'-vel szűrt tartalom</em>.]]></target>
+        <target><![CDATA[A <em>'%filter%'-vel szűrt tartalom</em>.]]></target>
       </segment>
     </unit>
     <unit id="hgNZLwW" name="extensions.title_configuration">
@@ -1896,7 +1896,7 @@
     <unit id="0C9.Vmh" name="collection.add_item">
       <segment>
         <source>collection.add_item</source>
-        <target>Tétel hozzáadása</target>
+        <target>Új tétel hozzáadása ehhez: '%name%'</target>
       </segment>
     </unit>
     <unit id="H9knE.O" name="collection.expand_all">


### PR DESCRIPTION
Follow up of https://github.com/bolt/core/pull/3753

## Summary

Fixes translations that dropped placeholders required by the calling code, preventing runtime values from being displayed.

## Changes

| File | Keys |
| --- | --- |
| `messages.bg` | `general.greeting`, `listing_details_box.listing_template` |
| `messages.de` | `contenttypes.generic.overview`, `contenttypes.generic.recent`, `reset_password.check_email_sent_text_2` |
| `messages.es` | `collection.add_item` |
| `messages.hu` | `collection.add_item`, `title.filtered_by` |

## Why

Symfony substitutes placeholders by exact name. When a translation omits a placeholder, the corresponding runtime value is lost.

Several of these were effectively hardcoded translations rather than direct equivalents of the source text. For example:

- The Bulgarian greeting always addressed the user as "admin" instead of using the provided `%name%`.
- The German ContentType headings were hardcoded to "Pages", making them incorrect for every other ContentType.
