### PR TITLE
fix(translations): replace unresolved %url% in built-with-bolt string

### DIFF
--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -882,7 +882,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment state="translated">
         <source>9fb3e6e</source>
-        <target>Tyto stránky jsou &lt;a href='%url%' target='_blank' title='Sofistikovaný, lehký &amp; jednoduchý CMS'&gt;postaveny na Boltu&lt;/a&gt;.</target>
+        <target>Tyto stránky jsou &lt;a href='https://boltcms.io' target='_blank' title='Sofistikovaný, lehký &amp; jednoduchý CMS'&gt;postaveny na Boltu&lt;/a&gt;.</target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">

--- a/translations/messages.el.xlf
+++ b/translations/messages.el.xlf
@@ -930,7 +930,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='%url%' target='_blank' title='
+        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='https://boltcms.io' target='_blank' title='
 Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
       </segment>
     </unit>
@@ -1027,7 +1027,7 @@
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='%url%' target='_blank' title='Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
+        <target><![CDATA[Αυτός ο ιστότοπος είναι <a href='https://boltcms.io' target='_blank' title='Εξελιγμένο, ελαφρύ & απλό CMS'>Χτισμένο με Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -940,7 +940,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[Ce site est <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Construit avec Bolt</a>.]]></target>
+        <target><![CDATA[Ce site est <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Construit avec Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -930,7 +930,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
+        <target><![CDATA[Ez a weboldal <a href='https://boltcms.io' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
@@ -1026,7 +1026,7 @@
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
+        <target><![CDATA[Ez a weboldal <a href='https://boltcms.io' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
@@ -1085,8 +1085,8 @@
     </unit>
     <unit id="eq5YMQf">
       <segment>
-        <source>This website is &lt;a href='%url%' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
-        <target><![CDATA[Ez a weboldal <a href='%url%' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
+        <source>This website is &lt;a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
+        <target><![CDATA[Ez a weboldal <a href='https://boltcms.io' target='_blank' title='Az ésszerű és egyszerű, Bolt CMS'>-sel készült</a>.]]></target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -936,7 +936,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
+        <target><![CDATA[Questo sito è <a href='https://boltcms.io' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
@@ -1032,7 +1032,7 @@
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
+        <target><![CDATA[Questo sito è <a href='https://boltcms.io' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">
@@ -1091,8 +1091,8 @@
     </unit>
     <unit id="eq5YMQf" name="9fb3e6e">
       <segment>
-        <source>This website is &lt;a href='%url%' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
-        <target><![CDATA[Questo sito è <a href='%url%' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
+        <source>This website is &lt;a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight &amp; simple CMS'&gt;Built with Bolt&lt;/a&gt;.</source>
+        <target><![CDATA[Questo sito è <a href='https://boltcms.io' target='_blank' title='CMS semplice e sofisticato'>realizzato con Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="3zlZmRK" name="action.add_user">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -930,7 +930,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[Bu internet sitesi <a href='%url%' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
+        <target><![CDATA[Bu internet sitesi <a href='https://boltcms.io' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">
@@ -1026,7 +1026,7 @@
     <unit id="psOa_9x" name="general.phrase.built-with-bolt">
       <segment>
         <source>general.phrase.built-with-bolt</source>
-        <target><![CDATA[Bu internet sitesi <a href='%url%' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
+        <target><![CDATA[Bu internet sitesi <a href='https://boltcms.io' target='_blank' title='Gelişmiş, hafif & basit CMS'>Bolt ile yapılmıştır</a>.]]></target>
       </segment>
     </unit>
     <unit id="5IxD63c" name="general.latest_bolt_news">

--- a/translations/messages.zh_CN.xlf
+++ b/translations/messages.zh_CN.xlf
@@ -930,7 +930,7 @@
     <unit id="z0k8hRg" name="9fb3e6e">
       <segment>
         <source>9fb3e6e</source>
-        <target><![CDATA[This website is <a href='%url%' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
+        <target><![CDATA[This website is <a href='https://boltcms.io' target='_blank' title='Sophisticated, lightweight & simple CMS'>Built with Bolt</a>.]]></target>
       </segment>
     </unit>
     <unit id="wNEwZy_" name="contenttypes.generic.overview">


### PR DESCRIPTION
Follow up of https://github.com/bolt/core/pull/3753

## Why

The footer calls the string with no parameters:

```twig
{# public/theme/skeleton/partials/_footer.twig:17 #}
{{ __('general.phrase.built-with-bolt') }}
```

So `%url%` was never filled in and rendered literally as `href='%url%'` — a relative link that 404'd on every page.

The URL is already hardcoded elsewhere

English and 8 of the 12 locales already write the URL directly: en, cs, de, fr, nl, ru, uk, zh_CN.

Only `el`, `hu`, `it`, `tr` used %url%. This brings them in line:

```
- <a href='%url%' target='_blank' ...>
+ <a href='https://boltcms.io' target='_blank' ...>
```

Wording untouched — only the href. Also applied to the unreachable duplicate copies of the same sentence so it can't come back.

`%url%` in `http_error*.suggestion` is left alone — English uses it there too.